### PR TITLE
Clean up some unused variables

### DIFF
--- a/quake3-rs/cgamex86_64/src/qcommon/q_shared.rs
+++ b/quake3-rs/cgamex86_64/src/qcommon/q_shared.rs
@@ -1621,11 +1621,10 @@ pub unsafe extern "C" fn Q_isanumber(
     mut s: *const libc::c_char,
 ) -> crate::src::qcommon::q_shared::qboolean {
     let mut p: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut d: libc::c_double = 0.;
     if *s as libc::c_int == '\u{0}' as i32 {
         return crate::src::qcommon::q_shared::qfalse;
     }
-    d = ::libc::strtod(s, &mut p);
+    ::libc::strtod(s, &mut p);
     return (*p as libc::c_int == '\u{0}' as i32) as libc::c_int
         as crate::src::qcommon::q_shared::qboolean;
 }

--- a/quake3-rs/ioquake3/src/qcommon/common.rs
+++ b/quake3-rs/ioquake3/src/qcommon/common.rs
@@ -2415,7 +2415,6 @@ pub unsafe extern "C" fn Hunk_SmallLog() {
     let mut block2: *mut hunkblock_t = 0 as *mut hunkblock_t;
     let mut buf: [libc::c_char; 4096] = [0; 4096];
     let mut size: libc::c_int = 0;
-    let mut locsize: libc::c_int = 0;
     let mut numBlocks: libc::c_int = 0;
     if logfile == 0 || crate::src::qcommon::files::FS_Initialized() as u64 == 0 {
         return;
@@ -2442,7 +2441,6 @@ pub unsafe extern "C" fn Hunk_SmallLog() {
     block = hunkblocks;
     while !block.is_null() {
         if !((*block).printed != 0) {
-            locsize = (*block).size;
             block2 = (*block).next;
             while !block2.is_null() {
                 if !((*block).line != (*block2).line) {
@@ -2450,7 +2448,6 @@ pub unsafe extern "C" fn Hunk_SmallLog() {
                         != 0)
                     {
                         size += (*block2).size;
-                        locsize += (*block2).size;
                         (*block2).printed = crate::src::qcommon::q_shared::qtrue as libc::c_int
                             as crate::src::qcommon::q_shared::byte
                     }

--- a/quake3-rs/ioquake3/src/sys/con_tty.rs
+++ b/quake3-rs/ioquake3/src/sys/con_tty.rs
@@ -173,25 +173,24 @@ send "\b \b"
 
 unsafe extern "C" fn CON_Back() {
     let mut key: libc::c_char = 0;
-    let mut size: crate::stddef_h::size_t = 0;
     key = '\u{8}' as i32 as libc::c_char;
-    size = crate::stdlib::write(
+    crate::stdlib::write(
         1 as libc::c_int,
         &mut key as *mut libc::c_char as *const libc::c_void,
         1 as libc::c_int as crate::stddef_h::size_t,
-    ) as crate::stddef_h::size_t;
+    );
     key = ' ' as i32 as libc::c_char;
-    size = crate::stdlib::write(
+    crate::stdlib::write(
         1 as libc::c_int,
         &mut key as *mut libc::c_char as *const libc::c_void,
         1 as libc::c_int as crate::stddef_h::size_t,
-    ) as crate::stddef_h::size_t;
+    );
     key = '\u{8}' as i32 as libc::c_char;
-    size = crate::stdlib::write(
+    crate::stdlib::write(
         1 as libc::c_int,
         &mut key as *mut libc::c_char as *const libc::c_void,
         1 as libc::c_int as crate::stddef_h::size_t,
-    ) as crate::stddef_h::size_t;
+    );
 }
 /*
 ==================
@@ -239,20 +238,19 @@ unsafe extern "C" fn CON_Show() {
         let mut i: libc::c_int = 0;
         ttycon_hide -= 1;
         if ttycon_hide == 0 as libc::c_int {
-            let mut size: crate::stddef_h::size_t = 0;
-            size = crate::stdlib::write(
+            crate::stdlib::write(
                 1 as libc::c_int,
                 b"tty]\x00" as *const u8 as *const libc::c_char as *const libc::c_void,
                 crate::stdlib::strlen(b"tty]\x00" as *const u8 as *const libc::c_char),
-            ) as crate::stddef_h::size_t;
+            );
             if TTY_con.cursor != 0 {
                 i = 0 as libc::c_int;
                 while i < TTY_con.cursor {
-                    size = crate::stdlib::write(
+                    crate::stdlib::write(
                         1 as libc::c_int,
                         TTY_con.buffer.as_mut_ptr().offset(i as isize) as *const libc::c_void,
                         1 as libc::c_int as crate::stddef_h::size_t,
-                    ) as crate::stddef_h::size_t;
+                    );
                     i += 1
                 }
             }
@@ -458,7 +456,6 @@ pub unsafe extern "C" fn CON_Input() -> *mut libc::c_char {
     let mut avail: libc::c_int = 0;
     let mut key: libc::c_char = 0;
     let mut history: *mut crate::qcommon_h::field_t = 0 as *mut crate::qcommon_h::field_t;
-    let mut size: crate::stddef_h::size_t = 0;
     if ttycon_on as u64 != 0 {
         avail = crate::stdlib::read(
             0 as libc::c_int,
@@ -624,11 +621,11 @@ pub unsafe extern "C" fn CON_Input() -> *mut libc::c_char {
             TTY_con.buffer[TTY_con.cursor as usize] = key; // next char will always be '\0'
             TTY_con.cursor += 1;
             // print the current line (this is differential)
-            size = crate::stdlib::write(
+            crate::stdlib::write(
                 1 as libc::c_int,
                 &mut key as *mut libc::c_char as *const libc::c_void,
                 1 as libc::c_int as crate::stddef_h::size_t,
-            ) as crate::stddef_h::size_t
+            );
         } // stdin
         return 0 as *mut libc::c_char;
     } else {

--- a/quake3-rs/qagamex86_64/src/qcommon/q_shared.rs
+++ b/quake3-rs/qagamex86_64/src/qcommon/q_shared.rs
@@ -1525,11 +1525,10 @@ pub unsafe extern "C" fn Q_isanumber(
     mut s: *const libc::c_char,
 ) -> crate::src::qcommon::q_shared::qboolean {
     let mut p: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut d: libc::c_double = 0.;
     if *s as libc::c_int == '\u{0}' as i32 {
         return crate::src::qcommon::q_shared::qfalse;
     }
-    d = ::libc::strtod(s, &mut p);
+    ::libc::strtod(s, &mut p);
     return (*p as libc::c_int == '\u{0}' as i32) as libc::c_int
         as crate::src::qcommon::q_shared::qboolean;
 }

--- a/quake3-rs/renderer_opengl1_x86_64/src/qcommon/q_shared.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/qcommon/q_shared.rs
@@ -1175,11 +1175,10 @@ pub unsafe extern "C" fn Q_isanumber(
     mut s: *const libc::c_char,
 ) -> crate::src::qcommon::q_shared::qboolean {
     let mut p: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut d: libc::c_double = 0.;
     if *s as libc::c_int == '\u{0}' as i32 {
         return crate::src::qcommon::q_shared::qfalse;
     }
-    d = ::libc::strtod(s, &mut p);
+    ::libc::strtod(s, &mut p);
     return (*p as libc::c_int == '\u{0}' as i32) as libc::c_int
         as crate::src::qcommon::q_shared::qboolean;
 }

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_bsp.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_bsp.rs
@@ -688,7 +688,6 @@ unsafe extern "C" fn R_LoadLightmaps(mut l: *mut crate::qfiles_h::lump_t) {
     let mut i: libc::c_int = 0;
     let mut j: libc::c_int = 0;
     let mut maxIntensity: libc::c_float = 0 as libc::c_int as libc::c_float;
-    let mut sumIntensity: libc::c_double = 0 as libc::c_int as libc::c_double;
     len = (*l).filelen;
     if len == 0 {
         return;
@@ -770,7 +769,6 @@ unsafe extern "C" fn R_LoadLightmaps(mut l: *mut crate::qfiles_h::lump_t) {
                         as crate::src::qcommon::q_shared::byte;
                 image[(j * 4 as libc::c_int + 3 as libc::c_int) as usize] =
                     255 as libc::c_int as crate::src::qcommon::q_shared::byte;
-                sumIntensity += intensity as libc::c_double;
                 j += 1
             }
         } else {

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_curve.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_curve.rs
@@ -262,7 +262,6 @@ unsafe extern "C" fn MakeMeshNormals(
     let mut dist: libc::c_int = 0;
     let mut normal: crate::src::qcommon::q_shared::vec3_t = [0.; 3];
     let mut sum: crate::src::qcommon::q_shared::vec3_t = [0.; 3];
-    let mut count: libc::c_int = 0 as libc::c_int;
     let mut base: crate::src::qcommon::q_shared::vec3_t = [0.; 3];
     let mut delta: crate::src::qcommon::q_shared::vec3_t = [0.; 3];
     let mut x: libc::c_int = 0;
@@ -341,7 +340,6 @@ unsafe extern "C" fn MakeMeshNormals(
     while i < width {
         j = 0 as libc::c_int;
         while j < height {
-            count = 0 as libc::c_int;
             dv = &mut *(*ctrl.offset(j as isize)).as_mut_ptr().offset(i as isize)
                 as *mut crate::qfiles_h::drawVert_t;
             base[0 as libc::c_int as usize] = (*dv).xyz[0 as libc::c_int as usize];
@@ -434,7 +432,6 @@ unsafe extern "C" fn MakeMeshNormals(
                             normal[1 as libc::c_int as usize] + sum[1 as libc::c_int as usize];
                         sum[2 as libc::c_int as usize] =
                             normal[2 as libc::c_int as usize] + sum[2 as libc::c_int as usize];
-                        count += 1
                     }
                 }
                 k += 1

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_main.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_main.rs
@@ -2150,7 +2150,6 @@ unsafe extern "C" fn SurfIsOffscreen(
     let mut clip: crate::src::qcommon::q_shared::vec4_t = [0.; 4];
     let mut eye: crate::src::qcommon::q_shared::vec4_t = [0.; 4];
     let mut i: libc::c_int = 0;
-    let mut pointOr: libc::c_uint = 0 as libc::c_int as libc::c_uint;
     let mut pointAnd: libc::c_uint = !(0 as libc::c_int) as libc::c_uint;
     R_RotateForViewer();
     R_DecomposeSort(
@@ -2189,7 +2188,6 @@ unsafe extern "C" fn SurfIsOffscreen(
             j += 1
         }
         pointAnd &= pointFlags;
-        pointOr |= pointFlags;
         i += 1
     }
     // trivially reject

--- a/quake3-rs/uix86_64/src/q3_ui/ui_controls2.rs
+++ b/quake3-rs/uix86_64/src/q3_ui/ui_controls2.rs
@@ -2279,10 +2279,8 @@ Controls_InitCvars
 */
 
 unsafe extern "C" fn Controls_InitCvars() {
-    let mut i: libc::c_int = 0;
     let mut cvarptr: *mut configcvar_t = 0 as *mut configcvar_t;
     cvarptr = g_configcvars.as_mut_ptr();
-    i = 0 as libc::c_int;
     while !(*cvarptr).name.is_null() {
         // get current value
         (*cvarptr).value = crate::src::ui::ui_syscalls::trap_Cvar_VariableValue((*cvarptr).name);
@@ -2292,7 +2290,6 @@ unsafe extern "C" fn Controls_InitCvars() {
             crate::src::ui::ui_syscalls::trap_Cvar_VariableValue((*cvarptr).name);
         // restore current value
         crate::src::ui::ui_syscalls::trap_Cvar_SetValue((*cvarptr).name, (*cvarptr).value);
-        i += 1;
         cvarptr = cvarptr.offset(1)
     }
 }
@@ -2304,9 +2301,7 @@ Controls_GetCvarDefault
 
 unsafe extern "C" fn Controls_GetCvarDefault(mut name: *mut libc::c_char) -> libc::c_float {
     let mut cvarptr: *mut configcvar_t = 0 as *mut configcvar_t;
-    let mut i: libc::c_int = 0;
     cvarptr = g_configcvars.as_mut_ptr();
-    i = 0 as libc::c_int;
     loop {
         if (*cvarptr).name.is_null() {
             return 0 as libc::c_int as libc::c_float;
@@ -2314,7 +2309,6 @@ unsafe extern "C" fn Controls_GetCvarDefault(mut name: *mut libc::c_char) -> lib
         if ::libc::strcmp((*cvarptr).name, name) == 0 {
             break;
         }
-        i += 1;
         cvarptr = cvarptr.offset(1)
     }
     return (*cvarptr).defaultvalue;
@@ -2327,9 +2321,7 @@ Controls_GetCvarValue
 
 unsafe extern "C" fn Controls_GetCvarValue(mut name: *mut libc::c_char) -> libc::c_float {
     let mut cvarptr: *mut configcvar_t = 0 as *mut configcvar_t;
-    let mut i: libc::c_int = 0;
     cvarptr = g_configcvars.as_mut_ptr();
-    i = 0 as libc::c_int;
     loop {
         if (*cvarptr).name.is_null() {
             return 0 as libc::c_int as libc::c_float;
@@ -2337,7 +2329,6 @@ unsafe extern "C" fn Controls_GetCvarValue(mut name: *mut libc::c_char) -> libc:
         if ::libc::strcmp((*cvarptr).name, name) == 0 {
             break;
         }
-        i += 1;
         cvarptr = cvarptr.offset(1)
     }
     return (*cvarptr).value;
@@ -2785,18 +2776,15 @@ Controls_GetConfig
 */
 
 unsafe extern "C" fn Controls_GetConfig() {
-    let mut i: libc::c_int = 0;
     let mut twokeys: [libc::c_int; 2] = [0; 2];
     let mut bindptr: *mut bind_t = 0 as *mut bind_t;
     // put the bindings into a local store
     bindptr = g_bindings.as_mut_ptr();
     // iterate each command, get its numeric binding
-    i = 0 as libc::c_int;
     while !(*bindptr).label.is_null() {
         Controls_GetKeyAssignment((*bindptr).command, twokeys.as_mut_ptr());
         (*bindptr).bind1 = twokeys[0 as libc::c_int as usize];
         (*bindptr).bind2 = twokeys[1 as libc::c_int as usize];
-        i += 1;
         bindptr = bindptr.offset(1)
     }
     s_controls.invertmouse.curvalue = (Controls_GetCvarValue(
@@ -2859,12 +2847,10 @@ Controls_SetConfig
 */
 
 unsafe extern "C" fn Controls_SetConfig() {
-    let mut i: libc::c_int = 0;
     let mut bindptr: *mut bind_t = 0 as *mut bind_t;
     // set the bindings from the local store
     bindptr = g_bindings.as_mut_ptr();
     // iterate each command, get its numeric binding
-    i = 0 as libc::c_int;
     while !(*bindptr).label.is_null() {
         if (*bindptr).bind1 != -(1 as libc::c_int) {
             crate::src::ui::ui_syscalls::trap_Key_SetBinding((*bindptr).bind1, (*bindptr).command);
@@ -2875,7 +2861,6 @@ unsafe extern "C" fn Controls_SetConfig() {
                 );
             }
         }
-        i += 1;
         bindptr = bindptr.offset(1)
     }
     if s_controls.invertmouse.curvalue != 0 {
@@ -2933,16 +2918,13 @@ Controls_SetDefaults
 */
 
 unsafe extern "C" fn Controls_SetDefaults() {
-    let mut i: libc::c_int = 0;
     let mut bindptr: *mut bind_t = 0 as *mut bind_t;
     // set the bindings from the local store
     bindptr = g_bindings.as_mut_ptr();
     // iterate each command, set its default binding
-    i = 0 as libc::c_int;
     while !(*bindptr).label.is_null() {
         (*bindptr).bind1 = (*bindptr).defaultbind1;
         (*bindptr).bind2 = (*bindptr).defaultbind2;
-        i += 1;
         bindptr = bindptr.offset(1)
     }
     s_controls.invertmouse.curvalue = (Controls_GetCvarDefault(

--- a/quake3-rs/uix86_64/src/qcommon/q_shared.rs
+++ b/quake3-rs/uix86_64/src/qcommon/q_shared.rs
@@ -1256,11 +1256,10 @@ pub unsafe extern "C" fn Q_isanumber(
     mut s: *const libc::c_char,
 ) -> crate::src::qcommon::q_shared::qboolean {
     let mut p: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut d: libc::c_double = 0.;
     if *s as libc::c_int == '\u{0}' as i32 {
         return crate::src::qcommon::q_shared::qfalse;
     }
-    d = ::libc::strtod(s, &mut p);
+    ::libc::strtod(s, &mut p);
     return (*p as libc::c_int == '\u{0}' as i32) as libc::c_int
         as crate::src::qcommon::q_shared::qboolean;
 }


### PR DESCRIPTION
## Summary
- remove unused counters in UI control helpers
- drop unused `d` temporary in various `Q_isanumber` functions
- clean up local size tracking in hunk logs
- get rid of temporary writes in tty console helpers
- remove unused accumulators in the renderer

## Testing
- `cargo +nightly-2019-12-05 build --release`

------
https://chatgpt.com/codex/tasks/task_e_6843dfe7f68083298ddc0f9e2d836591