### PR TITLE
Fix Rust compiler warnings

### DIFF
--- a/quake3-rs/ioquake3/lib.rs
+++ b/quake3-rs/ioquake3/lib.rs
@@ -9583,7 +9583,6 @@ pub mod stdlib {
 
     pub type __socklen_t = libc::c_uint;
 }
-#[macro_use]
 extern crate c2rust_asm_casts;
 extern crate libc;
 

--- a/quake3-rs/ioquake3/src/botlib/l_script.rs
+++ b/quake3-rs/ioquake3/src/botlib/l_script.rs
@@ -984,7 +984,7 @@ pub unsafe extern "C" fn PS_ReadEscapeCharacter(
 ) -> libc::c_int {
     let mut c: libc::c_int = 0;
     let mut val: libc::c_int = 0;
-    let mut i: libc::c_int = 0;
+    let mut _i: libc::c_int = 0;
     //step over the leading '\\'
     (*script).script_p = (*script).script_p.offset(1);
     //determine the escape character
@@ -1005,7 +1005,7 @@ pub unsafe extern "C" fn PS_ReadEscapeCharacter(
         63 => c = '?' as i32,
         120 => {
             (*script).script_p = (*script).script_p.offset(1); //end case
-            i = 0 as libc::c_int; //end for
+            _i = 0 as libc::c_int; //end for
             val = 0 as libc::c_int; //end if
             loop {
                 c = *(*script).script_p as libc::c_int;
@@ -1020,7 +1020,7 @@ pub unsafe extern "C" fn PS_ReadEscapeCharacter(
                     c = c - 'a' as i32 + 10 as libc::c_int
                 }
                 val = (val << 4 as libc::c_int) + c;
-                i += 1;
+                _i += 1;
                 (*script).script_p = (*script).script_p.offset(1)
             }
             (*script).script_p = (*script).script_p.offset(-1);
@@ -1045,7 +1045,7 @@ pub unsafe extern "C" fn PS_ReadEscapeCharacter(
                         as *mut libc::c_char,
                 ); //end for
             } //end if
-            i = 0 as libc::c_int;
+            _i = 0 as libc::c_int;
             val = 0 as libc::c_int;
             loop {
                 c = *(*script).script_p as libc::c_int;
@@ -1054,7 +1054,7 @@ pub unsafe extern "C" fn PS_ReadEscapeCharacter(
                 }
                 c = c - '0' as i32;
                 val = val * 10 as libc::c_int + c;
-                i += 1;
+                _i += 1;
                 (*script).script_p = (*script).script_p.offset(1)
             }
             (*script).script_p = (*script).script_p.offset(-1);

--- a/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/floor1.rs
+++ b/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/floor1.rs
@@ -961,7 +961,7 @@ unsafe extern "C" fn fit_line(
     let mut xb: libc::c_double = 0 as libc::c_int as libc::c_double;
     let mut yb: libc::c_double = 0 as libc::c_int as libc::c_double;
     let mut x2b: libc::c_double = 0 as libc::c_int as libc::c_double;
-    let mut y2b: libc::c_double = 0 as libc::c_int as libc::c_double;
+    let mut _y2b: libc::c_double = 0 as libc::c_int as libc::c_double;
     let mut xyb: libc::c_double = 0 as libc::c_int as libc::c_double;
     let mut bn: libc::c_double = 0 as libc::c_int as libc::c_double;
     let mut i: libc::c_int = 0;
@@ -981,7 +981,7 @@ unsafe extern "C" fn fit_line(
             + (*a.offset(i as isize)).ya as libc::c_double * weight;
         x2b += (*a.offset(i as isize)).x2b as libc::c_double
             + (*a.offset(i as isize)).x2a as libc::c_double * weight;
-        y2b += (*a.offset(i as isize)).y2b as libc::c_double
+        _y2b += (*a.offset(i as isize)).y2b as libc::c_double
             + (*a.offset(i as isize)).y2a as libc::c_double * weight;
         xyb += (*a.offset(i as isize)).xyb as libc::c_double
             + (*a.offset(i as isize)).xya as libc::c_double * weight;
@@ -993,7 +993,7 @@ unsafe extern "C" fn fit_line(
         xb += x0 as libc::c_double;
         yb += *y0 as libc::c_double;
         x2b += (x0 * x0) as libc::c_double;
-        y2b += (*y0 * *y0) as libc::c_double;
+        _y2b += (*y0 * *y0) as libc::c_double;
         xyb += (*y0 * x0) as libc::c_double;
         bn += 1.
     }
@@ -1001,7 +1001,7 @@ unsafe extern "C" fn fit_line(
         xb += x1 as libc::c_double;
         yb += *y1 as libc::c_double;
         x2b += (x1 * x1) as libc::c_double;
-        y2b += (*y1 * *y1) as libc::c_double;
+        _y2b += (*y1 * *y1) as libc::c_double;
         xyb += (*y1 * x1) as libc::c_double;
         bn += 1.
     }

--- a/quake3-rs/ioquake3/src/opus_1_2_1/celt/bands.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/celt/bands.rs
@@ -1487,7 +1487,7 @@ unsafe extern "C" fn quant_band_n1(
     mut ctx: *mut band_ctx,
     mut X: *mut crate::arch_h::celt_norm,
     mut Y: *mut crate::arch_h::celt_norm,
-    mut b: libc::c_int,
+    mut _b: libc::c_int,
     mut lowband_out: *mut crate::arch_h::celt_norm,
 ) -> libc::c_uint {
     let mut c: libc::c_int = 0;
@@ -1518,7 +1518,7 @@ unsafe extern "C" fn quant_band_n1(
                 ) as libc::c_int
             }
             (*ctx).remaining_bits -= (1 as libc::c_int) << 3 as libc::c_int;
-            b -= (1 as libc::c_int) << 3 as libc::c_int
+            _b -= (1 as libc::c_int) << 3 as libc::c_int
         }
         if (*ctx).resynth != 0 {
             *x.offset(0 as libc::c_int as isize) = if sign != 0 { -1.0f32 } else { 1.0f32 }

--- a/quake3-rs/ioquake3/src/opusfile_0_9/src/opusfile.rs
+++ b/quake3-rs/ioquake3/src/opusfile_0_9/src/opusfile.rs
@@ -1392,9 +1392,9 @@ pub unsafe extern "C" fn opus_granule_sample(
     mut _head: *const crate::src::opusfile_0_9::src::opusfile::OpusHead,
     mut _gp: crate::config_types_h::ogg_int64_t,
 ) -> crate::config_types_h::ogg_int64_t {
-    let mut pre_skip: crate::opus_types_h::opus_int32 = 0;
-    pre_skip = (*_head).pre_skip as crate::opus_types_h::opus_int32;
-    if _gp != -(1 as libc::c_int) as libc::c_long && op_granpos_add(&mut _gp, _gp, -pre_skip) != 0 {
+    let mut _pre_skip: crate::opus_types_h::opus_int32 = 0;
+    _pre_skip = (*_head).pre_skip as crate::opus_types_h::opus_int32;
+    if _gp != -(1 as libc::c_int) as libc::c_long && op_granpos_add(&mut _gp, _gp, -_pre_skip) != 0 {
         _gp = -(1 as libc::c_int) as crate::config_types_h::ogg_int64_t
     }
     return _gp;
@@ -3730,7 +3730,7 @@ unsafe extern "C" fn op_get_granulepos(
     let mut duration: crate::config_types_h::ogg_int64_t =
         0 as libc::c_int as crate::config_types_h::ogg_int64_t;
     let mut pcm_start: crate::config_types_h::ogg_int64_t = 0;
-    let mut pre_skip: crate::opus_types_h::opus_int32 = 0;
+    let mut _pre_skip: crate::opus_types_h::opus_int32 = 0;
     let mut nlinks: libc::c_int = 0;
     let mut li_lo: libc::c_int = 0;
     let mut li_hi: libc::c_int = 0;
@@ -3752,12 +3752,12 @@ unsafe extern "C" fn op_get_granulepos(
     }
     _pcm_offset -= (*links.offset(li_lo as isize)).pcm_file_offset;
     pcm_start = (*links.offset(li_lo as isize)).pcm_start;
-    pre_skip = (*links.offset(li_lo as isize)).head.pre_skip as crate::opus_types_h::opus_int32;
-    duration -= pre_skip as libc::c_long;
+    _pre_skip = (*links.offset(li_lo as isize)).head.pre_skip as crate::opus_types_h::opus_int32;
+    duration -= _pre_skip as libc::c_long;
     if _pcm_offset >= duration {
         return -(1 as libc::c_int) as crate::config_types_h::ogg_int64_t;
     }
-    _pcm_offset += pre_skip as libc::c_long;
+    _pcm_offset += _pre_skip as libc::c_long;
     if (pcm_start
         > (2 as libc::c_int as libc::c_long
             * (((1 as libc::c_int as crate::config_types_h::ogg_int64_t) << 62 as libc::c_int)
@@ -3857,7 +3857,7 @@ unsafe extern "C" fn op_pcm_seek_page(
     let mut best_gp: crate::config_types_h::ogg_int64_t = 0;
     let mut diff: crate::config_types_h::ogg_int64_t = 0;
     let mut serialno: crate::config_types_h::ogg_uint32_t = 0;
-    let mut pre_skip: crate::opus_types_h::opus_int32 = 0;
+    let mut _pre_skip: crate::opus_types_h::opus_int32 = 0;
     let mut begin: libc::c_longlong = 0;
     let mut end: libc::c_longlong = 0;
     let mut boundary: libc::c_longlong = 0;
@@ -3897,7 +3897,7 @@ unsafe extern "C" fn op_pcm_seek_page(
         _target_gp = pcm_start
     }
     /*Special case seeking to the start of the link.*/
-    pre_skip = (*link).head.pre_skip as crate::opus_types_h::opus_int32;
+    _pre_skip = (*link).head.pre_skip as crate::opus_types_h::opus_int32;
     if op_granpos_cmp(_target_gp, pcm_pre_skip) < 0 as libc::c_int {
         boundary = begin;
         end = boundary
@@ -4328,8 +4328,8 @@ pub unsafe extern "C" fn op_pcm_seek(
         let mut gp: crate::config_types_h::ogg_int64_t = 0;
         gp = (*_of).prev_packet_gp;
         if (gp != -(1 as libc::c_int) as libc::c_long) as libc::c_int as libc::c_long != 0 {
-            let mut nbuffered: libc::c_int = 0;
-            nbuffered = if (*_of).od_buffer_size - (*_of).od_buffer_pos > 0 as libc::c_int {
+            let mut _nbuffered: libc::c_int = 0;
+            _nbuffered = if (*_of).od_buffer_size - (*_of).od_buffer_pos > 0 as libc::c_int {
                 ((*_of).od_buffer_size) - (*_of).od_buffer_pos
             } else {
                 0 as libc::c_int
@@ -4486,7 +4486,7 @@ pub unsafe extern "C" fn op_pcm_tell(
     mut _of: *const crate::internal_h::OggOpusFile,
 ) -> crate::config_types_h::ogg_int64_t {
     let mut gp: crate::config_types_h::ogg_int64_t = 0;
-    let mut nbuffered: libc::c_int = 0;
+    let mut _nbuffered: libc::c_int = 0;
     let mut li: libc::c_int = 0;
     if ((*_of).ready_state < 2 as libc::c_int) as libc::c_int as libc::c_long != 0 {
         return -(131 as libc::c_int) as crate::config_types_h::ogg_int64_t;
@@ -4495,7 +4495,7 @@ pub unsafe extern "C" fn op_pcm_tell(
     if gp == -(1 as libc::c_int) as libc::c_long {
         return 0 as libc::c_int as crate::config_types_h::ogg_int64_t;
     }
-    nbuffered = if (*_of).od_buffer_size - (*_of).od_buffer_pos > 0 as libc::c_int {
+    _nbuffered = if (*_of).od_buffer_size - (*_of).od_buffer_pos > 0 as libc::c_int {
         ((*_of).od_buffer_size) - (*_of).od_buffer_pos
     } else {
         0 as libc::c_int

--- a/quake3-rs/ioquake3/src/opusfile_0_9/src/stream.rs
+++ b/quake3-rs/ioquake3/src/opusfile_0_9/src/stream.rs
@@ -252,9 +252,8 @@ unsafe extern "C" fn op_mem_close(mut _stream: *mut libc::c_void) -> libc::c_int
     return 0 as libc::c_int;
 }
 
-static mut OP_MEM_CALLBACKS: crate::src::opusfile_0_9::src::opusfile::OpusFileCallbacks = unsafe {
-    {
-        let mut init = crate::src::opusfile_0_9::src::opusfile::OpusFileCallbacks {
+static mut OP_MEM_CALLBACKS: crate::src::opusfile_0_9::src::opusfile::OpusFileCallbacks = {
+    let mut init = crate::src::opusfile_0_9::src::opusfile::OpusFileCallbacks {
             read: Some(
                 op_mem_read
                     as unsafe extern "C" fn(
@@ -275,9 +274,8 @@ static mut OP_MEM_CALLBACKS: crate::src::opusfile_0_9::src::opusfile::OpusFileCa
                 op_mem_tell as unsafe extern "C" fn(_: *mut libc::c_void) -> libc::c_longlong,
             ),
             close: Some(op_mem_close as unsafe extern "C" fn(_: *mut libc::c_void) -> libc::c_int),
-        };
-        init
-    }
+    };
+    init
 };
 /* *******************************************************************
 *                                                                  *

--- a/quake3-rs/ioquake3/src/qcommon/q_shared.rs
+++ b/quake3-rs/ioquake3/src/qcommon/q_shared.rs
@@ -1419,11 +1419,10 @@ pub unsafe extern "C" fn Q_isanumber(
     mut s: *const libc::c_char,
 ) -> crate::src::qcommon::q_shared::qboolean {
     let mut p: *mut libc::c_char = 0 as *mut libc::c_char;
-    let mut d: libc::c_double = 0.;
     if *s as libc::c_int == '\u{0}' as i32 {
         return crate::src::qcommon::q_shared::qfalse;
     }
-    d = ::libc::strtod(s, &mut p);
+    let _ = ::libc::strtod(s, &mut p);
     return (*p as libc::c_int == '\u{0}' as i32) as libc::c_int
         as crate::src::qcommon::q_shared::qboolean;
 }

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_shadows.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_shadows.rs
@@ -303,15 +303,15 @@ pub unsafe extern "C" fn R_RenderShadowEdges() {
     let mut j: libc::c_int = 0;
     let mut k: libc::c_int = 0;
     let mut i2: libc::c_int = 0;
-    let mut c_edges: libc::c_int = 0;
-    let mut c_rejected: libc::c_int = 0;
+    let mut _c_edges: libc::c_int = 0;
+    let mut _c_rejected: libc::c_int = 0;
     let mut hit: [libc::c_int; 2] = [0; 2];
     // an edge is NOT a silhouette edge if its face doesn't face the light,
     // or if it has a reverse paired edge that also faces the light.
     // A well behaved polyhedron would have exactly two faces for each edge,
     // but lots of models have dangling edges or overfanned edges
-    c_edges = 0 as libc::c_int;
-    c_rejected = 0 as libc::c_int;
+    _c_edges = 0 as libc::c_int;
+    _c_rejected = 0 as libc::c_int;
     i = 0 as libc::c_int;
     while i < crate::src::renderergl1::tr_shade::tess.numVertexes {
         c = numEdgeDefs[i as usize];
@@ -348,9 +348,9 @@ pub unsafe extern "C" fn R_RenderShadowEdges() {
                         shadowXyz[i2 as usize].as_mut_ptr(),
                     );
                     crate::src::sdl::sdl_glimp::qglEnd.expect("non-null function pointer")();
-                    c_edges += 1
+                    _c_edges += 1
                 } else {
-                    c_rejected += 1
+                    _c_rejected += 1
                 }
             }
             j += 1

--- a/quake3-rs/uix86_64/src/q3_ui/ui_controls2.rs
+++ b/quake3-rs/uix86_64/src/q3_ui/ui_controls2.rs
@@ -2963,7 +2963,7 @@ unsafe extern "C" fn Controls_MenuKey(
 ) -> crate::src::qcommon::q_shared::sfxHandle_t {
     let mut current_block: u64;
     let mut id: libc::c_int = 0;
-    let mut i: libc::c_int = 0;
+    let mut _i: libc::c_int = 0;
     let mut found: crate::src::qcommon::q_shared::qboolean = crate::src::qcommon::q_shared::qfalse;
     let mut bindptr: *mut bind_t = 0 as *mut bind_t;
     found = crate::src::qcommon::q_shared::qfalse;
@@ -3026,7 +3026,7 @@ unsafe extern "C" fn Controls_MenuKey(
             if key != -(1 as libc::c_int) {
                 // remove from any other bind
                 bindptr = g_bindings.as_mut_ptr();
-                i = 0 as libc::c_int;
+                _i = 0 as libc::c_int;
                 while !(*bindptr).label.is_null() {
                     if (*bindptr).bind2 == key {
                         (*bindptr).bind2 = -(1 as libc::c_int)
@@ -3035,7 +3035,7 @@ unsafe extern "C" fn Controls_MenuKey(
                         (*bindptr).bind1 = (*bindptr).bind2;
                         (*bindptr).bind2 = -(1 as libc::c_int)
                     }
-                    i += 1;
+                    _i += 1;
                     bindptr = bindptr.offset(1)
                 }
             }
@@ -3044,7 +3044,7 @@ unsafe extern "C" fn Controls_MenuKey(
                 as *mut crate::ui_local_h::menucommon_s))
                 .id;
             bindptr = g_bindings.as_mut_ptr();
-            i = 0 as libc::c_int;
+            _i = 0 as libc::c_int;
             while !(*bindptr).label.is_null() {
                 if (*bindptr).id == id {
                     found = crate::src::qcommon::q_shared::qtrue;
@@ -3081,7 +3081,7 @@ unsafe extern "C" fn Controls_MenuKey(
                     }
                     break;
                 } else {
-                    i += 1;
+                    _i += 1;
                     bindptr = bindptr.offset(1)
                 }
             }


### PR DESCRIPTION
## Summary
- eliminate unused macro import in lib
- silence unused variable warnings across modules
- drop unnecessary unsafe block

## Testing
- `cargo +nightly-2019-12-05 build --release`

------
https://chatgpt.com/codex/tasks/task_e_6843ead2bb108329bdb4c55117091bf6