### PR TITLE
Replace asm macro with fully qualified path

### DIFF
--- a/quake3-rs/ioquake3/src/asm/ftola.rs
+++ b/quake3-rs/ioquake3/src/asm/ftola.rs
@@ -29,14 +29,14 @@ static mut fpucw: libc::c_ushort = 0xc7f as libc::c_int as libc::c_ushort;
 
 pub unsafe extern "C" fn qftolsse(mut f: libc::c_float) -> libc::c_long {
     let mut retval: libc::c_long = 0;
-    asm!("cvttss2si $1, $0\n" : "=r" (retval) : "x" (f) : : "volatile");
+    std::arch::asm!("cvttss2si $1, $0\n" : "=r" (retval) : "x" (f) : : "volatile");
     return retval;
 }
 #[no_mangle]
 
 pub unsafe extern "C" fn qvmftolsse() -> libc::c_int {
     let mut retval: libc::c_int = 0;
-    asm!("movss (%rdi, %rbx, 4), %xmm0\ncvttss2si %xmm0, $0\n" : "=r" (retval) : :
+    std::arch::asm!("movss (%rdi, %rbx, 4), %xmm0\ncvttss2si %xmm0, $0\n" : "=r" (retval) : :
      "xmm0" : "volatile");
     return retval;
 }
@@ -45,7 +45,7 @@ pub unsafe extern "C" fn qvmftolsse() -> libc::c_int {
 pub unsafe extern "C" fn qftolx87(mut f: libc::c_float) -> libc::c_long {
     let mut retval: libc::c_long = 0;
     let mut oldcw: libc::c_ushort = 0 as libc::c_int as libc::c_ushort;
-    asm!("fnstcw $2\nfldcw $3\nflds $1\nfistpl $1\nfldcw $2\nmov $1, $0\n" : "=r"
+    std::arch::asm!("fnstcw $2\nfldcw $3\nflds $1\nfistpl $1\nfldcw $2\nmov $1, $0\n" : "=r"
      (retval) : "*m" (&f), "*m" (&oldcw), "*m" (&fpucw) : : "volatile");
     return retval;
 }
@@ -54,7 +54,7 @@ pub unsafe extern "C" fn qftolx87(mut f: libc::c_float) -> libc::c_long {
 pub unsafe extern "C" fn qvmftolx87() -> libc::c_int {
     let mut retval: libc::c_int = 0;
     let mut oldcw: libc::c_ushort = 0 as libc::c_int as libc::c_ushort;
-    asm!("fnstcw $1\nfldcw $2\nflds (%rdi, %rbx, 4)\nfistpl (%rdi, %rbx, 4)\nfldcw $1\nmov (%rdi, %rbx, 4), $0\n"
+    std::arch::asm!("fnstcw $1\nfldcw $2\nflds (%rdi, %rbx, 4)\nfistpl (%rdi, %rbx, 4)\nfldcw $1\nmov (%rdi, %rbx, 4), $0\n"
      : "=r" (retval) : "*m" (&oldcw), "*m" (&fpucw) : : "volatile");
     return retval;
 }

--- a/quake3-rs/ioquake3/src/asm/snapvector.rs
+++ b/quake3-rs/ioquake3/src/asm/snapvector.rs
@@ -123,13 +123,13 @@ MATHLIB
 #[no_mangle]
 
 pub unsafe extern "C" fn qsnapvectorsse(mut vec: *mut crate::src::qcommon::q_shared::vec_t) {
-    asm!("movaps ($0), %xmm1\nmovups ($1), %xmm0\nmovaps %xmm0, %xmm2\nandps %xmm1, %xmm0\nandnps %xmm2, %xmm1\ncvtps2dq %xmm0, %xmm0\ncvtdq2ps %xmm0, %xmm0\norps %xmm1, %xmm0\nmovups %xmm0, ($1)\n"
+    std::arch::asm!("movaps ($0), %xmm1\nmovups ($1), %xmm0\nmovaps %xmm0, %xmm2\nandps %xmm1, %xmm0\nandnps %xmm2, %xmm1\ncvtps2dq %xmm0, %xmm0\ncvtdq2ps %xmm0, %xmm0\norps %xmm1, %xmm0\nmovups %xmm0, ($1)\n"
      : : "r" (ssemask.0.as_mut_ptr()), "r" (vec) : "memory", "xmm0", "xmm1",
      "xmm2" : "volatile");
 }
 #[no_mangle]
 
 pub unsafe extern "C" fn qsnapvectorx87(mut vec: *mut crate::src::qcommon::q_shared::vec_t) {
-    asm!("flds ($0)\nfistpl ($0)\nfildl ($0)\nfstps ($0)\nflds 4($0)\nfistpl 4($0)\nfildl 4($0)\nfstps 4($0)\nflds 8($0)\nfistpl 8($0)\nfildl 8($0)\nfstps 8($0)\n"
+    std::arch::asm!("flds ($0)\nfistpl ($0)\nfildl ($0)\nfstps ($0)\nflds 4($0)\nfistpl 4($0)\nfildl 4($0)\nfstps 4($0)\nflds 8($0)\nfistpl 8($0)\nfildl 8($0)\nfstps 8($0)\n"
      : : "r" (vec) : "memory" : "volatile");
 }

--- a/quake3-rs/ioquake3/src/qcommon/net_ip.rs
+++ b/quake3-rs/ioquake3/src/qcommon/net_ip.rs
@@ -2435,7 +2435,7 @@ pub unsafe extern "C" fn NET_Sleep(mut msec: libc::c_int) {
         .__fds_bits
         .as_mut_ptr()
         .offset(0 as libc::c_int as isize) as *mut crate::stdlib::__fd_mask;
-    asm!("cld; rep; stosq" : "={cx}" (fresh1), "={di}" (fresh3) : "{ax}"
+    std::arch::asm!("cld; rep; stosq" : "={cx}" (fresh1), "={di}" (fresh3) : "{ax}"
      (0 as libc::c_int), "0"
      (c2rust_asm_casts::AsmCast::cast_in(fresh0, fresh4)), "1"
      (c2rust_asm_casts::AsmCast::cast_in(fresh2, fresh5)) : "memory" :

--- a/quake3-rs/ioquake3/src/qcommon/vm_x86.rs
+++ b/quake3-rs/ioquake3/src/qcommon/vm_x86.rs
@@ -2010,7 +2010,7 @@ pub unsafe extern "C" fn VM_CallCompiled(
         as *mut libc::c_void as *mut libc::c_int;
     *opStack = 0xdeadbeef as libc::c_uint as libc::c_int;
     opStackOfs = 0 as libc::c_int;
-    asm!("movq $5, %rax\nmovq $3, %r8\nmovq $4, %r9\npush %r15\npush %r14\npush %r13\npush %r12\ncallq *%rax\npop %r12\npop %r13\npop %r14\npop %r15\n"
+    std::arch::asm!("movq $5, %rax\nmovq $3, %r8\nmovq $4, %r9\npush %r15\npush %r14\npush %r13\npush %r12\ncallq *%rax\npop %r12\npop %r13\npop %r14\npop %r15\n"
      : "+{si}" (programStack), "+{di}" (opStack), "+{bx}" (opStackOfs) : "imr"
      ((*vm).instructionPointers), "imr" ((*vm).dataBase), "imr" (entryPoint) :
      "cc", "memory", "rax", "rcx", "rdx", "r8", "r9", "r10", "r11" :

--- a/quake3-rs/ioquake3/src/sys/con_tty.rs
+++ b/quake3-rs/ioquake3/src/sys/con_tty.rs
@@ -651,11 +651,11 @@ pub unsafe extern "C" fn CON_Input() -> *mut libc::c_char {
                 .as_mut_ptr()
                 .offset(0 as libc::c_int as isize)
                 as *mut crate::stdlib::__fd_mask;
-            asm!("cld; rep; stosq" : "={cx}" (fresh1), "={di}" (fresh3) : "{ax}"
-     (0 as libc::c_int), "0"
-     (c2rust_asm_casts::AsmCast::cast_in(fresh0, fresh4)), "1"
-     (c2rust_asm_casts::AsmCast::cast_in(fresh2, fresh5)) : "memory" :
-     "volatile");
+            std::arch::asm!("cld; rep; stosq" : "={cx}" (fresh1), "={di}" (fresh3) : "{ax}"
+             (0 as libc::c_int), "0"
+             (c2rust_asm_casts::AsmCast::cast_in(fresh0, fresh4)), "1"
+             (c2rust_asm_casts::AsmCast::cast_in(fresh2, fresh5)) : "memory" :
+             "volatile");
             c2rust_asm_casts::AsmCast::cast_out(fresh0, fresh4, fresh1);
             c2rust_asm_casts::AsmCast::cast_out(fresh2, fresh5, fresh3);
             fdset.__fds_bits[(0 as libc::c_int

--- a/quake3-rs/ioquake3/src/sys/sys_unix.rs
+++ b/quake3-rs/ioquake3/src/sys/sys_unix.rs
@@ -13134,7 +13134,7 @@ pub unsafe extern "C" fn Sys_Sleep(mut msec: libc::c_int) {
             .as_mut_ptr()
             .offset(0 as libc::c_int as isize)
             as *mut crate::stdlib::__fd_mask;
-        asm!("cld; rep; stosq" : "={cx}" (fresh6), "={di}" (fresh8) : "{ax}"
+        std::arch::asm!("cld; rep; stosq" : "={cx}" (fresh6), "={di}" (fresh8) : "{ax}"
      (0 as libc::c_int), "0"
      (c2rust_asm_casts::AsmCast::cast_in(fresh5, fresh9)), "1"
      (c2rust_asm_casts::AsmCast::cast_in(fresh7, fresh10)) : "memory" :


### PR DESCRIPTION
## Summary
- use `std::arch::asm!` everywhere instead of the plain `asm!` macro

## Testing
- `cargo +nightly-2019-12-05 build --release` *(fails: use of unstable features)*

------
https://chatgpt.com/codex/tasks/task_e_685376e13bb88329a9c7e2c04fe2d78a