### PR TITLE
Replace deprecated wrapping_offset_from

### DIFF
--- a/quake3-rs/cgamex86_64/lib.rs
+++ b/quake3-rs/cgamex86_64/lib.rs
@@ -7,7 +7,7 @@
 #![allow(unused_mut)]
 #![feature(c_variadic)]
 #![feature(const_raw_ptr_to_usize_cast)]
-#![feature(ptr_wrapping_offset_from)]
+#![feature(ptr_offset_from)]
 #![feature(register_tool)]
 #![register_tool(c2rust)]
 

--- a/quake3-rs/cgamex86_64/src/cgame/cg_draw.rs
+++ b/quake3-rs/cgamex86_64/src/cgame/cg_draw.rs
@@ -688,7 +688,7 @@ pub unsafe extern "C" fn CG_DrawFlagModel(
                 w,
                 h,
                 crate::src::cgame::cg_main::cg_items[item
-                    .wrapping_offset_from(crate::src::game::bg_misc::bg_itemlist.as_mut_ptr())
+                    .offset_from(crate::src::game::bg_misc::bg_itemlist.as_mut_ptr())
                     as libc::c_long as usize]
                     .icon,
             );

--- a/quake3-rs/cgamex86_64/src/cgame/cg_main.rs
+++ b/quake3-rs/cgamex86_64/src/cgame/cg_main.rs
@@ -3483,7 +3483,7 @@ unsafe extern "C" fn CG_RegisterItemSounds(mut itemNum: libc::c_int) {
         while *s as libc::c_int != 0 && *s as libc::c_int != ' ' as i32 {
             s = s.offset(1)
         }
-        len = s.wrapping_offset_from(start) as libc::c_long as libc::c_int;
+        len = s.offset_from(start) as libc::c_long as libc::c_int;
         if len >= 64 as libc::c_int || len < 5 as libc::c_int {
             CG_Error(
                 b"PrecacheItem: %s has bad precache string\x00" as *const u8 as *const libc::c_char,

--- a/quake3-rs/cgamex86_64/src/cgame/cg_servercmds.rs
+++ b/quake3-rs/cgamex86_64/src/cgame/cg_servercmds.rs
@@ -483,9 +483,9 @@ pub unsafe extern "C" fn CG_ShaderStateChanged() {
         crate::stdlib::strncpy(
             originalShader.as_mut_ptr(),
             o,
-            n.wrapping_offset_from(o) as libc::c_long as libc::c_ulong,
+            n.offset_from(o) as libc::c_long as libc::c_ulong,
         );
-        originalShader[n.wrapping_offset_from(o) as libc::c_long as usize] =
+        originalShader[n.offset_from(o) as libc::c_long as usize] =
             0 as libc::c_int as libc::c_char;
         n = n.offset(1);
         t = ::libc::strstr(n, b":\x00" as *const u8 as *const libc::c_char);
@@ -495,9 +495,9 @@ pub unsafe extern "C" fn CG_ShaderStateChanged() {
         crate::stdlib::strncpy(
             newShader.as_mut_ptr(),
             n,
-            t.wrapping_offset_from(n) as libc::c_long as libc::c_ulong,
+            t.offset_from(n) as libc::c_long as libc::c_ulong,
         );
-        newShader[t.wrapping_offset_from(n) as libc::c_long as usize] =
+        newShader[t.offset_from(n) as libc::c_long as usize] =
             0 as libc::c_int as libc::c_char;
         t = t.offset(1);
         o = ::libc::strstr(t, b"@\x00" as *const u8 as *const libc::c_char);
@@ -505,9 +505,9 @@ pub unsafe extern "C" fn CG_ShaderStateChanged() {
             crate::stdlib::strncpy(
                 timeOffset.as_mut_ptr(),
                 t,
-                o.wrapping_offset_from(t) as libc::c_long as libc::c_ulong,
+                o.offset_from(t) as libc::c_long as libc::c_ulong,
             );
-            timeOffset[o.wrapping_offset_from(t) as libc::c_long as usize] =
+            timeOffset[o.offset_from(t) as libc::c_long as usize] =
                 0 as libc::c_int as libc::c_char;
             o = o.offset(1);
             crate::src::cgame::cg_syscalls::trap_R_RemapShader(
@@ -662,9 +662,9 @@ unsafe extern "C" fn CG_AddToTeamChat(mut str: *const libc::c_char) {
     while *str != 0 {
         if len > 80 as libc::c_int - 1 as libc::c_int {
             if !ls.is_null() {
-                str = str.offset(-(p.wrapping_offset_from(ls) as libc::c_long as isize));
+                str = str.offset(-(p.offset_from(ls) as libc::c_long as isize));
                 str = str.offset(1);
-                p = p.offset(-(p.wrapping_offset_from(ls) as libc::c_long as isize))
+                p = p.offset(-(p.offset_from(ls) as libc::c_long as isize))
             }
             *p = 0 as libc::c_int as libc::c_char;
             crate::src::cgame::cg_main::cgs.teamChatMsgTimes

--- a/quake3-rs/cgamex86_64/src/cgame/cg_weapons.rs
+++ b/quake3-rs/cgamex86_64/src/cgame/cg_weapons.rs
@@ -1335,7 +1335,7 @@ pub unsafe extern "C" fn CG_RegisterWeapon(mut weaponNum: libc::c_int) {
         );
     }
     CG_RegisterItemVisuals(
-        item.wrapping_offset_from(crate::src::game::bg_misc::bg_itemlist.as_mut_ptr())
+        item.offset_from(crate::src::game::bg_misc::bg_itemlist.as_mut_ptr())
             as libc::c_long as libc::c_int,
     );
     // load cmodel before model so filecache works
@@ -2474,7 +2474,7 @@ pub unsafe extern "C" fn CG_AddPlayerWeapon(
     // if the index of the nonPredictedCent is not the same as the clientNum
     // then this is a fake player (like on the single player podiums), so
     // go ahead and use the cent
-    if nonPredictedCent.wrapping_offset_from(crate::src::cgame::cg_main::cg_entities.as_mut_ptr())
+    if nonPredictedCent.offset_from(crate::src::cgame::cg_main::cg_entities.as_mut_ptr())
         as libc::c_long
         != (*cent).currentState.clientNum as libc::c_long
     {

--- a/quake3-rs/cgamex86_64/src/qcommon/q_shared.rs
+++ b/quake3-rs/cgamex86_64/src/qcommon/q_shared.rs
@@ -991,11 +991,11 @@ pub unsafe extern "C" fn COM_StripExtension(
         (slash.is_null()) || slash < dot
     } {
         destsize = if (destsize as libc::c_long)
-            < dot.wrapping_offset_from(in_0) as libc::c_long + 1 as libc::c_int as libc::c_long
+            < dot.offset_from(in_0) as libc::c_long + 1 as libc::c_int as libc::c_long
         {
             destsize as libc::c_long
         } else {
-            (dot.wrapping_offset_from(in_0) as libc::c_long) + 1 as libc::c_int as libc::c_long
+            (dot.offset_from(in_0) as libc::c_long) + 1 as libc::c_int as libc::c_long
         } as libc::c_int
     }
     if in_0 == out as *const libc::c_char && destsize > 1 as libc::c_int {
@@ -1307,7 +1307,7 @@ pub unsafe extern "C" fn COM_Compress(mut data_p: *mut libc::c_char) -> libc::c_
         }
         *out = 0 as libc::c_int as libc::c_char
     }
-    return out.wrapping_offset_from(data_p) as libc::c_long as libc::c_int;
+    return out.offset_from(data_p) as libc::c_long as libc::c_int;
 }
 #[no_mangle]
 pub unsafe extern "C" fn COM_ParseExt(

--- a/quake3-rs/ioquake3/lib.rs
+++ b/quake3-rs/ioquake3/lib.rs
@@ -11,7 +11,7 @@
 #![feature(const_transmute)]
 #![feature(extern_types)]
 #![feature(main)]
-#![feature(ptr_wrapping_offset_from)]
+#![feature(ptr_offset_from)]
 #![feature(register_tool)]
 #![feature(stdsimd)]
 #![register_tool(c2rust)]

--- a/quake3-rs/ioquake3/src/botlib/be_ai_chat.rs
+++ b/quake3-rs/ioquake3/src/botlib/be_ai_chat.rs
@@ -2435,7 +2435,7 @@ pub unsafe extern "C" fn StringsMatch(
                         newstrptr = strptr.offset(index as isize); //end if
                         if lastvariable >= 0 as libc::c_int {
                             (*match_0).variables[lastvariable as usize].length = (newstrptr
-                                .wrapping_offset_from((*match_0).string.as_mut_ptr())
+                                .offset_from((*match_0).string.as_mut_ptr())
                                 as libc::c_long
                                 - (*match_0).variables[lastvariable as usize].offset
                                     as libc::c_long)
@@ -2462,7 +2462,7 @@ pub unsafe extern "C" fn StringsMatch(
             //if it is a variable piece of string
             //Log_Write("MT_VARIABLE");
             (*match_0).variables[(*mp).variable as usize].offset =
-                strptr.wrapping_offset_from((*match_0).string.as_mut_ptr()) as libc::c_long
+                strptr.offset_from((*match_0).string.as_mut_ptr()) as libc::c_long
                     as libc::c_char;
             lastvariable = (*mp).variable
         }

--- a/quake3-rs/ioquake3/src/botlib/l_precomp.rs
+++ b/quake3-rs/ioquake3/src/botlib/l_precomp.rs
@@ -1724,7 +1724,7 @@ pub unsafe extern "C" fn PC_WhiteSpaceBeforeToken(
 ) -> libc::c_int {
     return ((*token)
         .endwhitespace_p
-        .wrapping_offset_from((*token).whitespace_p) as libc::c_long
+        .offset_from((*token).whitespace_p) as libc::c_long
         > 0 as libc::c_int as libc::c_long) as libc::c_int;
 }
 //end of the function PC_WhiteSpaceBeforeToken

--- a/quake3-rs/ioquake3/src/client/cl_keys.rs
+++ b/quake3-rs/ioquake3/src/client/cl_keys.rs
@@ -4206,7 +4206,7 @@ pub unsafe extern "C" fn CL_LoadConsoleHistory() {
             text_p = text_p.offset(1);
             if numChars as libc::c_ulong
                 > crate::stdlib::strlen(consoleSaveBuffer.as_mut_ptr())
-                    .wrapping_sub(text_p.wrapping_offset_from(consoleSaveBuffer.as_mut_ptr())
+                    .wrapping_sub(text_p.offset_from(consoleSaveBuffer.as_mut_ptr())
                         as libc::c_long as libc::c_ulong)
             {
                 crate::src::qcommon::common::Com_DPrintf(

--- a/quake3-rs/ioquake3/src/client/cl_main.rs
+++ b/quake3-rs/ioquake3/src/client/cl_main.rs
@@ -2756,7 +2756,7 @@ pub unsafe extern "C" fn CL_PlayDemo_f() {
                 b"Protocol %d not supported for demos\n\x00" as *const u8 as *const libc::c_char,
                 protocol,
             );
-            len = ext_test.wrapping_offset_from(arg.as_mut_ptr()) as libc::c_long as libc::c_int;
+            len = ext_test.offset_from(arg.as_mut_ptr()) as libc::c_long as libc::c_int;
             if len as libc::c_ulong
                 >= (::std::mem::size_of::<[libc::c_char; 4096]>() as libc::c_ulong)
                     .wrapping_div(::std::mem::size_of::<libc::c_char>() as libc::c_ulong)
@@ -4611,7 +4611,7 @@ pub unsafe extern "C" fn CL_ServersResponsePacket(
         // IPv4 address
         if *buffptr as libc::c_int == '\\' as i32 {
             buffptr = buffptr.offset(1);
-            if (buffend.wrapping_offset_from(buffptr) as libc::c_long as libc::c_ulong)
+            if (buffend.offset_from(buffptr) as libc::c_long as libc::c_ulong)
                 < (::std::mem::size_of::<[crate::src::qcommon::q_shared::byte; 4]>()
                     as libc::c_ulong)
                     .wrapping_add(::std::mem::size_of::<libc::c_ushort>() as libc::c_ulong)
@@ -4635,7 +4635,7 @@ pub unsafe extern "C" fn CL_ServersResponsePacket(
                 break;
             }
             buffptr = buffptr.offset(1);
-            if (buffend.wrapping_offset_from(buffptr) as libc::c_long as libc::c_ulong)
+            if (buffend.offset_from(buffptr) as libc::c_long as libc::c_ulong)
                 < (::std::mem::size_of::<[crate::src::qcommon::q_shared::byte; 16]>()
                     as libc::c_ulong)
                     .wrapping_add(::std::mem::size_of::<libc::c_ushort>() as libc::c_ulong)

--- a/quake3-rs/ioquake3/src/client/snd_dma.rs
+++ b/quake3-rs/ioquake3/src/client/snd_dma.rs
@@ -787,7 +787,7 @@ pub unsafe extern "C" fn S_Base_RegisterSound(
             );
             return 0 as libc::c_int;
         }
-        return sfx.wrapping_offset_from(s_knownSfx.as_mut_ptr()) as libc::c_long
+        return sfx.offset_from(s_knownSfx.as_mut_ptr()) as libc::c_long
             as crate::src::qcommon::q_shared::sfxHandle_t;
     }
     (*sfx).inMemory = crate::src::qcommon::q_shared::qfalse;
@@ -801,7 +801,7 @@ pub unsafe extern "C" fn S_Base_RegisterSound(
         );
         return 0 as libc::c_int;
     }
-    return sfx.wrapping_offset_from(s_knownSfx.as_mut_ptr()) as libc::c_long
+    return sfx.offset_from(s_knownSfx.as_mut_ptr()) as libc::c_long
         as crate::src::qcommon::q_shared::sfxHandle_t;
 }
 /*

--- a/quake3-rs/ioquake3/src/libogg_1_3_3/src/framing.rs
+++ b/quake3-rs/ioquake3/src/libogg_1_3_3/src/framing.rs
@@ -1234,8 +1234,8 @@ pub unsafe extern "C" fn ogg_sync_pageseek(
     if next.is_null() {
         next = (*oy).data.offset((*oy).fill as isize)
     }
-    (*oy).returned = next.wrapping_offset_from((*oy).data) as libc::c_long as libc::c_int;
-    return -(next.wrapping_offset_from(page) as libc::c_long);
+    (*oy).returned = next.offset_from((*oy).data) as libc::c_long as libc::c_int;
+    return -(next.offset_from(page) as libc::c_long);
 }
 /* sync the stream and get a page.  Keep trying until we find a page.
 Suppress 'sync errors' after reporting the first.

--- a/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/floor1.rs
+++ b/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/floor1.rs
@@ -439,7 +439,7 @@ unsafe extern "C" fn floor1_look(
     i = 0 as libc::c_int;
     while i < n {
         (*look).forward_index[i as usize] = sortpointer[i as usize]
-            .wrapping_offset_from((*info).postlist.as_mut_ptr())
+            .offset_from((*info).postlist.as_mut_ptr())
             as libc::c_long as libc::c_int;
         i += 1
     }

--- a/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/psy.rs
+++ b/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/psy.rs
@@ -7991,7 +7991,7 @@ unsafe extern "C" fn noise_normalize(
         j = 0 as libc::c_int;
         while j < count {
             let mut k: libc::c_int =
-                (*sort.offset(j as isize)).wrapping_offset_from(q) as libc::c_long as libc::c_int;
+                (*sort.offset(j as isize)).offset_from(q) as libc::c_long as libc::c_int;
             if acc as libc::c_double >= (*vi).normal_thresh {
                 *out.offset(k as isize) = unitnorm(*r.offset(k as isize)) as libc::c_int;
                 acc -= 1.0f32;

--- a/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/sharedbook.rs
+++ b/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/sharedbook.rs
@@ -588,7 +588,7 @@ pub unsafe extern "C" fn vorbis_book_init_decode(
             i = 0 as libc::c_int;
             while i < n {
                 let mut position: libc::c_int = (*codep.offset(i as isize))
-                    .wrapping_offset_from(codes)
+                    .offset_from(codes)
                     as libc::c_long as libc::c_int;
                 *sortindex.offset(position as isize) = i;
                 i += 1

--- a/quake3-rs/ioquake3/src/opus_1_2_1/celt/bands.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/celt/bands.rs
@@ -765,7 +765,7 @@ unsafe extern "C" fn stereo_merge(
             (N as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_norm>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as libc::c_int as libc::c_long * Y.wrapping_offset_from(X) as libc::c_long)
+                    (0 as libc::c_int as libc::c_long * Y.offset_from(X) as libc::c_long)
                         as libc::c_ulong,
                 ),
         );
@@ -1008,7 +1008,7 @@ unsafe extern "C" fn deinterleave_hadamard(
         (N as libc::c_ulong)
             .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_norm>() as libc::c_ulong)
             .wrapping_add(
-                (0 as libc::c_int as libc::c_long * X.wrapping_offset_from(tmp) as libc::c_long)
+                (0 as libc::c_int as libc::c_long * X.offset_from(tmp) as libc::c_long)
                     as libc::c_ulong,
             ),
     );
@@ -1063,7 +1063,7 @@ unsafe extern "C" fn interleave_hadamard(
         (N as libc::c_ulong)
             .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_norm>() as libc::c_ulong)
             .wrapping_add(
-                (0 as libc::c_int as libc::c_long * X.wrapping_offset_from(tmp) as libc::c_long)
+                (0 as libc::c_int as libc::c_long * X.offset_from(tmp) as libc::c_long)
                     as libc::c_ulong,
             ),
     );
@@ -1845,7 +1845,7 @@ unsafe extern "C" fn quant_band(
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_norm>() as libc::c_ulong)
                 .wrapping_add(
                     (0 as libc::c_int as libc::c_long
-                        * lowband_scratch.wrapping_offset_from(lowband) as libc::c_long)
+                        * lowband_scratch.offset_from(lowband) as libc::c_long)
                         as libc::c_ulong,
                 ),
         );
@@ -2242,7 +2242,7 @@ unsafe extern "C" fn special_hybrid_folding(
             .wrapping_add(
                 (0 as libc::c_int as libc::c_long
                     * (&mut *norm.offset(n1 as isize) as *mut crate::arch_h::celt_norm)
-                        .wrapping_offset_from(
+                        .offset_from(
                             &mut *norm.offset((2 as libc::c_int * n1 - n2) as isize),
                         ) as libc::c_long) as libc::c_ulong,
             ),
@@ -2257,7 +2257,7 @@ unsafe extern "C" fn special_hybrid_folding(
                 .wrapping_add(
                     (0 as libc::c_int as libc::c_long
                         * (&mut *norm2.offset(n1 as isize) as *mut crate::arch_h::celt_norm)
-                            .wrapping_offset_from(
+                            .offset_from(
                                 &mut *norm2.offset((2 as libc::c_int * n1 - n2) as isize),
                             ) as libc::c_long) as libc::c_ulong,
                 ),
@@ -2804,7 +2804,7 @@ pub unsafe extern "C" fn quant_all_bands(
                             )
                             .wrapping_add(
                                 (0 as libc::c_int as libc::c_long
-                                    * X_save.wrapping_offset_from(X) as libc::c_long)
+                                    * X_save.offset_from(X) as libc::c_long)
                                     as libc::c_ulong,
                             ),
                     );
@@ -2817,7 +2817,7 @@ pub unsafe extern "C" fn quant_all_bands(
                             )
                             .wrapping_add(
                                 (0 as libc::c_int as libc::c_long
-                                    * Y_save.wrapping_offset_from(Y) as libc::c_long)
+                                    * Y_save.offset_from(Y) as libc::c_long)
                                     as libc::c_ulong,
                             ),
                     );
@@ -2860,7 +2860,7 @@ pub unsafe extern "C" fn quant_all_bands(
                             )
                             .wrapping_add(
                                 (0 as libc::c_int as libc::c_long
-                                    * X_save2.wrapping_offset_from(X) as libc::c_long)
+                                    * X_save2.offset_from(X) as libc::c_long)
                                     as libc::c_ulong,
                             ),
                     );
@@ -2873,7 +2873,7 @@ pub unsafe extern "C" fn quant_all_bands(
                             )
                             .wrapping_add(
                                 (0 as libc::c_int as libc::c_long
-                                    * Y_save2.wrapping_offset_from(Y) as libc::c_long)
+                                    * Y_save2.offset_from(Y) as libc::c_long)
                                     as libc::c_ulong,
                             ),
                     );
@@ -2888,7 +2888,7 @@ pub unsafe extern "C" fn quant_all_bands(
                                     as libc::c_ulong)
                                 .wrapping_add(
                                     (0 as libc::c_int as libc::c_long
-                                        * norm_save2.wrapping_offset_from(
+                                        * norm_save2.offset_from(
                                             norm.offset(
                                                 (M * *eBands.offset(i as isize) as libc::c_int)
                                                     as isize,
@@ -2910,7 +2910,7 @@ pub unsafe extern "C" fn quant_all_bands(
                             .wrapping_mul(::std::mem::size_of::<libc::c_uchar>() as libc::c_ulong)
                             .wrapping_add(
                                 (0 as libc::c_int as libc::c_long
-                                    * bytes_save.as_mut_ptr().wrapping_offset_from(bytes_buf)
+                                    * bytes_save.as_mut_ptr().offset_from(bytes_buf)
                                         as libc::c_long)
                                     as libc::c_ulong,
                             ),
@@ -2927,7 +2927,7 @@ pub unsafe extern "C" fn quant_all_bands(
                             )
                             .wrapping_add(
                                 (0 as libc::c_int as libc::c_long
-                                    * X.wrapping_offset_from(X_save) as libc::c_long)
+                                    * X.offset_from(X_save) as libc::c_long)
                                     as libc::c_ulong,
                             ),
                     );
@@ -2940,7 +2940,7 @@ pub unsafe extern "C" fn quant_all_bands(
                             )
                             .wrapping_add(
                                 (0 as libc::c_int as libc::c_long
-                                    * Y.wrapping_offset_from(Y_save) as libc::c_long)
+                                    * Y.offset_from(Y_save) as libc::c_long)
                                     as libc::c_ulong,
                             ),
                     );
@@ -2985,7 +2985,7 @@ pub unsafe extern "C" fn quant_all_bands(
                                     as libc::c_ulong)
                                 .wrapping_add(
                                     (0 as libc::c_int as libc::c_long
-                                        * X.wrapping_offset_from(X_save2) as libc::c_long)
+                                        * X.offset_from(X_save2) as libc::c_long)
                                         as libc::c_ulong,
                                 ),
                         );
@@ -2997,7 +2997,7 @@ pub unsafe extern "C" fn quant_all_bands(
                                     as libc::c_ulong)
                                 .wrapping_add(
                                     (0 as libc::c_int as libc::c_long
-                                        * Y.wrapping_offset_from(Y_save2) as libc::c_long)
+                                        * Y.offset_from(Y_save2) as libc::c_long)
                                         as libc::c_ulong,
                                 ),
                         );
@@ -3020,7 +3020,7 @@ pub unsafe extern "C" fn quant_all_bands(
                                                         as isize,
                                                 )
                                                 .offset(-(norm_offset as isize))
-                                                .wrapping_offset_from(norm_save2)
+                                                .offset_from(norm_save2)
                                                 as libc::c_long)
                                             as libc::c_ulong,
                                     ),
@@ -3035,7 +3035,7 @@ pub unsafe extern "C" fn quant_all_bands(
                                 )
                                 .wrapping_add(
                                     (0 as libc::c_int as libc::c_long
-                                        * bytes_buf.wrapping_offset_from(bytes_save.as_mut_ptr())
+                                        * bytes_buf.offset_from(bytes_save.as_mut_ptr())
                                             as libc::c_long)
                                         as libc::c_ulong,
                                 ),

--- a/quake3-rs/ioquake3/src/opus_1_2_1/celt/celt.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/celt/celt.rs
@@ -140,7 +140,7 @@ pub unsafe extern "C" fn comb_filter(
                     )
                     .wrapping_add(
                         (0 as libc::c_int as libc::c_long
-                            * y.wrapping_offset_from(x) as libc::c_long)
+                            * y.offset_from(x) as libc::c_long)
                             as libc::c_ulong,
                     ),
             );
@@ -211,7 +211,7 @@ pub unsafe extern "C" fn comb_filter(
                     .wrapping_add(
                         (0 as libc::c_int as libc::c_long
                             * y.offset(overlap as isize)
-                                .wrapping_offset_from(x.offset(overlap as isize))
+                                .offset_from(x.offset(overlap as isize))
                                 as libc::c_long) as libc::c_ulong,
                     ),
             );

--- a/quake3-rs/ioquake3/src/opus_1_2_1/celt/celt_decoder.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/celt/celt_decoder.rs
@@ -516,7 +516,7 @@ unsafe extern "C" fn celt_synthesis(
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_sig>() as libc::c_ulong)
                 .wrapping_add(
                     (0 as libc::c_int as libc::c_long
-                        * freq2.wrapping_offset_from(freq) as libc::c_long)
+                        * freq2.offset_from(freq) as libc::c_long)
                         as libc::c_ulong,
                 ),
         );
@@ -907,7 +907,7 @@ unsafe extern "C" fn celt_decode_lost(
                     .wrapping_add(
                         (0 as libc::c_int as libc::c_long
                             * decode_mem[c as usize]
-                                .wrapping_offset_from(decode_mem[c as usize].offset(N as isize))
+                                .offset_from(decode_mem[c as usize].offset(N as isize))
                                 as libc::c_long) as libc::c_ulong,
                     ),
             );
@@ -1066,7 +1066,7 @@ unsafe extern "C" fn celt_decode_lost(
                     .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_sig>() as libc::c_ulong)
                     .wrapping_add(
                         (0 as libc::c_int as libc::c_long
-                            * buf.wrapping_offset_from(buf.offset(N as isize)) as libc::c_long)
+                            * buf.offset_from(buf.offset(N as isize)) as libc::c_long)
                             as libc::c_ulong,
                     ),
             );
@@ -1667,7 +1667,7 @@ pub unsafe extern "C" fn celt_decode_with_ec(
                 .wrapping_add(
                     (0 as libc::c_int as libc::c_long
                         * decode_mem[c as usize]
-                            .wrapping_offset_from(decode_mem[c as usize].offset(N as isize))
+                            .offset_from(decode_mem[c as usize].offset(N as isize))
                             as libc::c_long) as libc::c_ulong,
                 ),
         );
@@ -1844,7 +1844,7 @@ pub unsafe extern "C" fn celt_decode_with_ec(
                     (0 as libc::c_int as libc::c_long
                         * (&mut *oldBandE.offset(nbEBands as isize)
                             as *mut crate::arch_h::opus_val16)
-                            .wrapping_offset_from(oldBandE)
+                            .offset_from(oldBandE)
                             as libc::c_long) as libc::c_ulong,
                 ),
         );
@@ -1859,7 +1859,7 @@ pub unsafe extern "C" fn celt_decode_with_ec(
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
                     (0 as libc::c_int as libc::c_long
-                        * oldLogE2.wrapping_offset_from(oldLogE) as libc::c_long)
+                        * oldLogE2.offset_from(oldLogE) as libc::c_long)
                         as libc::c_ulong,
                 ),
         );
@@ -1870,7 +1870,7 @@ pub unsafe extern "C" fn celt_decode_with_ec(
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
                     (0 as libc::c_int as libc::c_long
-                        * oldLogE.wrapping_offset_from(oldBandE) as libc::c_long)
+                        * oldLogE.offset_from(oldBandE) as libc::c_long)
                         as libc::c_ulong,
                 ),
         );
@@ -2042,7 +2042,7 @@ pub unsafe extern "C" fn opus_custom_decoder_ctl(
                 0 as libc::c_int,
                 ((opus_custom_decoder_get_size((*st).mode, (*st).channels) as libc::c_long
                     - (&mut (*st).rng as *mut crate::opus_types_h::opus_uint32 as *mut libc::c_char)
-                        .wrapping_offset_from(st as *mut libc::c_char)
+                        .offset_from(st as *mut libc::c_char)
                         as libc::c_long) as libc::c_ulong)
                     .wrapping_mul(::std::mem::size_of::<libc::c_char>() as libc::c_ulong),
             );

--- a/quake3-rs/ioquake3/src/opus_1_2_1/celt/celt_encoder.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/celt/celt_encoder.rs
@@ -1123,7 +1123,7 @@ unsafe extern "C" fn tf_analysis(
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_norm>() as libc::c_ulong)
                 .wrapping_add(
                     (0 as libc::c_int as libc::c_long
-                        * tmp.wrapping_offset_from(&mut *X.offset(
+                        * tmp.offset_from(&mut *X.offset(
                             (tf_chan * N0
                                 + ((*(*m).eBands.offset(i as isize) as libc::c_int) << LM))
                                 as isize,
@@ -1152,7 +1152,7 @@ unsafe extern "C" fn tf_analysis(
                                                                                          as
                                                                                          libc::c_long
                                                                                          *
-                                                                                         tmp_1.wrapping_offset_from(tmp)
+                                                                                         tmp_1.offset_from(tmp)
                                                                                              as
                                                                                              libc::c_long)
                                                                                         as
@@ -2072,7 +2072,7 @@ unsafe extern "C" fn run_prefilter(
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_sig>() as libc::c_ulong)
                 .wrapping_add(
                     (0 as libc::c_int as libc::c_long
-                        * pre[c as usize].wrapping_offset_from(
+                        * pre[c as usize].offset_from(
                             prefilter_mem.offset((c * 1024 as libc::c_int) as isize),
                         ) as libc::c_long) as libc::c_ulong,
                 ),
@@ -2087,7 +2087,7 @@ unsafe extern "C" fn run_prefilter(
                     (0 as libc::c_int as libc::c_long
                         * pre[c as usize]
                             .offset(1024 as libc::c_int as isize)
-                            .wrapping_offset_from(
+                            .offset_from(
                                 in_0.offset((c * (N + overlap)) as isize)
                                     .offset(overlap as isize),
                             ) as libc::c_long) as libc::c_ulong,
@@ -2228,7 +2228,7 @@ unsafe extern "C" fn run_prefilter(
                     (0 as libc::c_int as libc::c_long
                         * in_0
                             .offset((c * (N + overlap)) as isize)
-                            .wrapping_offset_from(
+                            .offset_from(
                                 (*st).in_mem.as_mut_ptr().offset((c * overlap) as isize),
                             ) as libc::c_long) as libc::c_ulong,
                 ),
@@ -2279,7 +2279,7 @@ unsafe extern "C" fn run_prefilter(
                             .in_mem
                             .as_mut_ptr()
                             .offset((c * overlap) as isize)
-                            .wrapping_offset_from(
+                            .offset_from(
                                 in_0.offset((c * (N + overlap)) as isize).offset(N as isize),
                             ) as libc::c_long) as libc::c_ulong,
                 ),
@@ -2294,7 +2294,7 @@ unsafe extern "C" fn run_prefilter(
                         (0 as libc::c_int as libc::c_long
                             * prefilter_mem
                                 .offset((c * 1024 as libc::c_int) as isize)
-                                .wrapping_offset_from(pre[c as usize].offset(N as isize))
+                                .offset_from(pre[c as usize].offset(N as isize))
                                 as libc::c_long) as libc::c_ulong,
                     ),
             );
@@ -2310,7 +2310,7 @@ unsafe extern "C" fn run_prefilter(
                         (0 as libc::c_int as libc::c_long
                             * prefilter_mem
                                 .offset((c * 1024 as libc::c_int) as isize)
-                                .wrapping_offset_from(
+                                .offset_from(
                                     prefilter_mem
                                         .offset((c * 1024 as libc::c_int) as isize)
                                         .offset(N as isize),
@@ -2331,7 +2331,7 @@ unsafe extern "C" fn run_prefilter(
                                 .offset((c * 1024 as libc::c_int) as isize)
                                 .offset(1024 as libc::c_int as isize)
                                 .offset(-(N as isize))
-                                .wrapping_offset_from(
+                                .offset_from(
                                     pre[c as usize].offset(1024 as libc::c_int as isize),
                                 ) as libc::c_long) as libc::c_ulong,
                     ),
@@ -3283,7 +3283,7 @@ pub unsafe extern "C" fn celt_encode_with_ec(
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
                     (0 as libc::c_int as libc::c_long
-                        * bandLogE2.wrapping_offset_from(bandLogE) as libc::c_long)
+                        * bandLogE2.offset_from(bandLogE) as libc::c_long)
                         as libc::c_ulong,
                 ),
         );
@@ -4128,7 +4128,7 @@ pub unsafe extern "C" fn celt_encode_with_ec(
                     (0 as libc::c_int as libc::c_long
                         * (&mut *oldBandE.offset(nbEBands as isize)
                             as *mut crate::arch_h::opus_val16)
-                            .wrapping_offset_from(oldBandE)
+                            .offset_from(oldBandE)
                             as libc::c_long) as libc::c_ulong,
                 ),
         );
@@ -4141,7 +4141,7 @@ pub unsafe extern "C" fn celt_encode_with_ec(
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
                     (0 as libc::c_int as libc::c_long
-                        * oldLogE2.wrapping_offset_from(oldLogE) as libc::c_long)
+                        * oldLogE2.offset_from(oldLogE) as libc::c_long)
                         as libc::c_ulong,
                 ),
         );
@@ -4152,7 +4152,7 @@ pub unsafe extern "C" fn celt_encode_with_ec(
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
                     (0 as libc::c_int as libc::c_long
-                        * oldLogE.wrapping_offset_from(oldBandE) as libc::c_long)
+                        * oldLogE.offset_from(oldBandE) as libc::c_long)
                         as libc::c_ulong,
                 ),
         );
@@ -4363,7 +4363,7 @@ pub unsafe extern "C" fn opus_custom_encoder_ctl(
                 0 as libc::c_int,
                 ((opus_custom_encoder_get_size((*st).mode, (*st).channels) as libc::c_long
                     - (&mut (*st).rng as *mut crate::opus_types_h::opus_uint32 as *mut libc::c_char)
-                        .wrapping_offset_from(st as *mut libc::c_char)
+                        .offset_from(st as *mut libc::c_char)
                         as libc::c_long) as libc::c_ulong)
                     .wrapping_mul(::std::mem::size_of::<libc::c_char>() as libc::c_ulong),
             );
@@ -4402,7 +4402,7 @@ pub unsafe extern "C" fn opus_custom_encoder_ctl(
                         .wrapping_add(
                             (0 as libc::c_int as libc::c_long
                                 * (&mut (*st).analysis as *mut crate::celt_h::AnalysisInfo)
-                                    .wrapping_offset_from(info)
+                                    .offset_from(info)
                                     as libc::c_long) as libc::c_ulong,
                         ),
                 );
@@ -4423,7 +4423,7 @@ pub unsafe extern "C" fn opus_custom_encoder_ctl(
                         .wrapping_add(
                             (0 as libc::c_int as libc::c_long
                                 * (&mut (*st).silk_info as *mut crate::celt_h::SILKInfo)
-                                    .wrapping_offset_from(info_0)
+                                    .offset_from(info_0)
                                     as libc::c_long) as libc::c_ulong,
                         ),
                 );

--- a/quake3-rs/ioquake3/src/opus_1_2_1/celt/entenc.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/celt/entenc.rs
@@ -419,7 +419,7 @@ pub unsafe extern "C" fn ec_enc_shrink(
                         .buf
                         .offset(_size as isize)
                         .offset(-((*_this).end_offs as isize))
-                        .wrapping_offset_from(
+                        .offset_from(
                             (*_this)
                                 .buf
                                 .offset((*_this).storage as isize)

--- a/quake3-rs/ioquake3/src/opus_1_2_1/celt/quant_bands.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/celt/quant_bands.rs
@@ -837,7 +837,7 @@ pub unsafe extern "C" fn quant_coarse_energy(
             .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
             .wrapping_add(
                 (0 as libc::c_int as libc::c_long
-                    * oldEBands_intra.wrapping_offset_from(oldEBands) as libc::c_long)
+                    * oldEBands_intra.offset_from(oldEBands) as libc::c_long)
                     as libc::c_ulong,
             ),
     );
@@ -908,7 +908,7 @@ pub unsafe extern "C" fn quant_coarse_energy(
                 .wrapping_mul(::std::mem::size_of::<libc::c_uchar>() as libc::c_ulong)
                 .wrapping_add(
                     (0 as libc::c_int as libc::c_long
-                        * intra_bits.wrapping_offset_from(intra_buf) as libc::c_long)
+                        * intra_bits.offset_from(intra_buf) as libc::c_long)
                         as libc::c_ulong,
                 ),
         );
@@ -948,7 +948,7 @@ pub unsafe extern "C" fn quant_coarse_energy(
                     .wrapping_mul(::std::mem::size_of::<libc::c_uchar>() as libc::c_ulong)
                     .wrapping_add(
                         (0 as libc::c_int as libc::c_long
-                            * intra_buf.wrapping_offset_from(intra_bits) as libc::c_long)
+                            * intra_buf.offset_from(intra_bits) as libc::c_long)
                             as libc::c_ulong,
                     ),
             );
@@ -961,7 +961,7 @@ pub unsafe extern "C" fn quant_coarse_energy(
                     )
                     .wrapping_add(
                         (0 as libc::c_int as libc::c_long
-                            * oldEBands.wrapping_offset_from(oldEBands_intra) as libc::c_long)
+                            * oldEBands.offset_from(oldEBands_intra) as libc::c_long)
                             as libc::c_ulong,
                     ),
             );
@@ -974,7 +974,7 @@ pub unsafe extern "C" fn quant_coarse_energy(
                     )
                     .wrapping_add(
                         (0 as libc::c_int as libc::c_long
-                            * error.wrapping_offset_from(error_intra) as libc::c_long)
+                            * error.offset_from(error_intra) as libc::c_long)
                             as libc::c_ulong,
                     ),
             );
@@ -988,7 +988,7 @@ pub unsafe extern "C" fn quant_coarse_energy(
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
                     (0 as libc::c_int as libc::c_long
-                        * oldEBands.wrapping_offset_from(oldEBands_intra) as libc::c_long)
+                        * oldEBands.offset_from(oldEBands_intra) as libc::c_long)
                         as libc::c_ulong,
                 ),
         );
@@ -999,7 +999,7 @@ pub unsafe extern "C" fn quant_coarse_energy(
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
                     (0 as libc::c_int as libc::c_long
-                        * error.wrapping_offset_from(error_intra) as libc::c_long)
+                        * error.offset_from(error_intra) as libc::c_long)
                         as libc::c_ulong,
                 ),
         );

--- a/quake3-rs/ioquake3/src/opus_1_2_1/silk/dec_API.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/silk/dec_API.rs
@@ -622,7 +622,7 @@ pub unsafe extern "C" fn silk_Decode(
                 )
                 .wrapping_add(
                     (0 as libc::c_int as libc::c_long
-                        * samplesOut1_tmp_storage2.wrapping_offset_from(samplesOut) as libc::c_long)
+                        * samplesOut1_tmp_storage2.offset_from(samplesOut) as libc::c_long)
                         as libc::c_ulong,
                 ),
         );

--- a/quake3-rs/ioquake3/src/opus_1_2_1/src/analysis.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/src/analysis.rs
@@ -752,7 +752,7 @@ unsafe extern "C" fn downmix_and_resample(
             (subframe as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val32>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as libc::c_int as libc::c_long * y.wrapping_offset_from(tmp) as libc::c_long)
+                    (0 as libc::c_int as libc::c_long * y.offset_from(tmp) as libc::c_long)
                         as libc::c_ulong,
                 ),
         );
@@ -816,7 +816,7 @@ pub unsafe extern "C" fn tonality_analysis_reset(
         (::std::mem::size_of::<crate::src::opus_1_2_1::src::analysis::TonalityAnalysisState>()
             as libc::c_ulong)
             .wrapping_sub(
-                start.wrapping_offset_from(tonal as *mut libc::c_char) as libc::c_long
+                start.offset_from(tonal as *mut libc::c_char) as libc::c_long
                     as libc::c_ulong,
             )
             .wrapping_mul(::std::mem::size_of::<libc::c_char>() as libc::c_ulong),
@@ -865,7 +865,7 @@ pub unsafe extern "C" fn tonality_get_info(
             .wrapping_add(
                 (0 as libc::c_int as libc::c_long
                     * info_out
-                        .wrapping_offset_from(&mut *(*tonal).info.as_mut_ptr().offset(pos as isize))
+                        .offset_from(&mut *(*tonal).info.as_mut_ptr().offset(pos as isize))
                         as libc::c_long) as libc::c_ulong,
             ),
     );
@@ -1118,7 +1118,7 @@ unsafe extern "C" fn tonality_analysis(
             .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val32>() as libc::c_ulong)
             .wrapping_add(
                 (0 as libc::c_int as libc::c_long
-                    * (*tonal).inmem.as_mut_ptr().wrapping_offset_from(
+                    * (*tonal).inmem.as_mut_ptr().offset_from(
                         (*tonal)
                             .inmem
                             .as_mut_ptr()

--- a/quake3-rs/ioquake3/src/opus_1_2_1/src/opus.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/src/opus.rs
@@ -490,7 +490,7 @@ pub unsafe extern "C" fn opus_packet_parse_impl(
             last_size as crate::opus_types_h::opus_int16
     }
     if !payload_offset.is_null() {
-        *payload_offset = data.wrapping_offset_from(data0) as libc::c_long as libc::c_int
+        *payload_offset = data.offset_from(data0) as libc::c_long as libc::c_int
     }
     i = 0 as libc::c_int;
     while i < count {
@@ -503,7 +503,7 @@ pub unsafe extern "C" fn opus_packet_parse_impl(
     }
     if !packet_offset.is_null() {
         *packet_offset = pad
-            + data.wrapping_offset_from(data0) as libc::c_long as crate::opus_types_h::opus_int32
+            + data.offset_from(data0) as libc::c_long as crate::opus_types_h::opus_int32
     }
     if !out_toc.is_null() {
         *out_toc = toc

--- a/quake3-rs/ioquake3/src/opus_1_2_1/src/opus_decoder.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/src/opus_decoder.rs
@@ -904,7 +904,7 @@ unsafe extern "C" fn opus_decode_frame(
             celt_dec,
             4031 as libc::c_int,
             (&mut redundant_rng as *mut crate::opus_types_h::opus_uint32).offset(
-                (&mut redundant_rng as *mut crate::opus_types_h::opus_uint32).wrapping_offset_from(
+                (&mut redundant_rng as *mut crate::opus_types_h::opus_uint32).offset_from(
                     &mut redundant_rng as *mut crate::opus_types_h::opus_uint32,
                 ) as libc::c_long as isize,
             ),
@@ -992,7 +992,7 @@ unsafe extern "C" fn opus_decode_frame(
         10015 as libc::c_int,
         (&mut celt_mode as *mut *const crate::src::opus_1_2_1::celt::modes::OpusCustomMode).offset(
             (&mut celt_mode as *mut *const crate::src::opus_1_2_1::celt::modes::OpusCustomMode)
-                .wrapping_offset_from(
+                .offset_from(
                     &mut celt_mode
                         as *mut *const crate::src::opus_1_2_1::celt::modes::OpusCustomMode,
                 ) as libc::c_long as isize,
@@ -1024,7 +1024,7 @@ unsafe extern "C" fn opus_decode_frame(
             celt_dec,
             4031 as libc::c_int,
             (&mut redundant_rng as *mut crate::opus_types_h::opus_uint32).offset(
-                (&mut redundant_rng as *mut crate::opus_types_h::opus_uint32).wrapping_offset_from(
+                (&mut redundant_rng as *mut crate::opus_types_h::opus_uint32).offset_from(
                     &mut redundant_rng as *mut crate::opus_types_h::opus_uint32,
                 ) as libc::c_long as isize,
             ),
@@ -1476,7 +1476,7 @@ pub unsafe extern "C" fn opus_decoder_ctl(
                 (::std::mem::size_of::<OpusDecoder>() as libc::c_ulong)
                     .wrapping_sub(
                         (&mut (*st).stream_channels as *mut libc::c_int as *mut libc::c_char)
-                            .wrapping_offset_from(st as *mut libc::c_char)
+                            .offset_from(st as *mut libc::c_char)
                             as libc::c_long as libc::c_ulong,
                     )
                     .wrapping_mul(::std::mem::size_of::<libc::c_char>() as libc::c_ulong),
@@ -1513,7 +1513,7 @@ pub unsafe extern "C" fn opus_decoder_ctl(
                         celt_dec,
                         4033 as libc::c_int,
                         value_2
-                            .offset(value_2.wrapping_offset_from(value_2) as libc::c_long as isize),
+                            .offset(value_2.offset_from(value_2) as libc::c_long as isize),
                     );
                 } else {
                     *value_2 = (*st).DecControl.prevPitchLag
@@ -1577,7 +1577,7 @@ pub unsafe extern "C" fn opus_decoder_ctl(
                 crate::src::opus_1_2_1::celt::celt_decoder::opus_custom_decoder_ctl(
                     celt_dec,
                     4047 as libc::c_int,
-                    value_7.offset(value_7.wrapping_offset_from(value_7) as libc::c_long as isize),
+                    value_7.offset(value_7.offset_from(value_7) as libc::c_long as isize),
                 );
                 current_block = 2116367355679836638;
             }

--- a/quake3-rs/ioquake3/src/opus_1_2_1/src/opus_encoder.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/src/opus_encoder.rs
@@ -1971,7 +1971,7 @@ pub unsafe extern "C" fn opus_encode_native(
         10015 as libc::c_int,
         (&mut celt_mode as *mut *const crate::src::opus_1_2_1::celt::modes::OpusCustomMode).offset(
             (&mut celt_mode as *mut *const crate::src::opus_1_2_1::celt::modes::OpusCustomMode)
-                .wrapping_offset_from(
+                .offset_from(
                     &mut celt_mode
                         as *mut *const crate::src::opus_1_2_1::celt::modes::OpusCustomMode,
                 ) as libc::c_long as isize,
@@ -2613,7 +2613,7 @@ pub unsafe extern "C" fn opus_encode_native(
             .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
             .wrapping_add(
                 (0 as libc::c_int as libc::c_long
-                    * pcm_buf.wrapping_offset_from(
+                    * pcm_buf.offset_from(
                         &mut *(*st).delay_buffer.as_mut_ptr().offset(
                             (((*st).encoder_buffer - total_buffer) * (*st).channels) as isize,
                         ),
@@ -3073,7 +3073,7 @@ pub unsafe extern "C" fn opus_encode_native(
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
                     (0 as libc::c_int as libc::c_long
-                        * tmp_prefill.wrapping_offset_from(
+                        * tmp_prefill.offset_from(
                             &mut *(*st).delay_buffer.as_mut_ptr().offset(
                                 (((*st).encoder_buffer
                                     - total_buffer
@@ -3097,7 +3097,7 @@ pub unsafe extern "C" fn opus_encode_native(
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
                     (0 as libc::c_int as libc::c_long
-                        * (*st).delay_buffer.as_mut_ptr().wrapping_offset_from(
+                        * (*st).delay_buffer.as_mut_ptr().offset_from(
                             &mut *(*st)
                                 .delay_buffer
                                 .as_mut_ptr()
@@ -3119,7 +3119,7 @@ pub unsafe extern "C" fn opus_encode_native(
                             ((*st).channels * ((*st).encoder_buffer - frame_size - total_buffer))
                                 as isize,
                         ) as *mut crate::arch_h::opus_val16)
-                            .wrapping_offset_from(&mut *pcm_buf.offset(0 as libc::c_int as isize))
+                            .offset_from(&mut *pcm_buf.offset(0 as libc::c_int as isize))
                             as libc::c_long) as libc::c_ulong,
                 ),
         );
@@ -3133,7 +3133,7 @@ pub unsafe extern "C" fn opus_encode_native(
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
                     (0 as libc::c_int as libc::c_long
-                        * (*st).delay_buffer.as_mut_ptr().wrapping_offset_from(
+                        * (*st).delay_buffer.as_mut_ptr().offset_from(
                             &mut *pcm_buf.offset(
                                 ((frame_size + total_buffer - (*st).encoder_buffer)
                                     * (*st).channels) as isize,
@@ -3290,7 +3290,7 @@ pub unsafe extern "C" fn opus_encode_native(
             celt_enc,
             10022 as libc::c_int,
             (&mut analysis_info as *mut crate::celt_h::AnalysisInfo).offset(
-                (&mut analysis_info as *mut crate::celt_h::AnalysisInfo).wrapping_offset_from(
+                (&mut analysis_info as *mut crate::celt_h::AnalysisInfo).offset_from(
                     &mut analysis_info as *mut crate::celt_h::AnalysisInfo
                         as *const crate::celt_h::AnalysisInfo,
                 ) as libc::c_long as isize,
@@ -3308,7 +3308,7 @@ pub unsafe extern "C" fn opus_encode_native(
             celt_enc,
             10028 as libc::c_int,
             (&mut info as *mut crate::celt_h::SILKInfo).offset(
-                (&mut info as *mut crate::celt_h::SILKInfo).wrapping_offset_from(
+                (&mut info as *mut crate::celt_h::SILKInfo).offset_from(
                     &mut info as *mut crate::celt_h::SILKInfo as *const crate::celt_h::SILKInfo,
                 ) as libc::c_long as isize,
             ),
@@ -3318,7 +3318,7 @@ pub unsafe extern "C" fn opus_encode_native(
             celt_enc,
             10028 as libc::c_int,
             (0 as *mut libc::c_void as *mut crate::celt_h::SILKInfo).offset(
-                (0 as *mut libc::c_void as *mut crate::celt_h::SILKInfo).wrapping_offset_from(
+                (0 as *mut libc::c_void as *mut crate::celt_h::SILKInfo).offset_from(
                     0 as *mut libc::c_void as *mut crate::celt_h::SILKInfo
                         as *const crate::celt_h::SILKInfo,
                 ) as libc::c_long as isize,
@@ -3359,7 +3359,7 @@ pub unsafe extern "C" fn opus_encode_native(
             celt_enc,
             4031 as libc::c_int,
             (&mut redundant_rng as *mut crate::opus_types_h::opus_uint32).offset(
-                (&mut redundant_rng as *mut crate::opus_types_h::opus_uint32).wrapping_offset_from(
+                (&mut redundant_rng as *mut crate::opus_types_h::opus_uint32).offset_from(
                     &mut redundant_rng as *mut crate::opus_types_h::opus_uint32,
                 ) as libc::c_long as isize,
             ),
@@ -3442,7 +3442,7 @@ pub unsafe extern "C" fn opus_encode_native(
                             (0 as libc::c_int as libc::c_long
                                 * data
                                     .offset(ret as isize)
-                                    .wrapping_offset_from(data.offset(nb_compr_bytes as isize))
+                                    .offset_from(data.offset(nb_compr_bytes as isize))
                                     as libc::c_long) as libc::c_ulong,
                         ),
                 );
@@ -3516,7 +3516,7 @@ pub unsafe extern "C" fn opus_encode_native(
             celt_enc,
             4031 as libc::c_int,
             (&mut redundant_rng as *mut crate::opus_types_h::opus_uint32).offset(
-                (&mut redundant_rng as *mut crate::opus_types_h::opus_uint32).wrapping_offset_from(
+                (&mut redundant_rng as *mut crate::opus_types_h::opus_uint32).offset_from(
                     &mut redundant_rng as *mut crate::opus_types_h::opus_uint32,
                 ) as libc::c_long as isize,
             ),
@@ -4244,7 +4244,7 @@ pub unsafe extern "C" fn opus_encoder_ctl(
                     celt_enc,
                     4047 as libc::c_int,
                     value_35
-                        .offset(value_35.wrapping_offset_from(value_35) as libc::c_long as isize),
+                        .offset(value_35.offset_from(value_35) as libc::c_long as isize),
                 );
                 current_block = 12032176231992402880;
             }
@@ -4291,7 +4291,7 @@ pub unsafe extern "C" fn opus_encoder_ctl(
                 start as *mut libc::c_void,
                 0 as libc::c_int,
                 (::std::mem::size_of::<OpusEncoder>() as libc::c_ulong)
-                    .wrapping_sub(start.wrapping_offset_from(st as *mut libc::c_char)
+                    .wrapping_sub(start.offset_from(st as *mut libc::c_char)
                         as libc::c_long as libc::c_ulong)
                     .wrapping_mul(::std::mem::size_of::<libc::c_char>() as libc::c_ulong),
             );
@@ -4347,7 +4347,7 @@ pub unsafe extern "C" fn opus_encoder_ctl(
             ret = crate::src::opus_1_2_1::celt::celt_encoder::opus_custom_encoder_ctl(
                 celt_enc,
                 10026 as libc::c_int,
-                value_38.offset(value_38.wrapping_offset_from(value_38) as libc::c_long as isize),
+                value_38.offset(value_38.offset_from(value_38) as libc::c_long as isize),
             );
             current_block = 12032176231992402880;
         }
@@ -4362,7 +4362,7 @@ pub unsafe extern "C" fn opus_encoder_ctl(
                     celt_enc,
                     10015 as libc::c_int,
                     value_39
-                        .offset(value_39.wrapping_offset_from(value_39) as libc::c_long as isize),
+                        .offset(value_39.offset_from(value_39) as libc::c_long as isize),
                 );
                 current_block = 12032176231992402880;
             }

--- a/quake3-rs/ioquake3/src/opus_1_2_1/src/opus_multistream_decoder.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/src/opus_multistream_decoder.rs
@@ -455,7 +455,7 @@ unsafe extern "C" fn opus_multistream_decode_native(
         4029 as libc::c_int,
         (&mut Fs as *mut crate::opus_types_h::opus_int32).offset(
             (&mut Fs as *mut crate::opus_types_h::opus_int32)
-                .wrapping_offset_from(&mut Fs as *mut crate::opus_types_h::opus_int32)
+                .offset_from(&mut Fs as *mut crate::opus_types_h::opus_int32)
                 as libc::c_long as isize,
         ),
     );

--- a/quake3-rs/ioquake3/src/opus_1_2_1/src/opus_multistream_encoder.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/src/opus_multistream_encoder.rs
@@ -699,7 +699,7 @@ pub unsafe extern "C" fn surround_analysis(
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val32>() as libc::c_ulong)
                 .wrapping_add(
                     (0 as libc::c_int as libc::c_long
-                        * in_0.wrapping_offset_from(mem.offset((c * overlap) as isize))
+                        * in_0.offset_from(mem.offset((c * overlap) as isize))
                             as libc::c_long) as libc::c_ulong,
                 ),
         );
@@ -858,7 +858,7 @@ pub unsafe extern "C" fn surround_analysis(
                     (0 as libc::c_int as libc::c_long
                         * mem
                             .offset((c * overlap) as isize)
-                            .wrapping_offset_from(in_0.offset(frame_size as isize))
+                            .offset_from(in_0.offset(frame_size as isize))
                             as libc::c_long) as libc::c_ulong,
                 ),
         );
@@ -1426,7 +1426,7 @@ unsafe extern "C" fn rate_allocation(
         4029 as libc::c_int,
         (&mut Fs as *mut crate::opus_types_h::opus_int32).offset(
             (&mut Fs as *mut crate::opus_types_h::opus_int32)
-                .wrapping_offset_from(&mut Fs as *mut crate::opus_types_h::opus_int32)
+                .offset_from(&mut Fs as *mut crate::opus_types_h::opus_int32)
                 as libc::c_long as isize,
         ),
     );
@@ -1494,7 +1494,7 @@ unsafe extern "C" fn opus_multistream_encode_native(
         4029 as libc::c_int,
         (&mut Fs as *mut crate::opus_types_h::opus_int32).offset(
             (&mut Fs as *mut crate::opus_types_h::opus_int32)
-                .wrapping_offset_from(&mut Fs as *mut crate::opus_types_h::opus_int32)
+                .offset_from(&mut Fs as *mut crate::opus_types_h::opus_int32)
                 as libc::c_long as isize,
         ),
     );
@@ -1503,7 +1503,7 @@ unsafe extern "C" fn opus_multistream_encode_native(
         4007 as libc::c_int,
         (&mut vbr as *mut crate::opus_types_h::opus_int32).offset(
             (&mut vbr as *mut crate::opus_types_h::opus_int32)
-                .wrapping_offset_from(&mut vbr as *mut crate::opus_types_h::opus_int32)
+                .offset_from(&mut vbr as *mut crate::opus_types_h::opus_int32)
                 as libc::c_long as isize,
         ),
     );
@@ -1512,7 +1512,7 @@ unsafe extern "C" fn opus_multistream_encode_native(
         10015 as libc::c_int,
         (&mut celt_mode as *mut *const crate::src::opus_1_2_1::celt::modes::OpusCustomMode).offset(
             (&mut celt_mode as *mut *const crate::src::opus_1_2_1::celt::modes::OpusCustomMode)
-                .wrapping_offset_from(
+                .offset_from(
                     &mut celt_mode
                         as *mut *const crate::src::opus_1_2_1::celt::modes::OpusCustomMode,
                 ) as libc::c_long as isize,
@@ -1776,7 +1776,7 @@ unsafe extern "C" fn opus_multistream_encode_native(
                 bandLogE.as_mut_ptr().offset(
                     bandLogE
                         .as_mut_ptr()
-                        .wrapping_offset_from(bandLogE.as_mut_ptr())
+                        .offset_from(bandLogE.as_mut_ptr())
                         as libc::c_long as isize,
                 ),
             );

--- a/quake3-rs/ioquake3/src/opus_1_2_1/src/repacketizer.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/src/repacketizer.rs
@@ -386,7 +386,7 @@ pub unsafe extern "C" fn opus_repacketizer_out_range_impl(
                 .wrapping_mul(::std::mem::size_of::<libc::c_uchar>() as libc::c_ulong)
                 .wrapping_add(
                     (0 as libc::c_int as libc::c_long
-                        * ptr.wrapping_offset_from(*frames.offset(i as isize)) as libc::c_long)
+                        * ptr.offset_from(*frames.offset(i as isize)) as libc::c_long)
                         as libc::c_ulong,
                 ),
         );
@@ -476,7 +476,7 @@ pub unsafe extern "C" fn opus_packet_pad(
                     * data
                         .offset(new_len as isize)
                         .offset(-(len as isize))
-                        .wrapping_offset_from(data) as libc::c_long)
+                        .offset_from(data) as libc::c_long)
                     as libc::c_ulong,
             ),
     );

--- a/quake3-rs/ioquake3/src/opusfile_0_9/src/http.rs
+++ b/quake3-rs/ioquake3/src/opusfile_0_9/src/http.rs
@@ -57,7 +57,7 @@ unsafe extern "C" fn op_string_range_dup(
 ) -> *mut libc::c_char {
     let mut len: crate::stddef_h::size_t = 0;
     let mut ret: *mut libc::c_char = 0 as *mut libc::c_char;
-    len = _end.wrapping_offset_from(_start) as libc::c_long as crate::stddef_h::size_t;
+    len = _end.offset_from(_start) as libc::c_long as crate::stddef_h::size_t;
     /*This is to help avoid overflow elsewhere, later.*/
     if (len >= 2147483647 as libc::c_int as libc::c_ulong) as libc::c_int as libc::c_long != 0 {
         return 0 as *mut libc::c_char;
@@ -188,7 +188,7 @@ unsafe extern "C" fn op_parse_file_url(mut _src: *const libc::c_char) -> *const 
             as *const libc::c_char,
     ) as isize);
     if (*scheme_end as libc::c_int != ':' as i32) as libc::c_int as libc::c_long != 0
-        || scheme_end.wrapping_offset_from(_src) as libc::c_long != 4 as libc::c_int as libc::c_long
+        || scheme_end.offset_from(_src) as libc::c_long != 4 as libc::c_int as libc::c_long
         || crate::src::opusfile_0_9::src::internal::op_strncasecmp(
             _src,
             b"file\x00" as *const u8 as *const libc::c_char,
@@ -235,7 +235,7 @@ unsafe extern "C" fn op_parse_file_url(mut _src: *const libc::c_char) -> *const 
                 return 0 as *const libc::c_char;
             }
             /*An escaped "localhost" can take at most 27 characters.*/
-            if (host_end.wrapping_offset_from(host) as libc::c_long
+            if (host_end.offset_from(host) as libc::c_long
                 > 27 as libc::c_int as libc::c_long) as libc::c_int as libc::c_long
                 != 0
             {
@@ -245,10 +245,10 @@ unsafe extern "C" fn op_parse_file_url(mut _src: *const libc::c_char) -> *const 
                 host_buf.as_mut_ptr() as *mut libc::c_void,
                 host as *const libc::c_void,
                 (::std::mem::size_of::<libc::c_char>() as libc::c_ulong).wrapping_mul(
-                    host_end.wrapping_offset_from(host) as libc::c_long as libc::c_ulong,
+                    host_end.offset_from(host) as libc::c_long as libc::c_ulong,
                 ),
             );
-            host_buf[host_end.wrapping_offset_from(host) as libc::c_long as usize] =
+            host_buf[host_end.offset_from(host) as libc::c_long as usize] =
                 '\u{0}' as i32 as libc::c_char;
             op_unescape_url_component(host_buf.as_mut_ptr());
             op_string_tolower(host_buf.as_mut_ptr());
@@ -384,7 +384,7 @@ unsafe extern "C" fn op_url_stream_vcreate_impl(
         request = _ap
             .as_va_list()
             .arg::<*mut libc::c_char>()
-            .wrapping_offset_from(0 as *mut libc::c_void as *mut libc::c_char)
+            .offset_from(0 as *mut libc::c_void as *mut libc::c_char)
             as libc::c_long;
         /*If we hit NULL, we're done processing options.*/
         if request == 0 {

--- a/quake3-rs/ioquake3/src/opusfile_0_9/src/info.rs
+++ b/quake3-rs/ioquake3/src/opusfile_0_9/src/info.rs
@@ -169,7 +169,7 @@ pub unsafe extern "C" fn opus_head_parse(
             _head as *mut libc::c_void,
             &mut head as *mut crate::src::opusfile_0_9::src::opusfile::OpusHead
                 as *const libc::c_void,
-            head.mapping.as_mut_ptr().wrapping_offset_from(
+            head.mapping.as_mut_ptr().offset_from(
                 &mut head as *mut crate::src::opusfile_0_9::src::opusfile::OpusHead
                     as *mut libc::c_uchar,
             ) as libc::c_long as libc::c_ulong,

--- a/quake3-rs/ioquake3/src/qcommon/cm_load.rs
+++ b/quake3-rs/ioquake3/src/qcommon/cm_load.rs
@@ -283,7 +283,7 @@ pub unsafe extern "C" fn CMod_LoadSubmodels(mut l: *mut crate::qfiles_h::lump_t)
                 crate::src::qcommon::q_shared::h_high,
             ) as *mut libc::c_int;
             (*out).leaf.firstLeafBrush =
-                indexes.wrapping_offset_from(cm.leafbrushes) as libc::c_long as libc::c_int;
+                indexes.offset_from(cm.leafbrushes) as libc::c_long as libc::c_int;
             j = 0 as libc::c_int;
             while j < (*out).leaf.numLeafBrushes {
                 *indexes.offset(j as isize) = (*in_0).firstBrush + j;
@@ -295,7 +295,7 @@ pub unsafe extern "C" fn CMod_LoadSubmodels(mut l: *mut crate::qfiles_h::lump_t)
                 crate::src::qcommon::q_shared::h_high,
             ) as *mut libc::c_int;
             (*out).leaf.firstLeafSurface =
-                indexes.wrapping_offset_from(cm.leafsurfaces) as libc::c_long as libc::c_int;
+                indexes.offset_from(cm.leafsurfaces) as libc::c_long as libc::c_int;
             j = 0 as libc::c_int;
             while j < (*out).leaf.numLeafSurfaces {
                 *indexes.offset(j as isize) = (*in_0).firstSurface + j;

--- a/quake3-rs/ioquake3/src/qcommon/common.rs
+++ b/quake3-rs/ioquake3/src/qcommon/common.rs
@@ -1099,7 +1099,7 @@ pub unsafe extern "C" fn Info_Print(mut s: *const libc::c_char) {
             o = o.offset(1);
             *fresh1 = *fresh0
         }
-        l = o.wrapping_offset_from(key.as_mut_ptr()) as libc::c_long as libc::c_int;
+        l = o.offset_from(key.as_mut_ptr()) as libc::c_long as libc::c_int;
         if l < 20 as libc::c_int {
             crate::stdlib::memset(
                 o as *mut libc::c_void,
@@ -4191,7 +4191,7 @@ pub unsafe extern "C" fn Com_ReadFromPipe() {
             );
             *brk = tmp;
             accu = (accu as libc::c_long
-                - brk.wrapping_offset_from(buf.as_mut_ptr()) as libc::c_long)
+                - brk.offset_from(buf.as_mut_ptr()) as libc::c_long)
                 as libc::c_int;
             crate::stdlib::memmove(
                 buf.as_mut_ptr() as *mut libc::c_void,

--- a/quake3-rs/ioquake3/src/qcommon/cvar.rs
+++ b/quake3-rs/ioquake3/src/qcommon/cvar.rs
@@ -1872,7 +1872,7 @@ pub unsafe extern "C" fn Cvar_Register(
     if vmCvar.is_null() {
         return;
     }
-    (*vmCvar).handle = cv.wrapping_offset_from(cvar_indexes.as_mut_ptr()) as libc::c_long
+    (*vmCvar).handle = cv.offset_from(cvar_indexes.as_mut_ptr()) as libc::c_long
         as crate::src::qcommon::q_shared::cvarHandle_t;
     (*vmCvar).modificationCount = -(1 as libc::c_int);
     Cvar_Update(vmCvar);

--- a/quake3-rs/ioquake3/src/qcommon/files.rs
+++ b/quake3-rs/ioquake3/src/qcommon/files.rs
@@ -4253,7 +4253,7 @@ pub unsafe extern "C" fn FS_ComparePaks(
                         // Find out whether it might have overflowed the buffer and don't add this file to the
                         // list if that is the case.
                         if crate::stdlib::strlen(origpos)
-                            .wrapping_add(origpos.wrapping_offset_from(neededpaks) as libc::c_long
+                            .wrapping_add(origpos.offset_from(neededpaks) as libc::c_long
                                 as libc::c_ulong)
                             >= (len - 1 as libc::c_int) as libc::c_ulong
                         {

--- a/quake3-rs/ioquake3/src/qcommon/q_shared.rs
+++ b/quake3-rs/ioquake3/src/qcommon/q_shared.rs
@@ -590,11 +590,11 @@ pub unsafe extern "C" fn COM_StripExtension(
         (slash.is_null()) || slash < dot
     } {
         destsize = if (destsize as libc::c_long)
-            < dot.wrapping_offset_from(in_0) as libc::c_long + 1 as libc::c_int as libc::c_long
+            < dot.offset_from(in_0) as libc::c_long + 1 as libc::c_int as libc::c_long
         {
             destsize as libc::c_long
         } else {
-            (dot.wrapping_offset_from(in_0) as libc::c_long) + 1 as libc::c_int as libc::c_long
+            (dot.offset_from(in_0) as libc::c_long) + 1 as libc::c_int as libc::c_long
         } as libc::c_int
     }
     if in_0 == out as *const libc::c_char && destsize > 1 as libc::c_int {
@@ -1061,7 +1061,7 @@ pub unsafe extern "C" fn COM_Compress(mut data_p: *mut libc::c_char) -> libc::c_
         }
         *out = 0 as libc::c_int as libc::c_char
     }
-    return out.wrapping_offset_from(data_p) as libc::c_long as libc::c_int;
+    return out.offset_from(data_p) as libc::c_long as libc::c_int;
 }
 #[no_mangle]
 

--- a/quake3-rs/ioquake3/src/qcommon/vm.rs
+++ b/quake3-rs/ioquake3/src/qcommon/vm.rs
@@ -1424,7 +1424,7 @@ pub unsafe extern "C" fn VM_LogSyscalls(mut args: *mut libc::c_int) {
         f,
         b"%i: %p (%i) = %i %i %i %i\n\x00" as *const u8 as *const libc::c_char,
         callnum,
-        args.wrapping_offset_from((*currentVM).dataBase as *mut libc::c_int) as libc::c_long
+        args.offset_from((*currentVM).dataBase as *mut libc::c_int) as libc::c_long
             as *mut libc::c_void,
         *args.offset(0 as libc::c_int as isize),
         *args.offset(1 as libc::c_int as isize),

--- a/quake3-rs/ioquake3/src/server/sv_client.rs
+++ b/quake3-rs/ioquake3/src/server/sv_client.rs
@@ -1166,7 +1166,7 @@ pub unsafe extern "C" fn SV_DirectConnect(mut from: crate::qcommon_h::netadr_t) 
     // accept the new client
     // this is the only place a client_t is ever initialized
     *newcl = temp;
-    clientNum = newcl.wrapping_offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
+    clientNum = newcl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
         as libc::c_int;
     ent = crate::src::server::sv_game::SV_GentityNum(clientNum)
         as *mut crate::g_public_h::sharedEntity_t;
@@ -1351,7 +1351,7 @@ pub unsafe extern "C" fn SV_DropClient(
     crate::src::qcommon::vm::VM_Call(
         crate::src::server::sv_main::gvm,
         crate::g_public_h::GAME_CLIENT_DISCONNECT as libc::c_int,
-        drop_0.wrapping_offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long,
+        drop_0.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long,
     );
     // add the disconnect command
     crate::src::server::sv_main::SV_SendServerCommand(
@@ -1361,7 +1361,7 @@ pub unsafe extern "C" fn SV_DropClient(
     );
     if isBot as u64 != 0 {
         crate::src::server::sv_bot::SV_BotFreeClient(
-            drop_0.wrapping_offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
+            drop_0.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
                 as libc::c_int,
         );
         // bots shouldn't go zombie, as there's no real net connection.
@@ -1376,7 +1376,7 @@ pub unsafe extern "C" fn SV_DropClient(
     }
     // nuke user info
     crate::src::server::sv_init::SV_SetUserinfo(
-        drop_0.wrapping_offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
+        drop_0.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
             as libc::c_int,
         b"\x00" as *const u8 as *const libc::c_char,
     );
@@ -1566,7 +1566,7 @@ unsafe extern "C" fn SV_SendClientGameState(mut client: *mut crate::server_h::cl
     );
     crate::src::qcommon::msg::MSG_WriteLong(
         &mut msg as *mut _ as *mut crate::qcommon_h::msg_t,
-        client.wrapping_offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
+        client.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
             as libc::c_int,
     );
     // write the checksum feed
@@ -1603,7 +1603,7 @@ pub unsafe extern "C" fn SV_ClientEnterWorld(
     // no longer sent when the client is CS_PRIMED
     crate::src::server::sv_init::SV_UpdateConfigstrings(client as *mut crate::server_h::client_s);
     // set up the entity for the client
-    clientNum = client.wrapping_offset_from(crate::src::server::sv_main::svs.clients)
+    clientNum = client.offset_from(crate::src::server::sv_main::svs.clients)
         as libc::c_long as libc::c_int; // generate a snapshot immediately
     ent = crate::src::server::sv_game::SV_GentityNum(clientNum)
         as *mut crate::g_public_h::sharedEntity_t;
@@ -1630,7 +1630,7 @@ pub unsafe extern "C" fn SV_ClientEnterWorld(
     crate::src::qcommon::vm::VM_Call(
         crate::src::server::sv_main::gvm,
         crate::g_public_h::GAME_CLIENT_BEGIN as libc::c_int,
-        client.wrapping_offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long,
+        client.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long,
     );
 }
 /*
@@ -1702,7 +1702,7 @@ unsafe extern "C" fn SV_StopDownload_f(mut cl: *mut crate::server_h::client_t) {
     if *(*cl).downloadName.as_mut_ptr() != 0 {
         crate::src::qcommon::common::Com_DPrintf(
             b"clientDownload: %d : file \"%s\" aborted\n\x00" as *const u8 as *const libc::c_char,
-            cl.wrapping_offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
+            cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
                 as libc::c_int,
             (*cl).downloadName.as_mut_ptr(),
         );
@@ -1743,7 +1743,7 @@ unsafe extern "C" fn SV_NextDownload_f(mut cl: *mut crate::server_h::client_t) {
         crate::src::qcommon::common::Com_DPrintf(
             b"clientDownload: %d : client acknowledge of block %d\n\x00" as *const u8
                 as *const libc::c_char,
-            cl.wrapping_offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
+            cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
                 as libc::c_int,
             block,
         );
@@ -1754,7 +1754,7 @@ unsafe extern "C" fn SV_NextDownload_f(mut cl: *mut crate::server_h::client_t) {
             crate::src::qcommon::common::Com_Printf(
                 b"clientDownload: %d : file \"%s\" completed\n\x00" as *const u8
                     as *const libc::c_char,
-                cl.wrapping_offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
+                cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
                     as libc::c_int,
                 (*cl).downloadName.as_mut_ptr(),
             );
@@ -1893,7 +1893,7 @@ pub unsafe extern "C" fn SV_WriteDownloadToClient(
                 crate::src::qcommon::common::Com_Printf(
                     b"clientDownload: %d : \"%s\" is not referenced and cannot be downloaded.\n\x00"
                         as *const u8 as *const libc::c_char,
-                    cl.wrapping_offset_from(crate::src::server::sv_main::svs.clients)
+                    cl.offset_from(crate::src::server::sv_main::svs.clients)
                         as libc::c_long as libc::c_int,
                     (*cl).downloadName.as_mut_ptr(),
                 );
@@ -1908,7 +1908,7 @@ pub unsafe extern "C" fn SV_WriteDownloadToClient(
                 crate::src::qcommon::common::Com_Printf(
                     b"clientDownload: %d : \"%s\" cannot download id pk3 files\n\x00" as *const u8
                         as *const libc::c_char,
-                    cl.wrapping_offset_from(crate::src::server::sv_main::svs.clients)
+                    cl.offset_from(crate::src::server::sv_main::svs.clients)
                         as libc::c_long as libc::c_int,
                     (*cl).downloadName.as_mut_ptr(),
                 );
@@ -1936,7 +1936,7 @@ pub unsafe extern "C" fn SV_WriteDownloadToClient(
                 crate::src::qcommon::common::Com_Printf(
                     b"clientDownload: %d : \"%s\" download disabled\n\x00" as *const u8
                         as *const libc::c_char,
-                    cl.wrapping_offset_from(crate::src::server::sv_main::svs.clients)
+                    cl.offset_from(crate::src::server::sv_main::svs.clients)
                         as libc::c_long as libc::c_int,
                     (*cl).downloadName.as_mut_ptr(),
                 );
@@ -1961,7 +1961,7 @@ pub unsafe extern "C" fn SV_WriteDownloadToClient(
                 crate::src::qcommon::common::Com_Printf(
                     b"clientDownload: %d : \"%s\" file not found on server\n\x00" as *const u8
                         as *const libc::c_char,
-                    cl.wrapping_offset_from(crate::src::server::sv_main::svs.clients)
+                    cl.offset_from(crate::src::server::sv_main::svs.clients)
                         as libc::c_long as libc::c_int,
                     (*cl).downloadName.as_mut_ptr(),
                 ); // client is expecting block zero
@@ -1997,7 +1997,7 @@ pub unsafe extern "C" fn SV_WriteDownloadToClient(
         }
         crate::src::qcommon::common::Com_Printf(
             b"clientDownload: %d : beginning \"%s\"\n\x00" as *const u8 as *const libc::c_char,
-            cl.wrapping_offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
+            cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
                 as libc::c_int,
             (*cl).downloadName.as_mut_ptr(),
         );
@@ -2087,7 +2087,7 @@ pub unsafe extern "C" fn SV_WriteDownloadToClient(
     }
     crate::src::qcommon::common::Com_DPrintf(
         b"clientDownload: %d : writing block %d\n\x00" as *const u8 as *const libc::c_char,
-        cl.wrapping_offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
+        cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
             as libc::c_int,
         (*cl).downloadXmitBlock,
     );
@@ -2579,7 +2579,7 @@ unsafe extern "C" fn SV_UpdateUserinfo_f(mut cl: *mut crate::server_h::client_t)
     crate::src::qcommon::vm::VM_Call(
         crate::src::server::sv_main::gvm,
         crate::g_public_h::GAME_CLIENT_USERINFO_CHANGED as libc::c_int,
-        cl.wrapping_offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long,
+        cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long,
     );
 }
 
@@ -2775,7 +2775,7 @@ pub unsafe extern "C" fn SV_ExecuteClientCommand(
             crate::src::qcommon::vm::VM_Call(
                 crate::src::server::sv_main::gvm,
                 crate::g_public_h::GAME_CLIENT_COMMAND as libc::c_int,
-                cl.wrapping_offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long,
+                cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long,
             );
         }
     } else if bProcessed as u64 == 0 {
@@ -2876,7 +2876,7 @@ pub unsafe extern "C" fn SV_ClientThink(
     crate::src::qcommon::vm::VM_Call(
         crate::src::server::sv_main::gvm,
         crate::g_public_h::GAME_CLIENT_THINK as libc::c_int,
-        cl.wrapping_offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long,
+        cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long,
     );
 }
 /*
@@ -3081,7 +3081,7 @@ unsafe extern "C" fn SV_UserVoip(
     let mut packet: *mut crate::server_h::voipServerPacket_t =
         0 as *mut crate::server_h::voipServerPacket_t;
     let mut i: libc::c_int = 0;
-    sender = cl.wrapping_offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
+    sender = cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
         as libc::c_int;
     generation = crate::src::qcommon::msg::MSG_ReadByte(msg as *mut crate::qcommon_h::msg_t);
     sequence = crate::src::qcommon::msg::MSG_ReadLong(msg as *mut crate::qcommon_h::msg_t);
@@ -3491,7 +3491,7 @@ pub unsafe extern "C" fn SV_ExecuteClientMessage(
     } else if c != crate::qcommon_h::clc_EOF as libc::c_int {
         crate::src::qcommon::common::Com_Printf(
             b"WARNING: bad command byte for client %i\n\x00" as *const u8 as *const libc::c_char,
-            cl.wrapping_offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
+            cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
                 as libc::c_int,
         );
     };

--- a/quake3-rs/ioquake3/src/server/sv_game.rs
+++ b/quake3-rs/ioquake3/src/server/sv_game.rs
@@ -449,7 +449,7 @@ pub unsafe extern "C" fn SV_NumForGentity(
     mut ent: *mut crate::g_public_h::sharedEntity_t,
 ) -> libc::c_int {
     let mut num: libc::c_int = 0;
-    num = ((ent as *mut crate::src::qcommon::q_shared::byte).wrapping_offset_from(
+    num = ((ent as *mut crate::src::qcommon::q_shared::byte).offset_from(
         crate::src::server::sv_main::sv.gentities as *mut crate::src::qcommon::q_shared::byte,
     ) as libc::c_long
         / crate::src::server::sv_main::sv.gentitySize as libc::c_long) as libc::c_int;
@@ -504,7 +504,7 @@ pub unsafe extern "C" fn SV_GEntityForSvEntity(
     mut svEnt: *mut crate::server_h::svEntity_t,
 ) -> *mut crate::g_public_h::sharedEntity_t {
     let mut num: libc::c_int = 0;
-    num = svEnt.wrapping_offset_from(crate::src::server::sv_main::sv.svEntities.as_mut_ptr())
+    num = svEnt.offset_from(crate::src::server::sv_main::sv.svEntities.as_mut_ptr())
         as libc::c_long as libc::c_int;
     return SV_GentityNum(num);
 }

--- a/quake3-rs/ioquake3/src/server/sv_snapshot.rs
+++ b/quake3-rs/ioquake3/src/server/sv_snapshot.rs
@@ -895,7 +895,7 @@ unsafe extern "C" fn SV_BuildClientSnapshot(mut client: *mut crate::server_h::cl
     }
     // grab the current playerState_t
     ps = crate::src::server::sv_game::SV_GameClientNum(
-        client.wrapping_offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
+        client.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long
             as libc::c_int,
     ) as *mut crate::src::qcommon::q_shared::playerState_s;
     (*frame).ps = *ps;

--- a/quake3-rs/ioquake3/src/server/sv_world.rs
+++ b/quake3-rs/ioquake3/src/server/sv_world.rs
@@ -538,7 +538,7 @@ unsafe extern "C" fn SV_AreaEntities_r(mut node: *mut worldSector_t, mut ap: *mu
                 return;
             }
             *(*ap).list.offset((*ap).count as isize) =
-                check.wrapping_offset_from(crate::src::server::sv_main::sv.svEntities.as_mut_ptr())
+                check.offset_from(crate::src::server::sv_main::sv.svEntities.as_mut_ptr())
                     as libc::c_long as libc::c_int;
             (*ap).count += 1
         }

--- a/quake3-rs/ioquake3/src/sys/sys_unix.rs
+++ b/quake3-rs/ioquake3/src/sys/sys_unix.rs
@@ -13313,7 +13313,7 @@ Sys_AppendToExecBuffer
 unsafe extern "C" fn Sys_AppendToExecBuffer(mut text: *const libc::c_char) {
     let mut size: crate::stddef_h::size_t =
         (::std::mem::size_of::<[libc::c_char; 1024]>() as libc::c_ulong).wrapping_sub(
-            execBufferPointer.wrapping_offset_from(execBuffer.as_mut_ptr()) as libc::c_long
+            execBufferPointer.offset_from(execBuffer.as_mut_ptr()) as libc::c_long
                 as libc::c_ulong,
         );
     let mut length: libc::c_int =

--- a/quake3-rs/ioquake3/src/zlib/inffast.rs
+++ b/quake3-rs/ioquake3/src/zlib/inffast.rs
@@ -248,7 +248,7 @@ pub unsafe extern "C" fn inflate_fast(mut strm: crate::zlib_h::z_streamp, mut st
                         );
                         hold >>= op;
                         bits = bits.wrapping_sub(op);
-                        op = out.wrapping_offset_from(beg) as libc::c_long as libc::c_uint;
+                        op = out.offset_from(beg) as libc::c_long as libc::c_uint;
                         if dist > op {
                             current_block_141 = 5873035170358615968;
                             break;
@@ -442,14 +442,14 @@ pub unsafe extern "C" fn inflate_fast(mut strm: crate::zlib_h::z_streamp, mut st
     (*strm).next_in = in_0.offset(1 as libc::c_int as isize);
     (*strm).next_out = out.offset(1 as libc::c_int as isize);
     (*strm).avail_in = if in_0 < last {
-        (5 as libc::c_int as libc::c_long) + last.wrapping_offset_from(in_0) as libc::c_long
+        (5 as libc::c_int as libc::c_long) + last.offset_from(in_0) as libc::c_long
     } else {
-        (5 as libc::c_int as libc::c_long) - in_0.wrapping_offset_from(last) as libc::c_long
+        (5 as libc::c_int as libc::c_long) - in_0.offset_from(last) as libc::c_long
     } as libc::c_uint;
     (*strm).avail_out = if out < end {
-        (257 as libc::c_int as libc::c_long) + end.wrapping_offset_from(out) as libc::c_long
+        (257 as libc::c_int as libc::c_long) + end.offset_from(out) as libc::c_long
     } else {
-        (257 as libc::c_int as libc::c_long) - out.wrapping_offset_from(end) as libc::c_long
+        (257 as libc::c_int as libc::c_long) - out.offset_from(end) as libc::c_long
     } as libc::c_uint;
     (*state).hold = hold;
     (*state).bits = bits;

--- a/quake3-rs/ioquake3/src/zlib/inflate.rs
+++ b/quake3-rs/ioquake3/src/zlib/inflate.rs
@@ -6881,20 +6881,20 @@ pub unsafe extern "C" fn inflateCopy(
         (*copy).lencode = (*copy).codes.as_mut_ptr().offset(
             (*state)
                 .lencode
-                .wrapping_offset_from((*state).codes.as_mut_ptr()) as libc::c_long
+                .offset_from((*state).codes.as_mut_ptr()) as libc::c_long
                 as isize,
         );
         (*copy).distcode = (*copy).codes.as_mut_ptr().offset(
             (*state)
                 .distcode
-                .wrapping_offset_from((*state).codes.as_mut_ptr()) as libc::c_long
+                .offset_from((*state).codes.as_mut_ptr()) as libc::c_long
                 as isize,
         )
     }
     (*copy).next = (*copy).codes.as_mut_ptr().offset(
         (*state)
             .next
-            .wrapping_offset_from((*state).codes.as_mut_ptr()) as libc::c_long as isize,
+            .offset_from((*state).codes.as_mut_ptr()) as libc::c_long as isize,
     );
     if !window.is_null() {
         wsize = (1 as libc::c_uint) << (*state).wbits;

--- a/quake3-rs/ioquake3/src/zlib/inftrees.rs
+++ b/quake3-rs/ioquake3/src/zlib/inftrees.rs
@@ -475,7 +475,7 @@ pub unsafe extern "C" fn inflate_table(
             (*(*table).offset(low as isize)).op = curr as libc::c_uchar;
             (*(*table).offset(low as isize)).bits = root as libc::c_uchar;
             (*(*table).offset(low as isize)).val =
-                next.wrapping_offset_from(*table) as libc::c_long as libc::c_ushort
+                next.offset_from(*table) as libc::c_long as libc::c_ushort
         }
     }
     /*

--- a/quake3-rs/qagamex86_64/lib.rs
+++ b/quake3-rs/qagamex86_64/lib.rs
@@ -7,7 +7,7 @@
 #![allow(unused_mut)]
 #![feature(c_variadic)]
 #![feature(const_raw_ptr_to_usize_cast)]
-#![feature(ptr_wrapping_offset_from)]
+#![feature(ptr_offset_from)]
 #![feature(register_tool)]
 #![register_tool(c2rust)]
 

--- a/quake3-rs/qagamex86_64/src/game/g_active.rs
+++ b/quake3-rs/qagamex86_64/src/game/g_active.rs
@@ -859,7 +859,7 @@ pub unsafe extern "C" fn ClientInactivityTimer(
     } else if (*client).pers.localClient as u64 == 0 {
         if crate::src::game::g_main::level.time > (*client).inactivityTime {
             crate::src::game::g_syscalls::trap_DropClient(
-                client.wrapping_offset_from(crate::src::game::g_main::level.clients) as libc::c_long
+                client.offset_from(crate::src::game::g_main::level.clients) as libc::c_long
                     as libc::c_int,
                 b"Dropped due to inactivity\x00" as *const u8 as *const libc::c_char,
             );
@@ -870,7 +870,7 @@ pub unsafe extern "C" fn ClientInactivityTimer(
         {
             (*client).inactivityWarning = crate::src::qcommon::q_shared::qtrue;
             crate::src::game::g_syscalls::trap_SendServerCommand(
-                client.wrapping_offset_from(crate::src::game::g_main::level.clients) as libc::c_long
+                client.offset_from(crate::src::game::g_main::level.clients) as libc::c_long
                     as libc::c_int,
                 b"cp \"Ten seconds until inactivity drop!\n\"\x00" as *const u8
                     as *const libc::c_char,
@@ -1550,7 +1550,7 @@ pub unsafe extern "C" fn SpectatorClientEndFrame(mut ent: *mut crate::g_local_h:
             crate::src::game::g_client::ClientBegin(
                 (*ent)
                     .client
-                    .wrapping_offset_from(crate::src::game::g_main::level.clients)
+                    .offset_from(crate::src::game::g_main::level.clients)
                     as libc::c_long as libc::c_int,
             );
         }

--- a/quake3-rs/qagamex86_64/src/game/g_arenas.rs
+++ b/quake3-rs/qagamex86_64/src/game/g_arenas.rs
@@ -445,7 +445,7 @@ unsafe extern "C" fn SpawnModelOnVictoryPad(
     (*body).s.eFlags = 0 as libc::c_int;
     (*body).s.powerups = 0 as libc::c_int;
     (*body).s.loopSound = 0 as libc::c_int;
-    (*body).s.number = body.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+    (*body).s.number = body.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
         as libc::c_long as libc::c_int;
     (*body).timestamp = crate::src::game::g_main::level.time;
     (*body).physicsObject = crate::src::qcommon::q_shared::qtrue;
@@ -771,7 +771,7 @@ unsafe extern "C" fn SpawnPodium() -> *mut crate::g_local_h::gentity_t {
     (*podium).classname = b"podium\x00" as *const u8 as *const libc::c_char as *mut libc::c_char;
     (*podium).s.eType = crate::bg_public_h::ET_GENERAL as libc::c_int;
     (*podium).s.number = podium
-        .wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+        .offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
         as libc::c_long as libc::c_int;
     (*podium).clipmask = 1 as libc::c_int;
     (*podium).r.contents = 1 as libc::c_int;

--- a/quake3-rs/qagamex86_64/src/game/g_client.rs
+++ b/quake3-rs/qagamex86_64/src/game/g_client.rs
@@ -982,7 +982,7 @@ pub unsafe extern "C" fn CopyToBodyQue(mut ent: *mut crate::g_local_h::gentity_t
     (*body).s.eFlags = 0x1 as libc::c_int; // don't bounce
     (*body).s.powerups = 0 as libc::c_int;
     (*body).s.loopSound = 0 as libc::c_int;
-    (*body).s.number = body.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+    (*body).s.number = body.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
         as libc::c_long as libc::c_int;
     (*body).timestamp = crate::src::game::g_main::level.time;
     (*body).physicsObject = crate::src::qcommon::q_shared::qtrue;
@@ -1873,7 +1873,7 @@ pub unsafe extern "C" fn ClientSpawn(mut ent: *mut crate::g_local_h::gentity_t) 
     let mut accuracy_shots: libc::c_int = 0;
     let mut eventSequence: libc::c_int = 0;
     let mut userinfo: [libc::c_char; 1024] = [0; 1024];
-    index = ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+    index = ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
         as libc::c_long as libc::c_int;
     client = (*ent).client;
     spawn_origin[2 as libc::c_int as usize] =
@@ -2041,7 +2041,7 @@ pub unsafe extern "C" fn ClientSpawn(mut ent: *mut crate::g_local_h::gentity_t) 
     // the respawned flag will be cleared after the attack and jump keys come up
     (*client).ps.pm_flags |= 512 as libc::c_int;
     crate::src::game::g_syscalls::trap_GetUsercmd(
-        client.wrapping_offset_from(crate::src::game::g_main::level.clients) as libc::c_long
+        client.offset_from(crate::src::game::g_main::level.clients) as libc::c_long
             as libc::c_int,
         &mut (*(*ent).client).pers.cmd as *mut _ as *mut crate::src::qcommon::q_shared::usercmd_s,
     );
@@ -2106,7 +2106,7 @@ pub unsafe extern "C" fn ClientSpawn(mut ent: *mut crate::g_local_h::gentity_t) 
     (*client).ps.commandTime = crate::src::game::g_main::level.time - 100 as libc::c_int;
     (*(*ent).client).pers.cmd.serverTime = crate::src::game::g_main::level.time;
     crate::src::game::g_active::ClientThink(
-        ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr()) as libc::c_long
+        ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr()) as libc::c_long
             as libc::c_int,
     );
     // run the presend to set anything else, follow spectators wait

--- a/quake3-rs/qagamex86_64/src/game/g_cmds.rs
+++ b/quake3-rs/qagamex86_64/src/game/g_cmds.rs
@@ -366,7 +366,7 @@ pub unsafe extern "C" fn DeathmatchScoreboardMessage(mut ent: *mut crate::g_loca
         i += 1
     }
     crate::src::game::g_syscalls::trap_SendServerCommand(
-        ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr()) as libc::c_long
+        ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr()) as libc::c_long
             as libc::c_int,
         crate::src::qcommon::q_shared::va(
             b"scores %i %i %i%s\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
@@ -403,7 +403,7 @@ pub unsafe extern "C" fn CheatsOk(
 ) -> crate::src::qcommon::q_shared::qboolean {
     if crate::src::game::g_main::g_cheats.integer == 0 {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"Cheats are not enabled on this server.\n\"\x00" as *const u8
                 as *const libc::c_char,
@@ -412,7 +412,7 @@ pub unsafe extern "C" fn CheatsOk(
     }
     if (*ent).health <= 0 as libc::c_int {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"You must be alive to use this command.\n\"\x00" as *const u8
                 as *const libc::c_char,
@@ -552,7 +552,7 @@ pub unsafe extern "C" fn ClientNumberFromString(
         }
     }
     crate::src::game::g_syscalls::trap_SendServerCommand(
-        to.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr()) as libc::c_long
+        to.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr()) as libc::c_long
             as libc::c_int,
         crate::src::qcommon::q_shared::va(
             b"print \"User %s is not on the server\n\"\x00" as *const u8 as *const libc::c_char
@@ -764,7 +764,7 @@ pub unsafe extern "C" fn Cmd_God_f(mut ent: *mut crate::g_local_h::gentity_t) {
         msg = b"godmode ON\n\x00" as *const u8 as *const libc::c_char as *mut libc::c_char
     }
     crate::src::game::g_syscalls::trap_SendServerCommand(
-        ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr()) as libc::c_long
+        ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr()) as libc::c_long
             as libc::c_int,
         crate::src::qcommon::q_shared::va(
             b"print \"%s\"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
@@ -795,7 +795,7 @@ pub unsafe extern "C" fn Cmd_Notarget_f(mut ent: *mut crate::g_local_h::gentity_
         msg = b"notarget ON\n\x00" as *const u8 as *const libc::c_char as *mut libc::c_char
     }
     crate::src::game::g_syscalls::trap_SendServerCommand(
-        ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr()) as libc::c_long
+        ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr()) as libc::c_long
             as libc::c_int,
         crate::src::qcommon::q_shared::va(
             b"print \"%s\"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
@@ -825,7 +825,7 @@ pub unsafe extern "C" fn Cmd_Noclip_f(mut ent: *mut crate::g_local_h::gentity_t)
     (*(*ent).client).noclip = ((*(*ent).client).noclip as u64 == 0) as libc::c_int
         as crate::src::qcommon::q_shared::qboolean;
     crate::src::game::g_syscalls::trap_SendServerCommand(
-        ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr()) as libc::c_long
+        ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr()) as libc::c_long
             as libc::c_int,
         crate::src::qcommon::q_shared::va(
             b"print \"%s\"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
@@ -848,7 +848,7 @@ hide the scoreboard, and take a special screenshot
 pub unsafe extern "C" fn Cmd_LevelShot_f(mut ent: *mut crate::g_local_h::gentity_t) {
     if (*(*ent).client).pers.localClient as u64 == 0 {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"The levelshot command must be executed by a local client\n\"\x00" as *const u8
                 as *const libc::c_char,
@@ -863,7 +863,7 @@ pub unsafe extern "C" fn Cmd_LevelShot_f(mut ent: *mut crate::g_local_h::gentity
         == crate::bg_public_h::GT_SINGLE_PLAYER as libc::c_int
     {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"Must not be in singleplayer mode for levelshot\n\"\x00" as *const u8
                 as *const libc::c_char,
@@ -872,7 +872,7 @@ pub unsafe extern "C" fn Cmd_LevelShot_f(mut ent: *mut crate::g_local_h::gentity
     }
     crate::src::game::g_main::BeginIntermission();
     crate::src::game::g_syscalls::trap_SendServerCommand(
-        ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr()) as libc::c_long
+        ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr()) as libc::c_long
             as libc::c_int,
         b"clientLevelShot\x00" as *const u8 as *const libc::c_char,
     );
@@ -890,7 +890,7 @@ pub unsafe extern "C" fn Cmd_TeamTask_f(mut ent: *mut crate::g_local_h::gentity_
     let mut task: libc::c_int = 0;
     let mut client: libc::c_int = (*ent)
         .client
-        .wrapping_offset_from(crate::src::game::g_main::level.clients)
+        .offset_from(crate::src::game::g_main::level.clients)
         as libc::c_long as libc::c_int;
     if crate::src::game::g_syscalls::trap_Argc() != 2 as libc::c_int {
         return;
@@ -1027,7 +1027,7 @@ pub unsafe extern "C" fn SetTeam(
     // see what change is requested
     //
     client = (*ent).client;
-    clientNum = client.wrapping_offset_from(crate::src::game::g_main::level.clients) as libc::c_long
+    clientNum = client.offset_from(crate::src::game::g_main::level.clients) as libc::c_long
         as libc::c_int;
     specClient = 0 as libc::c_int;
     specState = crate::g_local_h::SPECTATOR_NOT;
@@ -1247,7 +1247,7 @@ pub unsafe extern "C" fn StopFollowing(mut ent: *mut crate::g_local_h::gentity_t
     (*(*ent).client).ps.pm_flags &= !(4096 as libc::c_int);
     (*ent).r.svFlags &= !(0x8 as libc::c_int);
     (*(*ent).client).ps.clientNum = ent
-        .wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+        .offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
         as libc::c_long as libc::c_int;
     crate::src::game::g_client::SetClientViewAngle(
         ent as *mut crate::g_local_h::gentity_s,
@@ -1276,28 +1276,28 @@ pub unsafe extern "C" fn Cmd_Team_f(mut ent: *mut crate::g_local_h::gentity_t) {
         match oldTeam {
             2 => {
                 crate::src::game::g_syscalls::trap_SendServerCommand(
-                    ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+                    ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                         as libc::c_long as libc::c_int,
                     b"print \"Blue team\n\"\x00" as *const u8 as *const libc::c_char,
                 );
             }
             1 => {
                 crate::src::game::g_syscalls::trap_SendServerCommand(
-                    ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+                    ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                         as libc::c_long as libc::c_int,
                     b"print \"Red team\n\"\x00" as *const u8 as *const libc::c_char,
                 );
             }
             0 => {
                 crate::src::game::g_syscalls::trap_SendServerCommand(
-                    ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+                    ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                         as libc::c_long as libc::c_int,
                     b"print \"Free team\n\"\x00" as *const u8 as *const libc::c_char,
                 );
             }
             3 => {
                 crate::src::game::g_syscalls::trap_SendServerCommand(
-                    ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+                    ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                         as libc::c_long as libc::c_int,
                     b"print \"Spectator team\n\"\x00" as *const u8 as *const libc::c_char,
                 );
@@ -1308,7 +1308,7 @@ pub unsafe extern "C" fn Cmd_Team_f(mut ent: *mut crate::g_local_h::gentity_t) {
     }
     if (*(*ent).client).switchTeamTime > crate::src::game::g_main::level.time {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"May not switch teams more than once per 5 seconds.\n\"\x00" as *const u8
                 as *const libc::c_char,
@@ -1523,7 +1523,7 @@ unsafe extern "C" fn G_SayTo(
         return;
     }
     crate::src::game::g_syscalls::trap_SendServerCommand(
-        other.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+        other.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
             as libc::c_long as libc::c_int,
         crate::src::qcommon::q_shared::va(
             b"%s \"%s%c%c%s\"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
@@ -1737,7 +1737,7 @@ unsafe extern "C" fn Cmd_Tell_f(mut ent: *mut crate::g_local_h::gentity_t) {
     let mut arg: [libc::c_char; 1024] = [0; 1024];
     if crate::src::game::g_syscalls::trap_Argc() < 3 as libc::c_int {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"Usage: tell <player id> <message>\n\"\x00" as *const u8
                 as *const libc::c_char,
@@ -1801,7 +1801,7 @@ pub unsafe extern "C" fn Cmd_GameCommand_f(mut ent: *mut crate::g_local_h::genti
     let mut arg: [libc::c_char; 1024] = [0; 1024];
     if crate::src::game::g_syscalls::trap_Argc() != 3 as libc::c_int {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             crate::src::qcommon::q_shared::va(
                 b"print \"Usage: gc <player id> <order 0-%d>\n\"\x00" as *const u8
@@ -1819,7 +1819,7 @@ pub unsafe extern "C" fn Cmd_GameCommand_f(mut ent: *mut crate::g_local_h::genti
     order = atoi(arg.as_mut_ptr());
     if order < 0 as libc::c_int || order >= numgc_orders {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             crate::src::qcommon::q_shared::va(
                 b"print \"Bad order: %i\n\"\x00" as *const u8 as *const libc::c_char
@@ -1871,7 +1871,7 @@ Cmd_Where_f
 
 pub unsafe extern "C" fn Cmd_Where_f(mut ent: *mut crate::g_local_h::gentity_t) {
     crate::src::game::g_syscalls::trap_SendServerCommand(
-        ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr()) as libc::c_long
+        ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr()) as libc::c_long
             as libc::c_int,
         crate::src::qcommon::q_shared::va(
             b"print \"%s\n\"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
@@ -1906,7 +1906,7 @@ pub unsafe extern "C" fn Cmd_CallVote_f(mut ent: *mut crate::g_local_h::gentity_
     let mut arg2: [libc::c_char; 1024] = [0; 1024];
     if crate::src::game::g_main::g_allowVote.integer == 0 {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"Voting not allowed here.\n\"\x00" as *const u8 as *const libc::c_char,
         );
@@ -1914,7 +1914,7 @@ pub unsafe extern "C" fn Cmd_CallVote_f(mut ent: *mut crate::g_local_h::gentity_
     }
     if crate::src::game::g_main::level.voteTime != 0 {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"A vote is already in progress.\n\"\x00" as *const u8 as *const libc::c_char,
         );
@@ -1922,7 +1922,7 @@ pub unsafe extern "C" fn Cmd_CallVote_f(mut ent: *mut crate::g_local_h::gentity_
     }
     if (*(*ent).client).pers.voteCount >= 3 as libc::c_int {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"You have called the maximum number of votes.\n\"\x00" as *const u8
                 as *const libc::c_char,
@@ -1933,7 +1933,7 @@ pub unsafe extern "C" fn Cmd_CallVote_f(mut ent: *mut crate::g_local_h::gentity_
         == crate::bg_public_h::TEAM_SPECTATOR as libc::c_int as libc::c_uint
     {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"Not allowed to call a vote as spectator.\n\"\x00" as *const u8
                 as *const libc::c_char,
@@ -1957,7 +1957,7 @@ pub unsafe extern "C" fn Cmd_CallVote_f(mut ent: *mut crate::g_local_h::gentity_
         match *c as libc::c_int {
             10 | 13 | 59 => {
                 crate::src::game::g_syscalls::trap_SendServerCommand(
-                    ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+                    ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                         as libc::c_long as libc::c_int,
                     b"print \"Invalid vote string.\n\"\x00" as *const u8 as *const libc::c_char,
                 );
@@ -2014,7 +2014,7 @@ pub unsafe extern "C" fn Cmd_CallVote_f(mut ent: *mut crate::g_local_h::gentity_
                                     {
                                     } else {
                                         crate::src::game::g_syscalls::trap_SendServerCommand(
-                                            ent.wrapping_offset_from(
+                                            ent.offset_from(
                                                 crate::src::game::g_main::g_entities.as_mut_ptr(),
                                             )
                                                 as libc::c_long
@@ -2022,7 +2022,7 @@ pub unsafe extern "C" fn Cmd_CallVote_f(mut ent: *mut crate::g_local_h::gentity_
                                             b"print \"Invalid vote string.\n\"\x00" as *const u8
                                                 as *const libc::c_char,
                                         );
-                                        crate::src::game::g_syscalls::trap_SendServerCommand(ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+                                        crate::src::game::g_syscalls::trap_SendServerCommand(ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                                                                    as
                                                                    libc::c_long
                                                                    as
@@ -2057,7 +2057,7 @@ pub unsafe extern "C" fn Cmd_CallVote_f(mut ent: *mut crate::g_local_h::gentity_
             ) == 0
         {
             crate::src::game::g_syscalls::trap_SendServerCommand(
-                ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+                ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                     as libc::c_long as libc::c_int,
                 b"print \"Vote after map change.\n\"\x00" as *const u8 as *const libc::c_char,
             );
@@ -2084,7 +2084,7 @@ pub unsafe extern "C" fn Cmd_CallVote_f(mut ent: *mut crate::g_local_h::gentity_
             || i >= crate::bg_public_h::GT_MAX_GAME_TYPE as libc::c_int
         {
             crate::src::game::g_syscalls::trap_SendServerCommand(
-                ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+                ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                     as libc::c_long as libc::c_int,
                 b"print \"Invalid gametype.\n\"\x00" as *const u8 as *const libc::c_char,
             );
@@ -2158,7 +2158,7 @@ pub unsafe extern "C" fn Cmd_CallVote_f(mut ent: *mut crate::g_local_h::gentity_
         );
         if *s_0.as_mut_ptr() == 0 {
             crate::src::game::g_syscalls::trap_SendServerCommand(
-                ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+                ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                     as libc::c_long as libc::c_int,
                 b"print \"nextmap not set.\n\"\x00" as *const u8 as *const libc::c_char,
             );
@@ -2207,7 +2207,7 @@ pub unsafe extern "C" fn Cmd_CallVote_f(mut ent: *mut crate::g_local_h::gentity_
             != 0
         {
             crate::src::game::g_syscalls::trap_SendServerCommand(
-                ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+                ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                     as libc::c_long as libc::c_int,
                 b"print \"Cannot kick host player.\n\"\x00" as *const u8 as *const libc::c_char,
             );
@@ -2306,7 +2306,7 @@ pub unsafe extern "C" fn Cmd_Vote_f(mut ent: *mut crate::g_local_h::gentity_t) {
     let mut msg: [libc::c_char; 64] = [0; 64];
     if crate::src::game::g_main::level.voteTime == 0 {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"No vote in progress.\n\"\x00" as *const u8 as *const libc::c_char,
         );
@@ -2314,7 +2314,7 @@ pub unsafe extern "C" fn Cmd_Vote_f(mut ent: *mut crate::g_local_h::gentity_t) {
     }
     if (*(*ent).client).ps.eFlags & 0x4000 as libc::c_int != 0 {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"Vote already cast.\n\"\x00" as *const u8 as *const libc::c_char,
         );
@@ -2324,7 +2324,7 @@ pub unsafe extern "C" fn Cmd_Vote_f(mut ent: *mut crate::g_local_h::gentity_t) {
         == crate::bg_public_h::TEAM_SPECTATOR as libc::c_int as libc::c_uint
     {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"Not allowed to vote as spectator.\n\"\x00" as *const u8
                 as *const libc::c_char,
@@ -2332,7 +2332,7 @@ pub unsafe extern "C" fn Cmd_Vote_f(mut ent: *mut crate::g_local_h::gentity_t) {
         return;
     }
     crate::src::game::g_syscalls::trap_SendServerCommand(
-        ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr()) as libc::c_long
+        ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr()) as libc::c_long
             as libc::c_int,
         b"print \"Vote cast.\n\"\x00" as *const u8 as *const libc::c_char,
     );
@@ -2410,7 +2410,7 @@ pub unsafe extern "C" fn Cmd_CallTeamVote_f(mut ent: *mut crate::g_local_h::gent
     }
     if crate::src::game::g_main::g_allowVote.integer == 0 {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"Voting not allowed here.\n\"\x00" as *const u8 as *const libc::c_char,
         );
@@ -2418,7 +2418,7 @@ pub unsafe extern "C" fn Cmd_CallTeamVote_f(mut ent: *mut crate::g_local_h::gent
     }
     if crate::src::game::g_main::level.teamVoteTime[cs_offset as usize] != 0 {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"A team vote is already in progress.\n\"\x00" as *const u8
                 as *const libc::c_char,
@@ -2427,7 +2427,7 @@ pub unsafe extern "C" fn Cmd_CallTeamVote_f(mut ent: *mut crate::g_local_h::gent
     }
     if (*(*ent).client).pers.teamVoteCount >= 3 as libc::c_int {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"You have called the maximum number of team votes.\n\"\x00" as *const u8
                 as *const libc::c_char,
@@ -2438,7 +2438,7 @@ pub unsafe extern "C" fn Cmd_CallTeamVote_f(mut ent: *mut crate::g_local_h::gent
         == crate::bg_public_h::TEAM_SPECTATOR as libc::c_int as libc::c_uint
     {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"Not allowed to call a vote as spectator.\n\"\x00" as *const u8
                 as *const libc::c_char,
@@ -2477,7 +2477,7 @@ pub unsafe extern "C" fn Cmd_CallTeamVote_f(mut ent: *mut crate::g_local_h::gent
         match *c as libc::c_int {
             10 | 13 | 59 => {
                 crate::src::game::g_syscalls::trap_SendServerCommand(
-                    ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+                    ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                         as libc::c_long as libc::c_int,
                     b"print \"Invalid vote string.\n\"\x00" as *const u8 as *const libc::c_char,
                 );
@@ -2512,7 +2512,7 @@ pub unsafe extern "C" fn Cmd_CallTeamVote_f(mut ent: *mut crate::g_local_h::gent
                 i = atoi(arg2.as_mut_ptr());
                 if i < 0 as libc::c_int || i >= crate::src::game::g_main::level.maxclients {
                     crate::src::game::g_syscalls::trap_SendServerCommand(
-                        ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+                        ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                             as libc::c_long as libc::c_int,
                         crate::src::qcommon::q_shared::va(
                             b"print \"Bad client slot: %i\n\"\x00" as *const u8
@@ -2525,7 +2525,7 @@ pub unsafe extern "C" fn Cmd_CallTeamVote_f(mut ent: *mut crate::g_local_h::gent
                 }
                 if crate::src::game::g_main::g_entities[i as usize].inuse as u64 == 0 {
                     crate::src::game::g_syscalls::trap_SendServerCommand(
-                        ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+                        ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                             as libc::c_long as libc::c_int,
                         crate::src::qcommon::q_shared::va(
                             b"print \"Client %i is not active\n\"\x00" as *const u8
@@ -2578,7 +2578,7 @@ pub unsafe extern "C" fn Cmd_CallTeamVote_f(mut ent: *mut crate::g_local_h::gent
                 }
                 if i >= crate::src::game::g_main::level.maxclients {
                     crate::src::game::g_syscalls::trap_SendServerCommand(
-                        ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+                        ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                             as libc::c_long as libc::c_int,
                         crate::src::qcommon::q_shared::va(
                             b"print \"%s is not a valid player on your team.\n\"\x00" as *const u8
@@ -2599,12 +2599,12 @@ pub unsafe extern "C" fn Cmd_CallTeamVote_f(mut ent: *mut crate::g_local_h::gent
         );
     } else {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"Invalid vote string.\n\"\x00" as *const u8 as *const libc::c_char,
         );
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"Team vote commands are: leader <player>.\n\"\x00" as *const u8
                 as *const libc::c_char,
@@ -2708,7 +2708,7 @@ pub unsafe extern "C" fn Cmd_TeamVote_f(mut ent: *mut crate::g_local_h::gentity_
     }
     if crate::src::game::g_main::level.teamVoteTime[cs_offset as usize] == 0 {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"No team vote in progress.\n\"\x00" as *const u8 as *const libc::c_char,
         );
@@ -2716,7 +2716,7 @@ pub unsafe extern "C" fn Cmd_TeamVote_f(mut ent: *mut crate::g_local_h::gentity_
     }
     if (*(*ent).client).ps.eFlags & 0x80000 as libc::c_int != 0 {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"Team vote already cast.\n\"\x00" as *const u8 as *const libc::c_char,
         );
@@ -2726,7 +2726,7 @@ pub unsafe extern "C" fn Cmd_TeamVote_f(mut ent: *mut crate::g_local_h::gentity_
         == crate::bg_public_h::TEAM_SPECTATOR as libc::c_int as libc::c_uint
     {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"Not allowed to vote as spectator.\n\"\x00" as *const u8
                 as *const libc::c_char,
@@ -2734,7 +2734,7 @@ pub unsafe extern "C" fn Cmd_TeamVote_f(mut ent: *mut crate::g_local_h::gentity_
         return;
     }
     crate::src::game::g_syscalls::trap_SendServerCommand(
-        ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr()) as libc::c_long
+        ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr()) as libc::c_long
             as libc::c_int,
         b"print \"Team vote cast.\n\"\x00" as *const u8 as *const libc::c_char,
     );
@@ -2802,7 +2802,7 @@ pub unsafe extern "C" fn Cmd_SetViewpos_f(mut ent: *mut crate::g_local_h::gentit
     let mut i: libc::c_int = 0;
     if crate::src::game::g_main::g_cheats.integer == 0 {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"Cheats are not enabled on this server.\n\"\x00" as *const u8
                 as *const libc::c_char,
@@ -2811,7 +2811,7 @@ pub unsafe extern "C" fn Cmd_SetViewpos_f(mut ent: *mut crate::g_local_h::gentit
     }
     if crate::src::game::g_syscalls::trap_Argc() != 5 as libc::c_int {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             b"print \"usage: setviewpos x y z yaw\n\"\x00" as *const u8 as *const libc::c_char,
         );

--- a/quake3-rs/qagamex86_64/src/game/g_items.rs
+++ b/quake3-rs/qagamex86_64/src/game/g_items.rs
@@ -386,7 +386,7 @@ pub unsafe extern "C" fn Pickup_Holdable(
     (*(*other).client).ps.stats[crate::bg_public_h::STAT_HOLDABLE_ITEM as libc::c_int as usize] =
         (*ent)
             .item
-            .wrapping_offset_from(crate::src::game::bg_misc::bg_itemlist.as_mut_ptr())
+            .offset_from(crate::src::game::bg_misc::bg_itemlist.as_mut_ptr())
             as libc::c_long as libc::c_int;
     if (*(*ent).item).giTag == crate::bg_public_h::HI_KAMIKAZE as libc::c_int {
         (*(*other).client).ps.eFlags |= 0x200 as libc::c_int
@@ -792,7 +792,7 @@ pub unsafe extern "C" fn LaunchItem(
     dropped = crate::src::game::g_utils::G_Spawn() as *mut crate::g_local_h::gentity_s; // This is non-zero is it's a dropped item
     (*dropped).s.eType = crate::bg_public_h::ET_ITEM as libc::c_int; // auto-remove after 30 seconds
     (*dropped).s.modelindex = item
-        .wrapping_offset_from(crate::src::game::bg_misc::bg_itemlist.as_mut_ptr())
+        .offset_from(crate::src::game::bg_misc::bg_itemlist.as_mut_ptr())
         as libc::c_long as libc::c_int;
     (*dropped).s.modelindex2 = 1 as libc::c_int;
     (*dropped).classname = (*item).classname;
@@ -960,7 +960,7 @@ pub unsafe extern "C" fn FinishSpawningItem(mut ent: *mut crate::g_local_h::gent
     (*ent).s.eType = crate::bg_public_h::ET_ITEM as libc::c_int;
     (*ent).s.modelindex = (*ent)
         .item
-        .wrapping_offset_from(crate::src::game::bg_misc::bg_itemlist.as_mut_ptr())
+        .offset_from(crate::src::game::bg_misc::bg_itemlist.as_mut_ptr())
         as libc::c_long as libc::c_int;
     (*ent).s.modelindex2 = 0 as libc::c_int;
     (*ent).r.contents = 0x40000000 as libc::c_int;
@@ -1071,7 +1071,7 @@ pub unsafe extern "C" fn G_CheckTeamItems() {
         ) as *mut crate::bg_public_h::gitem_s;
         if item.is_null()
             || itemRegistered[item
-                .wrapping_offset_from(crate::src::game::bg_misc::bg_itemlist.as_mut_ptr())
+                .offset_from(crate::src::game::bg_misc::bg_itemlist.as_mut_ptr())
                 as libc::c_long as usize] as u64
                 == 0
         {
@@ -1084,7 +1084,7 @@ pub unsafe extern "C" fn G_CheckTeamItems() {
         ) as *mut crate::bg_public_h::gitem_s;
         if item.is_null()
             || itemRegistered[item
-                .wrapping_offset_from(crate::src::game::bg_misc::bg_itemlist.as_mut_ptr())
+                .offset_from(crate::src::game::bg_misc::bg_itemlist.as_mut_ptr())
                 as libc::c_long as usize] as u64
                 == 0
         {
@@ -1132,7 +1132,7 @@ pub unsafe extern "C" fn RegisterItem(mut item: *mut crate::bg_public_h::gitem_t
             b"RegisterItem: NULL\x00" as *const u8 as *const libc::c_char,
         );
     }
-    itemRegistered[item.wrapping_offset_from(crate::src::game::bg_misc::bg_itemlist.as_mut_ptr())
+    itemRegistered[item.offset_from(crate::src::game::bg_misc::bg_itemlist.as_mut_ptr())
         as libc::c_long as usize] = crate::src::qcommon::q_shared::qtrue;
 }
 /*

--- a/quake3-rs/qagamex86_64/src/game/g_main.rs
+++ b/quake3-rs/qagamex86_64/src/game/g_main.rs
@@ -2387,7 +2387,7 @@ pub unsafe extern "C" fn AddTournamentPlayer() {
     crate::src::game::g_cmds::SetTeam(
         &mut *g_entities
             .as_mut_ptr()
-            .offset(nextInLine.wrapping_offset_from(level.clients) as libc::c_long as isize)
+            .offset(nextInLine.offset_from(level.clients) as libc::c_long as isize)
             as *mut _ as *mut crate::g_local_h::gentity_s,
         b"f\x00" as *const u8 as *const libc::c_char,
     );

--- a/quake3-rs/qagamex86_64/src/game/g_session.rs
+++ b/quake3-rs/qagamex86_64/src/game/g_session.rs
@@ -163,7 +163,7 @@ pub unsafe extern "C" fn G_WriteClientSessionData(mut client: *mut crate::g_loca
     );
     var = crate::src::qcommon::q_shared::va(
         b"session%i\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-        client.wrapping_offset_from(crate::src::game::g_main::level.clients) as libc::c_long
+        client.offset_from(crate::src::game::g_main::level.clients) as libc::c_long
             as libc::c_int,
     );
     crate::src::game::g_syscalls::trap_Cvar_Set(var, s);
@@ -185,7 +185,7 @@ pub unsafe extern "C" fn G_ReadSessionData(mut client: *mut crate::g_local_h::gc
     let mut sessionTeam: libc::c_int = 0;
     var = crate::src::qcommon::q_shared::va(
         b"session%i\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-        client.wrapping_offset_from(crate::src::game::g_main::level.clients) as libc::c_long
+        client.offset_from(crate::src::game::g_main::level.clients) as libc::c_long
             as libc::c_int,
     );
     crate::src::game::g_syscalls::trap_Cvar_VariableStringBuffer(
@@ -256,7 +256,7 @@ pub unsafe extern "C" fn G_InitSessionData(
         {
             crate::src::game::g_cmds::SetTeam(
                 &mut *crate::src::game::g_main::g_entities.as_mut_ptr().offset(
-                    client.wrapping_offset_from(crate::src::game::g_main::level.clients)
+                    client.offset_from(crate::src::game::g_main::level.clients)
                         as libc::c_long as isize,
                 ) as *mut _ as *mut crate::g_local_h::gentity_s,
                 value,

--- a/quake3-rs/qagamex86_64/src/game/g_svcmds.rs
+++ b/quake3-rs/qagamex86_64/src/game/g_svcmds.rs
@@ -1030,7 +1030,7 @@ pub unsafe extern "C" fn Svcmd_ForceTeam_f() {
     );
     crate::src::game::g_cmds::SetTeam(
         &mut *crate::src::game::g_main::g_entities.as_mut_ptr().offset(
-            cl.wrapping_offset_from(crate::src::game::g_main::level.clients) as libc::c_long
+            cl.offset_from(crate::src::game::g_main::level.clients) as libc::c_long
                 as isize,
         ) as *mut _ as *mut crate::g_local_h::gentity_s,
         str.as_mut_ptr(),

--- a/quake3-rs/qagamex86_64/src/game/g_target.rs
+++ b/quake3-rs/qagamex86_64/src/game/g_target.rs
@@ -495,7 +495,7 @@ pub unsafe extern "C" fn Use_Target_Print(
 ) {
     if !(*activator).client.is_null() && (*ent).spawnflags & 4 as libc::c_int != 0 {
         crate::src::game::g_syscalls::trap_SendServerCommand(
-            activator.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            activator.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long as libc::c_int,
             crate::src::qcommon::q_shared::va(
                 b"cp \"%s\"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,

--- a/quake3-rs/qagamex86_64/src/game/g_team.rs
+++ b/quake3-rs/qagamex86_64/src/game/g_team.rs
@@ -594,7 +594,7 @@ unsafe extern "C" fn PrintMsg(
         if ent.is_null() {
             -(1 as libc::c_int) as libc::c_long
         } else {
-            ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+            ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
                 as libc::c_long
         } as libc::c_int,
         crate::src::qcommon::q_shared::va(
@@ -1892,7 +1892,7 @@ pub unsafe extern "C" fn TeamplayInfoMessage(mut ent: *mut crate::g_local_h::gen
         i += 1
     }
     crate::src::game::g_syscalls::trap_SendServerCommand(
-        ent.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr()) as libc::c_long
+        ent.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr()) as libc::c_long
             as libc::c_int,
         crate::src::qcommon::q_shared::va(
             b"tinfo %i %s\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,

--- a/quake3-rs/qagamex86_64/src/game/g_utils.rs
+++ b/quake3-rs/qagamex86_64/src/game/g_utils.rs
@@ -977,7 +977,7 @@ pub unsafe extern "C" fn vectoyaw(
 pub unsafe extern "C" fn G_InitGentity(mut e: *mut crate::g_local_h::gentity_t) {
     (*e).inuse = crate::src::qcommon::q_shared::qtrue;
     (*e).classname = b"noclass\x00" as *const u8 as *const libc::c_char as *mut libc::c_char;
-    (*e).s.number = e.wrapping_offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
+    (*e).s.number = e.offset_from(crate::src::game::g_main::g_entities.as_mut_ptr())
         as libc::c_long as libc::c_int;
     (*e).r.ownerNum = ((1 as libc::c_int) << 10 as libc::c_int) - 1 as libc::c_int;
 }

--- a/quake3-rs/qagamex86_64/src/qcommon/q_shared.rs
+++ b/quake3-rs/qagamex86_64/src/qcommon/q_shared.rs
@@ -895,11 +895,11 @@ pub unsafe extern "C" fn COM_StripExtension(
         (slash.is_null()) || slash < dot
     } {
         destsize = if (destsize as libc::c_long)
-            < dot.wrapping_offset_from(in_0) as libc::c_long + 1 as libc::c_int as libc::c_long
+            < dot.offset_from(in_0) as libc::c_long + 1 as libc::c_int as libc::c_long
         {
             destsize as libc::c_long
         } else {
-            (dot.wrapping_offset_from(in_0) as libc::c_long) + 1 as libc::c_int as libc::c_long
+            (dot.offset_from(in_0) as libc::c_long) + 1 as libc::c_int as libc::c_long
         } as libc::c_int
     }
     if in_0 == out as *const libc::c_char && destsize > 1 as libc::c_int {
@@ -1211,7 +1211,7 @@ pub unsafe extern "C" fn COM_Compress(mut data_p: *mut libc::c_char) -> libc::c_
         }
         *out = 0 as libc::c_int as libc::c_char
     }
-    return out.wrapping_offset_from(data_p) as libc::c_long as libc::c_int;
+    return out.offset_from(data_p) as libc::c_long as libc::c_int;
 }
 #[no_mangle]
 pub unsafe extern "C" fn COM_ParseExt(

--- a/quake3-rs/renderer_opengl1_x86_64/lib.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/lib.rs
@@ -9,7 +9,7 @@
 #![feature(const_raw_ptr_to_usize_cast)]
 #![feature(const_transmute)]
 #![feature(extern_types)]
-#![feature(ptr_wrapping_offset_from)]
+#![feature(ptr_offset_from)]
 #![feature(register_tool)]
 #![register_tool(c2rust)]
 

--- a/quake3-rs/renderer_opengl1_x86_64/src/qcommon/q_shared.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/qcommon/q_shared.rs
@@ -346,11 +346,11 @@ pub unsafe extern "C" fn COM_StripExtension(
         (slash.is_null()) || slash < dot
     } {
         destsize = if (destsize as libc::c_long)
-            < dot.wrapping_offset_from(in_0) as libc::c_long + 1 as libc::c_int as libc::c_long
+            < dot.offset_from(in_0) as libc::c_long + 1 as libc::c_int as libc::c_long
         {
             destsize as libc::c_long
         } else {
-            (dot.wrapping_offset_from(in_0) as libc::c_long) + 1 as libc::c_int as libc::c_long
+            (dot.offset_from(in_0) as libc::c_long) + 1 as libc::c_int as libc::c_long
         } as libc::c_int
     }
     if in_0 == out as *const libc::c_char && destsize > 1 as libc::c_int {
@@ -817,7 +817,7 @@ pub unsafe extern "C" fn COM_Compress(mut data_p: *mut libc::c_char) -> libc::c_
         }
         *out = 0 as libc::c_int as libc::c_char
     }
-    return out.wrapping_offset_from(data_p) as libc::c_long as libc::c_int;
+    return out.offset_from(data_p) as libc::c_long as libc::c_int;
 }
 #[no_mangle]
 

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderercommon/tr_image_pcx.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderercommon/tr_image_pcx.rs
@@ -254,9 +254,9 @@ pub unsafe extern "C" fn R_LoadPCX(
     }
     if raw
         .b
-        .wrapping_offset_from(pcx as *mut crate::src::qcommon::q_shared::byte)
+        .offset_from(pcx as *mut crate::src::qcommon::q_shared::byte)
         as libc::c_long
-        >= end.wrapping_offset_from(769 as libc::c_int as *mut crate::src::qcommon::q_shared::byte)
+        >= end.offset_from(769 as libc::c_int as *mut crate::src::qcommon::q_shared::byte)
             as libc::c_long
         || *end.offset(-(769 as libc::c_int) as isize) as libc::c_int != 0xc as libc::c_int
     {

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderercommon/tr_image_png.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderercommon/tr_image_png.rs
@@ -221,7 +221,7 @@ unsafe extern "C" fn BufferedFileRewind(
     /*
      *  How many bytes do we have already read?
      */
-    BytesRead = (*BF).Ptr.wrapping_offset_from((*BF).Buffer) as libc::c_long as libc::c_uint;
+    BytesRead = (*BF).Ptr.offset_from((*BF).Buffer) as libc::c_long as libc::c_uint;
     /*
      *  We can only rewind to the beginning of the BufferedFile.
      */

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_bsp.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_bsp.rs
@@ -4905,7 +4905,7 @@ pub unsafe extern "C" fn RE_LoadWorldMap(mut name: *const libc::c_char) {
         .expect("non-null function pointer")(
         0 as libc::c_int, crate::src::qcommon::q_shared::h_low
     ) as *mut crate::src::qcommon::q_shared::byte)
-        .wrapping_offset_from(startMarker) as libc::c_long
+        .offset_from(startMarker) as libc::c_long
         as libc::c_int;
     // only set tr.world now that we know the entire level has loaded properly
     crate::src::renderergl1::tr_main::tr.world = &mut s_worldData;

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_init.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_init.rs
@@ -1265,7 +1265,7 @@ pub unsafe extern "C" fn RB_ReadPixels(
         0x1401 as libc::c_int as crate::stdlib::GLenum,
         bufstart as *mut libc::c_void,
     );
-    *offset = bufstart.wrapping_offset_from(buffer) as libc::c_long as crate::stddef_h::size_t;
+    *offset = bufstart.offset_from(buffer) as libc::c_long as crate::stddef_h::size_t;
     *padlen = padwidth - linelen;
     return buffer;
 }

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_model.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_model.rs
@@ -1132,7 +1132,7 @@ unsafe extern "C" fn R_LoadMDR(
     /* The first frame will be put into the first free space after the header */
     frame = mdr.offset(1 as libc::c_int as isize) as *mut crate::qfiles_h::mdrFrame_t;
     (*mdr).ofsFrames = (frame as *mut crate::src::qcommon::q_shared::byte)
-        .wrapping_offset_from(mdr as *mut crate::src::qcommon::q_shared::byte)
+        .offset_from(mdr as *mut crate::src::qcommon::q_shared::byte)
         as libc::c_long as libc::c_int;
     if (*pinmodel).ofsFrames < 0 as libc::c_int {
         let mut cframe: *mut crate::qfiles_h::mdrCompFrame_t =
@@ -1247,7 +1247,7 @@ unsafe extern "C" fn R_LoadMDR(
     // frame should now point to the first free address after all frames.
     lod = frame as *mut crate::qfiles_h::mdrLOD_t;
     (*mdr).ofsLODs = (lod as *mut crate::src::qcommon::q_shared::byte)
-        .wrapping_offset_from(mdr as *mut crate::src::qcommon::q_shared::byte)
+        .offset_from(mdr as *mut crate::src::qcommon::q_shared::byte)
         as libc::c_long as libc::c_int;
     curlod = (pinmodel as *mut crate::src::qcommon::q_shared::byte)
         .offset((*pinmodel).ofsLODs as isize) as *mut crate::qfiles_h::mdrLOD_t;
@@ -1271,7 +1271,7 @@ unsafe extern "C" fn R_LoadMDR(
         // swap all the surfaces
         surf = lod.offset(1 as libc::c_int as isize) as *mut crate::qfiles_h::mdrSurface_t;
         (*lod).ofsSurfaces = (surf as *mut crate::src::qcommon::q_shared::byte)
-            .wrapping_offset_from(lod as *mut crate::src::qcommon::q_shared::byte)
+            .offset_from(lod as *mut crate::src::qcommon::q_shared::byte)
             as libc::c_long as libc::c_int;
         cursurf = (curlod as *mut crate::src::qcommon::q_shared::byte)
             .offset((*curlod).ofsSurfaces as isize)
@@ -1305,7 +1305,7 @@ unsafe extern "C" fn R_LoadMDR(
                 ::std::mem::size_of::<[libc::c_char; 64]>() as libc::c_ulong as libc::c_int,
             );
             (*surf).ofsHeader = (mdr as *mut crate::src::qcommon::q_shared::byte)
-                .wrapping_offset_from(surf as *mut crate::src::qcommon::q_shared::byte)
+                .offset_from(surf as *mut crate::src::qcommon::q_shared::byte)
                 as libc::c_long as libc::c_int;
             (*surf).numVerts = (*cursurf).numVerts;
             (*surf).numTriangles = (*cursurf).numTriangles;
@@ -1363,7 +1363,7 @@ unsafe extern "C" fn R_LoadMDR(
             // now copy the vertexes.
             v = surf.offset(1 as libc::c_int as isize) as *mut crate::qfiles_h::mdrVertex_t;
             (*surf).ofsVerts = (v as *mut crate::src::qcommon::q_shared::byte)
-                .wrapping_offset_from(surf as *mut crate::src::qcommon::q_shared::byte)
+                .offset_from(surf as *mut crate::src::qcommon::q_shared::byte)
                 as libc::c_long as libc::c_int;
             curv = (cursurf as *mut crate::src::qcommon::q_shared::byte)
                 .offset((*cursurf).ofsVerts as isize)
@@ -1429,7 +1429,7 @@ unsafe extern "C" fn R_LoadMDR(
             // we know the offset to the triangles now:
             tri = v as *mut crate::qfiles_h::mdrTriangle_t;
             (*surf).ofsTriangles = (tri as *mut crate::src::qcommon::q_shared::byte)
-                .wrapping_offset_from(surf as *mut crate::src::qcommon::q_shared::byte)
+                .offset_from(surf as *mut crate::src::qcommon::q_shared::byte)
                 as libc::c_long as libc::c_int;
             curtri = (cursurf as *mut crate::src::qcommon::q_shared::byte)
                 .offset((*cursurf).ofsTriangles as isize)
@@ -1464,7 +1464,7 @@ unsafe extern "C" fn R_LoadMDR(
             }
             // tri now points to the end of the surface.
             (*surf).ofsEnd = (tri as *mut crate::src::qcommon::q_shared::byte)
-                .wrapping_offset_from(surf as *mut crate::src::qcommon::q_shared::byte)
+                .offset_from(surf as *mut crate::src::qcommon::q_shared::byte)
                 as libc::c_long as libc::c_int;
             surf = tri as *mut crate::qfiles_h::mdrSurface_t;
             // find the next surface.
@@ -1475,7 +1475,7 @@ unsafe extern "C" fn R_LoadMDR(
         }
         // surf points to the next lod now.
         (*lod).ofsEnd = (surf as *mut crate::src::qcommon::q_shared::byte)
-            .wrapping_offset_from(lod as *mut crate::src::qcommon::q_shared::byte)
+            .offset_from(lod as *mut crate::src::qcommon::q_shared::byte)
             as libc::c_long as libc::c_int;
         lod = surf as *mut crate::qfiles_h::mdrLOD_t;
         // find the next LOD.
@@ -1486,7 +1486,7 @@ unsafe extern "C" fn R_LoadMDR(
     // lod points to the first tag now, so update the offset too.
     tag = lod as *mut crate::qfiles_h::mdrTag_t;
     (*mdr).ofsTags = (tag as *mut crate::src::qcommon::q_shared::byte)
-        .wrapping_offset_from(mdr as *mut crate::src::qcommon::q_shared::byte)
+        .offset_from(mdr as *mut crate::src::qcommon::q_shared::byte)
         as libc::c_long as libc::c_int;
     curtag = (pinmodel as *mut crate::src::qcommon::q_shared::byte)
         .offset((*pinmodel).ofsTags as isize) as *mut crate::qfiles_h::mdrTag_t;
@@ -1518,7 +1518,7 @@ unsafe extern "C" fn R_LoadMDR(
     }
     // And finally we know the real offset to the end.
     (*mdr).ofsEnd = (tag as *mut crate::src::qcommon::q_shared::byte)
-        .wrapping_offset_from(mdr as *mut crate::src::qcommon::q_shared::byte)
+        .offset_from(mdr as *mut crate::src::qcommon::q_shared::byte)
         as libc::c_long as libc::c_int;
     // phew! we're done.
     return crate::src::qcommon::q_shared::qtrue;

--- a/quake3-rs/uix86_64/lib.rs
+++ b/quake3-rs/uix86_64/lib.rs
@@ -7,7 +7,7 @@
 #![allow(unused_mut)]
 #![feature(c_variadic)]
 #![feature(const_raw_ptr_to_usize_cast)]
-#![feature(ptr_wrapping_offset_from)]
+#![feature(ptr_offset_from)]
 #![feature(register_tool)]
 #![register_tool(c2rust)]
 

--- a/quake3-rs/uix86_64/src/q3_ui/ui_demo2.rs
+++ b/quake3-rs/uix86_64/src/q3_ui/ui_demo2.rs
@@ -764,7 +764,7 @@ unsafe extern "C" fn Demos_MenuInit() {
                 demoname,
                 (::std::mem::size_of::<[libc::c_char; 32768]>() as libc::c_ulong)
                     .wrapping_div(::std::mem::size_of::<libc::c_char>() as libc::c_ulong)
-                    .wrapping_sub(demoname.wrapping_offset_from(s_demos.names.as_mut_ptr())
+                    .wrapping_sub(demoname.offset_from(s_demos.names.as_mut_ptr())
                         as libc::c_long as libc::c_ulong) as libc::c_int,
             )
         }

--- a/quake3-rs/uix86_64/src/q3_ui/ui_playermodel.rs
+++ b/quake3-rs/uix86_64/src/q3_ui/ui_playermodel.rs
@@ -1134,7 +1134,7 @@ unsafe extern "C" fn PlayerModel_PicEvent(mut ptr: *mut libc::c_void, mut event:
         crate::src::qcommon::q_shared::Q_strncpyz(
             s_playermodel.modelskin.as_mut_ptr(),
             buffptr,
-            (pdest.wrapping_offset_from(buffptr) as libc::c_long + 1 as libc::c_int as libc::c_long)
+            (pdest.offset_from(buffptr) as libc::c_long + 1 as libc::c_int as libc::c_long)
                 as libc::c_int,
         );
         ::libc::strcat(
@@ -1142,7 +1142,7 @@ unsafe extern "C" fn PlayerModel_PicEvent(mut ptr: *mut libc::c_void, mut event:
             pdest.offset(5 as libc::c_int as isize),
         );
         // separate the model name
-        maxlen = pdest.wrapping_offset_from(buffptr) as libc::c_long as libc::c_int;
+        maxlen = pdest.offset_from(buffptr) as libc::c_long as libc::c_int;
         if maxlen > 16 as libc::c_int {
             maxlen = 16 as libc::c_int
         }
@@ -1353,7 +1353,7 @@ unsafe extern "C" fn PlayerModel_SetMenuItems() {
             crate::src::qcommon::q_shared::Q_strncpyz(
                 modelskin.as_mut_ptr(),
                 buffptr,
-                (pdest.wrapping_offset_from(buffptr) as libc::c_long
+                (pdest.offset_from(buffptr) as libc::c_long
                     + 1 as libc::c_int as libc::c_long) as libc::c_int,
             );
             ::libc::strcat(
@@ -1369,7 +1369,7 @@ unsafe extern "C" fn PlayerModel_SetMenuItems() {
                 s_playermodel.selectedmodel = i;
                 s_playermodel.modelpage = i / (4 as libc::c_int * 4 as libc::c_int);
                 // separate the model name
-                maxlen = pdest.wrapping_offset_from(buffptr) as libc::c_long as libc::c_int;
+                maxlen = pdest.offset_from(buffptr) as libc::c_long as libc::c_int;
                 if maxlen > 16 as libc::c_int {
                     maxlen = 16 as libc::c_int
                 }

--- a/quake3-rs/uix86_64/src/q3_ui/ui_video.rs
+++ b/quake3-rs/uix86_64/src/q3_ui/ui_video.rs
@@ -1364,7 +1364,7 @@ unsafe extern "C" fn GraphicsOptions_GetAspectRatios() {
         crate::src::qcommon::q_shared::Q_strncpyz(
             str.as_mut_ptr(),
             *resolutions.offset(r as isize),
-            x.wrapping_offset_from(*resolutions.offset(r as isize)) as libc::c_long as libc::c_int,
+            x.offset_from(*resolutions.offset(r as isize)) as libc::c_long as libc::c_int,
         );
         w = atoi(str.as_mut_ptr());
         h = atoi(x);

--- a/quake3-rs/uix86_64/src/qcommon/q_shared.rs
+++ b/quake3-rs/uix86_64/src/qcommon/q_shared.rs
@@ -447,11 +447,11 @@ pub unsafe extern "C" fn COM_StripExtension(
         (slash.is_null()) || slash < dot
     } {
         destsize = if (destsize as libc::c_long)
-            < dot.wrapping_offset_from(in_0) as libc::c_long + 1 as libc::c_int as libc::c_long
+            < dot.offset_from(in_0) as libc::c_long + 1 as libc::c_int as libc::c_long
         {
             destsize as libc::c_long
         } else {
-            (dot.wrapping_offset_from(in_0) as libc::c_long) + 1 as libc::c_int as libc::c_long
+            (dot.offset_from(in_0) as libc::c_long) + 1 as libc::c_int as libc::c_long
         } as libc::c_int
     }
     if in_0 == out as *const libc::c_char && destsize > 1 as libc::c_int {
@@ -911,7 +911,7 @@ pub unsafe extern "C" fn COM_Compress(mut data_p: *mut libc::c_char) -> libc::c_
         }
         *out = 0 as libc::c_int as libc::c_char
     }
-    return out.wrapping_offset_from(data_p) as libc::c_long as libc::c_int;
+    return out.offset_from(data_p) as libc::c_long as libc::c_int;
 }
 #[no_mangle]
 pub unsafe extern "C" fn COM_ParseExt(


### PR DESCRIPTION
## Summary
- switch to `ptr_offset_from` feature
- replace deprecated `.wrapping_offset_from()` with `.offset_from()`

## Testing
- `cargo +nightly-2019-12-05 build --release`

------
https://chatgpt.com/codex/tasks/task_e_68536efd8fcc8329beed6d15bc3a5a02