### PR TITLE
Remove unnecessary unsafe blocks

### DIFF
--- a/quake3-rs/cgamex86_64/src/cgame/cg_consolecmds.rs
+++ b/quake3-rs/cgamex86_64/src/cgame/cg_consolecmds.rs
@@ -300,7 +300,7 @@ unsafe extern "C" fn CG_StartOrbit_f() {
     };
 }
 
-static mut commands: [consoleCommand_t; 21] = unsafe {
+static mut commands: [consoleCommand_t; 21] = {
     [
         {
             let mut init = consoleCommand_t {

--- a/quake3-rs/ioquake3/src/botlib/l_precomp.rs
+++ b/quake3-rs/ioquake3/src/botlib/l_precomp.rs
@@ -3736,7 +3736,7 @@ pub unsafe extern "C" fn PC_Directive_evalfloat(
 //============================================================================
 #[no_mangle]
 
-pub static mut directives: [directive_t; 20] = unsafe {
+pub static mut directives: [directive_t; 20] = {
     [
         {
             let mut init = directive_s {
@@ -4112,7 +4112,7 @@ pub unsafe extern "C" fn PC_DollarDirective_evalfloat(
 //============================================================================
 #[no_mangle]
 
-pub static mut dollardirectives: [directive_t; 20] = unsafe {
+pub static mut dollardirectives: [directive_t; 20] = {
     [
         {
             let mut init = directive_s {

--- a/quake3-rs/ioquake3/src/client/snd_codec_ogg.rs
+++ b/quake3-rs/ioquake3/src/client/snd_codec_ogg.rs
@@ -45,7 +45,7 @@ pub use crate::ogg_h::oggpack_buffer;
 // Q3 OGG codec
 #[no_mangle]
 
-pub static mut ogg_codec: crate::src::client::snd_codec::snd_codec_t = unsafe {
+pub static mut ogg_codec: crate::src::client::snd_codec::snd_codec_t = {
     {
         let mut init = crate::src::client::snd_codec::snd_codec_s {
             ext: b"ogg\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,

--- a/quake3-rs/ioquake3/src/client/snd_codec_opus.rs
+++ b/quake3-rs/ioquake3/src/client/snd_codec_opus.rs
@@ -48,7 +48,7 @@ pub use crate::src::qcommon::q_shared::FS_SEEK_SET;
 // Q3 Ogg Opus codec
 #[no_mangle]
 
-pub static mut opus_codec: crate::src::client::snd_codec::snd_codec_t = unsafe {
+pub static mut opus_codec: crate::src::client::snd_codec::snd_codec_t = {
     {
         let mut init = crate::src::client::snd_codec::snd_codec_s {
             ext: b"opus\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,

--- a/quake3-rs/ioquake3/src/client/snd_codec_wav.rs
+++ b/quake3-rs/ioquake3/src/client/snd_codec_wav.rs
@@ -241,7 +241,7 @@ unsafe extern "C" fn S_ReadRIFFHeader(
 // WAV codec
 #[no_mangle]
 
-pub static mut wav_codec: crate::src::client::snd_codec::snd_codec_t = unsafe {
+pub static mut wav_codec: crate::src::client::snd_codec::snd_codec_t = {
     {
         let mut init = crate::src::client::snd_codec::snd_codec_s {
             ext: b"wav\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,

--- a/quake3-rs/ioquake3/src/server/sv_client.rs
+++ b/quake3-rs/ioquake3/src/server/sv_client.rs
@@ -2628,7 +2628,7 @@ unsafe extern "C" fn SV_Voip_f(mut cl: *mut crate::server_h::client_t) {
     };
 }
 
-static mut ucmds: [ucmd_t; 10] = unsafe {
+static mut ucmds: [ucmd_t; 10] = {
     [
         {
             let mut init = ucmd_t {

--- a/quake3-rs/qagamex86_64/src/game/ai_vcmd.rs
+++ b/quake3-rs/qagamex86_64/src/game/ai_vcmd.rs
@@ -785,7 +785,7 @@ pub unsafe extern "C" fn BotVoiceChat_Dummy(
 }
 #[no_mangle]
 
-pub static mut voiceCommands: [voiceCommand_t; 15] = unsafe {
+pub static mut voiceCommands: [voiceCommand_t; 15] = {
     [
         {
             let mut init = voiceCommand_s {

--- a/quake3-rs/qagamex86_64/src/game/g_spawn.rs
+++ b/quake3-rs/qagamex86_64/src/game/g_spawn.rs
@@ -371,7 +371,7 @@ pub static mut fields: [field_t; 20] = [field_t {
 pub unsafe extern "C" fn SP_item_botroam(mut _ent: *mut crate::g_local_h::gentity_t) {}
 #[no_mangle]
 
-pub static mut spawns: [spawn_t; 49] = unsafe {
+pub static mut spawns: [spawn_t; 49] = {
     [
         {
             let mut init = spawn_t {

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_image.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_image.rs
@@ -1854,7 +1854,7 @@ pub unsafe extern "C" fn R_CreateImage(
 // Note that the ordering indicates the order of preference used
 // when there are multiple images of different formats available
 
-static mut imageLoaders: [imageExtToLoaderMap_t; 6] = unsafe {
+static mut imageLoaders: [imageExtToLoaderMap_t; 6] = {
     [
         {
             let mut init = imageExtToLoaderMap_t {

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_model.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_model.rs
@@ -489,7 +489,7 @@ pub unsafe extern "C" fn R_RegisterIQM(
 // Note that the ordering indicates the order of preference used
 // when there are multiple models of different formats available
 
-static mut modelLoaders: [modelExtToLoaderMap_t; 3] = unsafe {
+static mut modelLoaders: [modelExtToLoaderMap_t; 3] = {
     [
         {
             let mut init = modelExtToLoaderMap_t {


### PR DESCRIPTION
## Summary
- clean up unneeded `unsafe` initializations in game modules
- remove extraneous wrappers in codecs and renderer

## Testing
- `cargo +nightly-2019-12-05 build --release`

------
https://chatgpt.com/codex/tasks/task_e_6843db4f6d648329aee2ac95db97d70d