### PR TITLE
Remove unnecessary module prefixes

### DIFF
--- a/quake3-rs/cgamex86_64/src/cgame/cg_consolecmds.rs
+++ b/quake3-rs/cgamex86_64/src/cgame/cg_consolecmds.rs
@@ -121,16 +121,16 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 pub unsafe extern "C" fn CG_TargetCommand_f() {
     let mut targetNum: libc::c_int = 0;
     let mut test: [libc::c_char; 4] = [0; 4];
-    targetNum = crate::src::cgame::cg_main::CG_CrosshairPlayer();
+    targetNum = CG_CrosshairPlayer();
     if targetNum == -(1 as libc::c_int) {
         return;
     }
-    crate::src::cgame::cg_syscalls::trap_Argv(
+    trap_Argv(
         1 as libc::c_int,
         test.as_mut_ptr(),
         4 as libc::c_int,
     );
-    crate::src::cgame::cg_syscalls::trap_SendClientCommand(crate::src::qcommon::q_shared::va(
+    trap_SendClientCommand(va(
         b"gc %i %i\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         targetNum,
         atoi(test.as_mut_ptr()),
@@ -145,11 +145,11 @@ Keybinding command
 */
 
 unsafe extern "C" fn CG_SizeUp_f() {
-    crate::src::cgame::cg_syscalls::trap_Cvar_Set(
+    trap_Cvar_Set(
         b"cg_viewsize\x00" as *const u8 as *const libc::c_char,
-        crate::src::qcommon::q_shared::va(
+        va(
             b"%i\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-            crate::src::cgame::cg_main::cg_viewsize.integer + 10 as libc::c_int,
+            cg_viewsize.integer + 10 as libc::c_int,
         ),
     );
 }
@@ -162,11 +162,11 @@ Keybinding command
 */
 
 unsafe extern "C" fn CG_SizeDown_f() {
-    crate::src::cgame::cg_syscalls::trap_Cvar_Set(
+    trap_Cvar_Set(
         b"cg_viewsize\x00" as *const u8 as *const libc::c_char,
-        crate::src::qcommon::q_shared::va(
+        va(
             b"%i\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-            crate::src::cgame::cg_main::cg_viewsize.integer - 10 as libc::c_int,
+            cg_viewsize.integer - 10 as libc::c_int,
         ),
     );
 }
@@ -179,42 +179,42 @@ Debugging command to print the current position
 */
 
 unsafe extern "C" fn CG_Viewpos_f() {
-    crate::src::cgame::cg_main::CG_Printf(
+    CG_Printf(
         b"(%i %i %i) : %i\n\x00" as *const u8 as *const libc::c_char,
-        crate::src::cgame::cg_main::cg.refdef.vieworg[0 as libc::c_int as usize] as libc::c_int,
-        crate::src::cgame::cg_main::cg.refdef.vieworg[1 as libc::c_int as usize] as libc::c_int,
-        crate::src::cgame::cg_main::cg.refdef.vieworg[2 as libc::c_int as usize] as libc::c_int,
-        crate::src::cgame::cg_main::cg.refdefViewAngles[1 as libc::c_int as usize] as libc::c_int,
+        cg.refdef.vieworg[0 as libc::c_int as usize] as libc::c_int,
+        cg.refdef.vieworg[1 as libc::c_int as usize] as libc::c_int,
+        cg.refdef.vieworg[2 as libc::c_int as usize] as libc::c_int,
+        cg.refdefViewAngles[1 as libc::c_int as usize] as libc::c_int,
     );
 }
 
 unsafe extern "C" fn CG_ScoresDown_f() {
-    if (crate::src::cgame::cg_main::cg.scoresRequestTime + 2000 as libc::c_int)
-        < crate::src::cgame::cg_main::cg.time
+    if (cg.scoresRequestTime + 2000 as libc::c_int)
+        < cg.time
     {
         // the scores are more than two seconds out of data,
         // so request new ones
-        crate::src::cgame::cg_main::cg.scoresRequestTime = crate::src::cgame::cg_main::cg.time;
-        crate::src::cgame::cg_syscalls::trap_SendClientCommand(
+        cg.scoresRequestTime = cg.time;
+        trap_SendClientCommand(
             b"score\x00" as *const u8 as *const libc::c_char,
         );
         // leave the current scores up if they were already
         // displayed, but if this is the first hit, clear them out
-        if crate::src::cgame::cg_main::cg.showScores as u64 == 0 {
-            crate::src::cgame::cg_main::cg.showScores = crate::src::qcommon::q_shared::qtrue;
-            crate::src::cgame::cg_main::cg.numScores = 0 as libc::c_int
+        if cg.showScores as u64 == 0 {
+            cg.showScores = qtrue;
+            cg.numScores = 0 as libc::c_int
         }
     } else {
         // show the cached contents even if they just pressed if it
         // is within two seconds
-        crate::src::cgame::cg_main::cg.showScores = crate::src::qcommon::q_shared::qtrue
+        cg.showScores = qtrue
     };
 }
 
 unsafe extern "C" fn CG_ScoresUp_f() {
-    if crate::src::cgame::cg_main::cg.showScores as u64 != 0 {
-        crate::src::cgame::cg_main::cg.showScores = crate::src::qcommon::q_shared::qfalse;
-        crate::src::cgame::cg_main::cg.scoreFadeTime = crate::src::cgame::cg_main::cg.time
+    if cg.showScores as u64 != 0 {
+        cg.showScores = qfalse;
+        cg.scoreFadeTime = cg.time
     };
 }
 
@@ -222,38 +222,38 @@ unsafe extern "C" fn CG_TellTarget_f() {
     let mut clientNum: libc::c_int = 0;
     let mut command: [libc::c_char; 128] = [0; 128];
     let mut message: [libc::c_char; 128] = [0; 128];
-    clientNum = crate::src::cgame::cg_main::CG_CrosshairPlayer();
+    clientNum = CG_CrosshairPlayer();
     if clientNum == -(1 as libc::c_int) {
         return;
     }
-    crate::src::cgame::cg_syscalls::trap_Args(message.as_mut_ptr(), 128 as libc::c_int);
-    crate::src::qcommon::q_shared::Com_sprintf(
+    trap_Args(message.as_mut_ptr(), 128 as libc::c_int);
+    Com_sprintf(
         command.as_mut_ptr(),
         128 as libc::c_int,
         b"tell %i %s\x00" as *const u8 as *const libc::c_char,
         clientNum,
         message.as_mut_ptr(),
     );
-    crate::src::cgame::cg_syscalls::trap_SendClientCommand(command.as_mut_ptr());
+    trap_SendClientCommand(command.as_mut_ptr());
 }
 
 unsafe extern "C" fn CG_TellAttacker_f() {
     let mut clientNum: libc::c_int = 0;
     let mut command: [libc::c_char; 128] = [0; 128];
     let mut message: [libc::c_char; 128] = [0; 128];
-    clientNum = crate::src::cgame::cg_main::CG_LastAttacker();
+    clientNum = CG_LastAttacker();
     if clientNum == -(1 as libc::c_int) {
         return;
     }
-    crate::src::cgame::cg_syscalls::trap_Args(message.as_mut_ptr(), 128 as libc::c_int);
-    crate::src::qcommon::q_shared::Com_sprintf(
+    trap_Args(message.as_mut_ptr(), 128 as libc::c_int);
+    Com_sprintf(
         command.as_mut_ptr(),
         128 as libc::c_int,
         b"tell %i %s\x00" as *const u8 as *const libc::c_char,
         clientNum,
         message.as_mut_ptr(),
     );
-    crate::src::cgame::cg_syscalls::trap_SendClientCommand(command.as_mut_ptr());
+    trap_SendClientCommand(command.as_mut_ptr());
 }
 /*
 ==================
@@ -263,7 +263,7 @@ CG_StartOrbit_f
 
 unsafe extern "C" fn CG_StartOrbit_f() {
     let mut var: [libc::c_char; 1024] = [0; 1024];
-    crate::src::cgame::cg_syscalls::trap_Cvar_VariableStringBuffer(
+    trap_Cvar_VariableStringBuffer(
         b"developer\x00" as *const u8 as *const libc::c_char,
         var.as_mut_ptr(),
         ::std::mem::size_of::<[libc::c_char; 1024]>() as libc::c_ulong as libc::c_int,
@@ -271,29 +271,29 @@ unsafe extern "C" fn CG_StartOrbit_f() {
     if atoi(var.as_mut_ptr()) == 0 {
         return;
     }
-    if crate::src::cgame::cg_main::cg_cameraOrbit.value != 0 as libc::c_int as libc::c_float {
-        crate::src::cgame::cg_syscalls::trap_Cvar_Set(
+    if cg_cameraOrbit.value != 0 as libc::c_int as libc::c_float {
+        trap_Cvar_Set(
             b"cg_cameraOrbit\x00" as *const u8 as *const libc::c_char,
             b"0\x00" as *const u8 as *const libc::c_char,
         );
-        crate::src::cgame::cg_syscalls::trap_Cvar_Set(
+        trap_Cvar_Set(
             b"cg_thirdPerson\x00" as *const u8 as *const libc::c_char,
             b"0\x00" as *const u8 as *const libc::c_char,
         );
     } else {
-        crate::src::cgame::cg_syscalls::trap_Cvar_Set(
+        trap_Cvar_Set(
             b"cg_cameraOrbit\x00" as *const u8 as *const libc::c_char,
             b"5\x00" as *const u8 as *const libc::c_char,
         );
-        crate::src::cgame::cg_syscalls::trap_Cvar_Set(
+        trap_Cvar_Set(
             b"cg_thirdPerson\x00" as *const u8 as *const libc::c_char,
             b"1\x00" as *const u8 as *const libc::c_char,
         );
-        crate::src::cgame::cg_syscalls::trap_Cvar_Set(
+        trap_Cvar_Set(
             b"cg_thirdPersonAngle\x00" as *const u8 as *const libc::c_char,
             b"0\x00" as *const u8 as *const libc::c_char,
         );
-        crate::src::cgame::cg_syscalls::trap_Cvar_Set(
+        trap_Cvar_Set(
             b"cg_thirdPersonRange\x00" as *const u8 as *const libc::c_char,
             b"100\x00" as *const u8 as *const libc::c_char,
         );
@@ -306,7 +306,7 @@ static mut commands: [consoleCommand_t; 21] = {
             let mut init = consoleCommand_t {
                 cmd: b"testgun\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 function: Some(
-                    crate::src::cgame::cg_view::CG_TestGun_f as unsafe extern "C" fn() -> (),
+                    CG_TestGun_f as unsafe extern "C" fn() -> (),
                 ),
             };
             init
@@ -315,7 +315,7 @@ static mut commands: [consoleCommand_t; 21] = {
             let mut init = consoleCommand_t {
                 cmd: b"testmodel\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 function: Some(
-                    crate::src::cgame::cg_view::CG_TestModel_f as unsafe extern "C" fn() -> (),
+                    CG_TestModel_f as unsafe extern "C" fn() -> (),
                 ),
             };
             init
@@ -324,7 +324,7 @@ static mut commands: [consoleCommand_t; 21] = {
             let mut init = consoleCommand_t {
                 cmd: b"nextframe\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 function: Some(
-                    crate::src::cgame::cg_view::CG_TestModelNextFrame_f
+                    CG_TestModelNextFrame_f
                         as unsafe extern "C" fn() -> (),
                 ),
             };
@@ -334,7 +334,7 @@ static mut commands: [consoleCommand_t; 21] = {
             let mut init = consoleCommand_t {
                 cmd: b"prevframe\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 function: Some(
-                    crate::src::cgame::cg_view::CG_TestModelPrevFrame_f
+                    CG_TestModelPrevFrame_f
                         as unsafe extern "C" fn() -> (),
                 ),
             };
@@ -344,7 +344,7 @@ static mut commands: [consoleCommand_t; 21] = {
             let mut init = consoleCommand_t {
                 cmd: b"nextskin\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 function: Some(
-                    crate::src::cgame::cg_view::CG_TestModelNextSkin_f
+                    CG_TestModelNextSkin_f
                         as unsafe extern "C" fn() -> (),
                 ),
             };
@@ -354,7 +354,7 @@ static mut commands: [consoleCommand_t; 21] = {
             let mut init = consoleCommand_t {
                 cmd: b"prevskin\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 function: Some(
-                    crate::src::cgame::cg_view::CG_TestModelPrevSkin_f
+                    CG_TestModelPrevSkin_f
                         as unsafe extern "C" fn() -> (),
                 ),
             };
@@ -385,7 +385,7 @@ static mut commands: [consoleCommand_t; 21] = {
             let mut init = consoleCommand_t {
                 cmd: b"+zoom\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 function: Some(
-                    crate::src::cgame::cg_view::CG_ZoomDown_f as unsafe extern "C" fn() -> (),
+                    CG_ZoomDown_f as unsafe extern "C" fn() -> (),
                 ),
             };
             init
@@ -394,7 +394,7 @@ static mut commands: [consoleCommand_t; 21] = {
             let mut init = consoleCommand_t {
                 cmd: b"-zoom\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 function: Some(
-                    crate::src::cgame::cg_view::CG_ZoomUp_f as unsafe extern "C" fn() -> (),
+                    CG_ZoomUp_f as unsafe extern "C" fn() -> (),
                 ),
             };
             init
@@ -417,7 +417,7 @@ static mut commands: [consoleCommand_t; 21] = {
             let mut init = consoleCommand_t {
                 cmd: b"weapnext\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 function: Some(
-                    crate::src::cgame::cg_weapons::CG_NextWeapon_f as unsafe extern "C" fn() -> (),
+                    CG_NextWeapon_f as unsafe extern "C" fn() -> (),
                 ),
             };
             init
@@ -426,7 +426,7 @@ static mut commands: [consoleCommand_t; 21] = {
             let mut init = consoleCommand_t {
                 cmd: b"weapprev\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 function: Some(
-                    crate::src::cgame::cg_weapons::CG_PrevWeapon_f as unsafe extern "C" fn() -> (),
+                    CG_PrevWeapon_f as unsafe extern "C" fn() -> (),
                 ),
             };
             init
@@ -435,7 +435,7 @@ static mut commands: [consoleCommand_t; 21] = {
             let mut init = consoleCommand_t {
                 cmd: b"weapon\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 function: Some(
-                    crate::src::cgame::cg_weapons::CG_Weapon_f as unsafe extern "C" fn() -> (),
+                    CG_Weapon_f as unsafe extern "C" fn() -> (),
                 ),
             };
             init
@@ -472,7 +472,7 @@ static mut commands: [consoleCommand_t; 21] = {
             let mut init = consoleCommand_t {
                 cmd: b"loaddeferred\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 function: Some(
-                    crate::src::cgame::cg_players::CG_LoadDeferredPlayers
+                    CG_LoadDeferredPlayers
                         as unsafe extern "C" fn() -> (),
                 ),
             };
@@ -490,24 +490,24 @@ Cmd_Argc() / Cmd_Argv()
 */
 #[no_mangle]
 
-pub unsafe extern "C" fn CG_ConsoleCommand() -> crate::src::qcommon::q_shared::qboolean {
+pub unsafe extern "C" fn CG_ConsoleCommand() -> qboolean {
     let mut cmd: *const libc::c_char = 0 as *const libc::c_char;
     let mut i: libc::c_int = 0;
-    cmd = crate::src::cgame::cg_main::CG_Argv(0 as libc::c_int);
+    cmd = CG_Argv(0 as libc::c_int);
     i = 0 as libc::c_int;
     while (i as libc::c_ulong)
         < (::std::mem::size_of::<[consoleCommand_t; 21]>() as libc::c_ulong)
             .wrapping_div(::std::mem::size_of::<consoleCommand_t>() as libc::c_ulong)
     {
-        if crate::src::qcommon::q_shared::Q_stricmp(cmd, commands[i as usize].cmd) == 0 {
+        if Q_stricmp(cmd, commands[i as usize].cmd) == 0 {
             commands[i as usize]
                 .function
                 .expect("non-null function pointer")();
-            return crate::src::qcommon::q_shared::qtrue;
+            return qtrue;
         }
         i += 1
     }
-    return crate::src::qcommon::q_shared::qfalse;
+    return qfalse;
 }
 /*
 ===========================================================================
@@ -774,76 +774,76 @@ pub unsafe extern "C" fn CG_InitConsoleCommands() {
         < (::std::mem::size_of::<[consoleCommand_t; 21]>() as libc::c_ulong)
             .wrapping_div(::std::mem::size_of::<consoleCommand_t>() as libc::c_ulong)
     {
-        crate::src::cgame::cg_syscalls::trap_AddCommand(commands[i as usize].cmd);
+        trap_AddCommand(commands[i as usize].cmd);
         i += 1
     }
     //
     // the game server will interpret these commands, which will be automatically
     // forwarded to the server after they are not recognized locally
     //
-    crate::src::cgame::cg_syscalls::trap_AddCommand(
+    trap_AddCommand(
         b"kill\x00" as *const u8 as *const libc::c_char,
     );
-    crate::src::cgame::cg_syscalls::trap_AddCommand(b"say\x00" as *const u8 as *const libc::c_char);
-    crate::src::cgame::cg_syscalls::trap_AddCommand(
+    trap_AddCommand(b"say\x00" as *const u8 as *const libc::c_char);
+    trap_AddCommand(
         b"say_team\x00" as *const u8 as *const libc::c_char,
     );
-    crate::src::cgame::cg_syscalls::trap_AddCommand(
+    trap_AddCommand(
         b"tell\x00" as *const u8 as *const libc::c_char,
     );
-    crate::src::cgame::cg_syscalls::trap_AddCommand(
+    trap_AddCommand(
         b"give\x00" as *const u8 as *const libc::c_char,
     );
-    crate::src::cgame::cg_syscalls::trap_AddCommand(b"god\x00" as *const u8 as *const libc::c_char);
-    crate::src::cgame::cg_syscalls::trap_AddCommand(
+    trap_AddCommand(b"god\x00" as *const u8 as *const libc::c_char);
+    trap_AddCommand(
         b"notarget\x00" as *const u8 as *const libc::c_char,
     );
-    crate::src::cgame::cg_syscalls::trap_AddCommand(
+    trap_AddCommand(
         b"noclip\x00" as *const u8 as *const libc::c_char,
     );
-    crate::src::cgame::cg_syscalls::trap_AddCommand(
+    trap_AddCommand(
         b"where\x00" as *const u8 as *const libc::c_char,
     );
-    crate::src::cgame::cg_syscalls::trap_AddCommand(
+    trap_AddCommand(
         b"team\x00" as *const u8 as *const libc::c_char,
     );
-    crate::src::cgame::cg_syscalls::trap_AddCommand(
+    trap_AddCommand(
         b"follow\x00" as *const u8 as *const libc::c_char,
     );
-    crate::src::cgame::cg_syscalls::trap_AddCommand(
+    trap_AddCommand(
         b"follownext\x00" as *const u8 as *const libc::c_char,
     );
-    crate::src::cgame::cg_syscalls::trap_AddCommand(
+    trap_AddCommand(
         b"followprev\x00" as *const u8 as *const libc::c_char,
     );
-    crate::src::cgame::cg_syscalls::trap_AddCommand(
+    trap_AddCommand(
         b"levelshot\x00" as *const u8 as *const libc::c_char,
     );
-    crate::src::cgame::cg_syscalls::trap_AddCommand(
+    trap_AddCommand(
         b"addbot\x00" as *const u8 as *const libc::c_char,
     );
-    crate::src::cgame::cg_syscalls::trap_AddCommand(
+    trap_AddCommand(
         b"setviewpos\x00" as *const u8 as *const libc::c_char,
     );
-    crate::src::cgame::cg_syscalls::trap_AddCommand(
+    trap_AddCommand(
         b"callvote\x00" as *const u8 as *const libc::c_char,
     );
-    crate::src::cgame::cg_syscalls::trap_AddCommand(
+    trap_AddCommand(
         b"vote\x00" as *const u8 as *const libc::c_char,
     );
-    crate::src::cgame::cg_syscalls::trap_AddCommand(
+    trap_AddCommand(
         b"callteamvote\x00" as *const u8 as *const libc::c_char,
     );
-    crate::src::cgame::cg_syscalls::trap_AddCommand(
+    trap_AddCommand(
         b"teamvote\x00" as *const u8 as *const libc::c_char,
     );
-    crate::src::cgame::cg_syscalls::trap_AddCommand(
+    trap_AddCommand(
         b"stats\x00" as *const u8 as *const libc::c_char,
     );
-    crate::src::cgame::cg_syscalls::trap_AddCommand(
+    trap_AddCommand(
         b"teamtask\x00" as *const u8 as *const libc::c_char,
     );
-    crate::src::cgame::cg_syscalls::trap_AddCommand(
+    trap_AddCommand(
         b"loaddefered\x00" as *const u8 as *const libc::c_char,
     );
     // spelled wrong, but not changing for demo

--- a/quake3-rs/cgamex86_64/src/cgame/cg_draw.rs
+++ b/quake3-rs/cgamex86_64/src/cgame/cg_draw.rs
@@ -385,7 +385,7 @@ unsafe extern "C" fn CG_DrawField(
         }
         _ => {}
     }
-    crate::src::qcommon::q_shared::Com_sprintf(
+    Com_sprintf(
         num.as_mut_ptr(),
         ::std::mem::size_of::<[libc::c_char; 16]>() as libc::c_ulong as libc::c_int,
         b"%i\x00" as *const u8 as *const libc::c_char,
@@ -403,12 +403,12 @@ unsafe extern "C" fn CG_DrawField(
         } else {
             frame = *ptr as libc::c_int - '0' as i32
         }
-        crate::src::cgame::cg_drawtools::CG_DrawPic(
+        CG_DrawPic(
             x as libc::c_float,
             y as libc::c_float,
             32 as libc::c_int as libc::c_float,
             48 as libc::c_int as libc::c_float,
-            crate::src::cgame::cg_main::cgs.media.numberShaders[frame as usize],
+            cgs.media.numberShaders[frame as usize],
         );
         x += 32 as libc::c_int;
         ptr = ptr.offset(1);
@@ -429,12 +429,12 @@ pub unsafe extern "C" fn CG_Draw3DModel(
     mut y: libc::c_float,
     mut w: libc::c_float,
     mut h: libc::c_float,
-    mut model: crate::src::qcommon::q_shared::qhandle_t,
-    mut skin: crate::src::qcommon::q_shared::qhandle_t,
-    mut origin: *mut crate::src::qcommon::q_shared::vec_t,
-    mut angles: *mut crate::src::qcommon::q_shared::vec_t,
+    mut model: qhandle_t,
+    mut skin: qhandle_t,
+    mut origin: *mut vec_t,
+    mut angles: *mut vec_t,
 ) {
-    let mut refdef: crate::tr_types_h::refdef_t = crate::tr_types_h::refdef_t {
+    let mut refdef: refdef_t = refdef_t {
         x: 0,
         y: 0,
         width: 0,
@@ -448,14 +448,14 @@ pub unsafe extern "C" fn CG_Draw3DModel(
         areamask: [0; 32],
         text: [[0; 32]; 8],
     }; // no stencil shadows
-    let mut ent: crate::tr_types_h::refEntity_t = crate::tr_types_h::refEntity_t {
-        reType: crate::tr_types_h::RT_MODEL,
+    let mut ent: refEntity_t = refEntity_t {
+        reType: RT_MODEL,
         renderfx: 0,
         hModel: 0,
         lightingOrigin: [0.; 3],
         shadowPlane: 0.,
         axis: [[0.; 3]; 3],
-        nonNormalizedAxes: crate::src::qcommon::q_shared::qfalse,
+        nonNormalizedAxes: qfalse,
         origin: [0.; 3],
         frame: 0,
         oldorigin: [0.; 3],
@@ -470,24 +470,24 @@ pub unsafe extern "C" fn CG_Draw3DModel(
         radius: 0.,
         rotation: 0.,
     };
-    if crate::src::cgame::cg_main::cg_draw3dIcons.integer == 0
-        || crate::src::cgame::cg_main::cg_drawIcons.integer == 0
+    if cg_draw3dIcons.integer == 0
+        || cg_drawIcons.integer == 0
     {
         return;
     }
-    crate::src::cgame::cg_drawtools::CG_AdjustFrom640(&mut x, &mut y, &mut w, &mut h);
+    CG_AdjustFrom640(&mut x, &mut y, &mut w, &mut h);
     crate::stdlib::memset(
-        &mut refdef as *mut crate::tr_types_h::refdef_t as *mut libc::c_void,
+        &mut refdef as *mut refdef_t as *mut libc::c_void,
         0 as libc::c_int,
-        ::std::mem::size_of::<crate::tr_types_h::refdef_t>() as libc::c_ulong,
+        ::std::mem::size_of::<refdef_t>() as libc::c_ulong,
     );
     crate::stdlib::memset(
-        &mut ent as *mut crate::tr_types_h::refEntity_t as *mut libc::c_void,
+        &mut ent as *mut refEntity_t as *mut libc::c_void,
         0 as libc::c_int,
-        ::std::mem::size_of::<crate::tr_types_h::refEntity_t>() as libc::c_ulong,
+        ::std::mem::size_of::<refEntity_t>() as libc::c_ulong,
     );
-    crate::src::qcommon::q_math::AnglesToAxis(
-        angles as *const crate::src::qcommon::q_shared::vec_t,
+    AnglesToAxis(
+        angles as *const vec_t,
         ent.axis.as_mut_ptr(),
     );
     ent.origin[0 as libc::c_int as usize] = *origin.offset(0 as libc::c_int as isize);
@@ -497,20 +497,20 @@ pub unsafe extern "C" fn CG_Draw3DModel(
     ent.customSkin = skin;
     ent.renderfx = 0x40 as libc::c_int;
     refdef.rdflags = 0x1 as libc::c_int;
-    crate::src::qcommon::q_math::AxisClear(refdef.viewaxis.as_mut_ptr());
+    AxisClear(refdef.viewaxis.as_mut_ptr());
     refdef.fov_x = 30 as libc::c_int as libc::c_float;
     refdef.fov_y = 30 as libc::c_int as libc::c_float;
     refdef.x = x as libc::c_int;
     refdef.y = y as libc::c_int;
     refdef.width = w as libc::c_int;
     refdef.height = h as libc::c_int;
-    refdef.time = crate::src::cgame::cg_main::cg.time;
+    refdef.time = cg.time;
     crate::src::cgame::cg_syscalls::trap_R_ClearScene();
     crate::src::cgame::cg_syscalls::trap_R_AddRefEntityToScene(
-        &mut ent as *mut _ as *const crate::tr_types_h::refEntity_t,
+        &mut ent as *mut _ as *const refEntity_t,
     );
     crate::src::cgame::cg_syscalls::trap_R_RenderScene(
-        &mut refdef as *mut _ as *const crate::tr_types_h::refdef_t,
+        &mut refdef as *mut _ as *const refdef_t,
     );
 }
 /*
@@ -528,19 +528,19 @@ pub unsafe extern "C" fn CG_DrawHead(
     mut w: libc::c_float,
     mut h: libc::c_float,
     mut clientNum: libc::c_int,
-    mut headAngles: *mut crate::src::qcommon::q_shared::vec_t,
+    mut headAngles: *mut vec_t,
 ) {
-    let mut cm: crate::src::qcommon::q_shared::clipHandle_t = 0;
+    let mut cm: clipHandle_t = 0;
     let mut ci: *mut crate::cg_local_h::clientInfo_t = 0 as *mut crate::cg_local_h::clientInfo_t;
     let mut len: libc::c_float = 0.;
-    let mut origin: crate::src::qcommon::q_shared::vec3_t = [0.; 3];
-    let mut mins: crate::src::qcommon::q_shared::vec3_t = [0.; 3];
-    let mut maxs: crate::src::qcommon::q_shared::vec3_t = [0.; 3];
-    ci = &mut *crate::src::cgame::cg_main::cgs
+    let mut origin: vec3_t = [0.; 3];
+    let mut mins: vec3_t = [0.; 3];
+    let mut maxs: vec3_t = [0.; 3];
+    ci = &mut *cgs
         .clientinfo
         .as_mut_ptr()
         .offset(clientNum as isize) as *mut crate::cg_local_h::clientInfo_t;
-    if crate::src::cgame::cg_main::cg_draw3dIcons.integer != 0 {
+    if cg_draw3dIcons.integer != 0 {
         cm = (*ci).headModel;
         if cm == 0 {
             return;
@@ -553,17 +553,17 @@ pub unsafe extern "C" fn CG_DrawHead(
         );
         origin[2 as libc::c_int as usize] = (-0.5f64
             * (mins[2 as libc::c_int as usize] + maxs[2 as libc::c_int as usize]) as libc::c_double)
-            as crate::src::qcommon::q_shared::vec_t;
+            as vec_t;
         origin[1 as libc::c_int as usize] = (0.5f64
             * (mins[1 as libc::c_int as usize] + maxs[1 as libc::c_int as usize]) as libc::c_double)
-            as crate::src::qcommon::q_shared::vec_t;
+            as vec_t;
         // calculate distance so the head nearly fills the box
         // assume heads are taller than wide
         len = (0.7f64
             * (maxs[2 as libc::c_int as usize] - mins[2 as libc::c_int as usize]) as libc::c_double)
             as libc::c_float; // len / tan( fov/2 )
         origin[0 as libc::c_int as usize] =
-            (len as libc::c_double / 0.268f64) as crate::src::qcommon::q_shared::vec_t;
+            (len as libc::c_double / 0.268f64) as vec_t;
         // allow per-model tweaking
         origin[0 as libc::c_int as usize] =
             origin[0 as libc::c_int as usize] + (*ci).headOffset[0 as libc::c_int as usize];
@@ -581,17 +581,17 @@ pub unsafe extern "C" fn CG_DrawHead(
             origin.as_mut_ptr(),
             headAngles,
         );
-    } else if crate::src::cgame::cg_main::cg_drawIcons.integer != 0 {
-        crate::src::cgame::cg_drawtools::CG_DrawPic(x, y, w, h, (*ci).modelIcon);
+    } else if cg_drawIcons.integer != 0 {
+        CG_DrawPic(x, y, w, h, (*ci).modelIcon);
     }
     // if they are deferred, draw a cross out
     if (*ci).deferred as u64 != 0 {
-        crate::src::cgame::cg_drawtools::CG_DrawPic(
+        CG_DrawPic(
             x,
             y,
             w,
             h,
-            crate::src::cgame::cg_main::cgs.media.deferShader,
+            cgs.media.deferShader,
         );
     };
 }
@@ -610,21 +610,21 @@ pub unsafe extern "C" fn CG_DrawFlagModel(
     mut w: libc::c_float,
     mut h: libc::c_float,
     mut team: libc::c_int,
-    mut force2D: crate::src::qcommon::q_shared::qboolean,
+    mut force2D: qboolean,
 ) {
-    let mut cm: crate::src::qcommon::q_shared::qhandle_t = 0;
+    let mut cm: qhandle_t = 0;
     let mut len: libc::c_float = 0.;
-    let mut origin: crate::src::qcommon::q_shared::vec3_t = [0.; 3];
-    let mut angles: crate::src::qcommon::q_shared::vec3_t = [0.; 3];
-    let mut mins: crate::src::qcommon::q_shared::vec3_t = [0.; 3];
-    let mut maxs: crate::src::qcommon::q_shared::vec3_t = [0.; 3];
-    let mut handle: crate::src::qcommon::q_shared::qhandle_t = 0;
-    if force2D as u64 == 0 && crate::src::cgame::cg_main::cg_draw3dIcons.integer != 0 {
+    let mut origin: vec3_t = [0.; 3];
+    let mut angles: vec3_t = [0.; 3];
+    let mut mins: vec3_t = [0.; 3];
+    let mut maxs: vec3_t = [0.; 3];
+    let mut handle: qhandle_t = 0;
+    if force2D as u64 == 0 && cg_draw3dIcons.integer != 0 {
         angles[2 as libc::c_int as usize] =
-            0 as libc::c_int as crate::src::qcommon::q_shared::vec_t;
+            0 as libc::c_int as vec_t;
         angles[1 as libc::c_int as usize] = angles[2 as libc::c_int as usize];
         angles[0 as libc::c_int as usize] = angles[1 as libc::c_int as usize];
-        cm = crate::src::cgame::cg_main::cgs.media.redFlagModel;
+        cm = cgs.media.redFlagModel;
         // offset the origin y and z to center the flag
         crate::src::cgame::cg_syscalls::trap_R_ModelBounds(
             cm,
@@ -633,26 +633,26 @@ pub unsafe extern "C" fn CG_DrawFlagModel(
         );
         origin[2 as libc::c_int as usize] = (-0.5f64
             * (mins[2 as libc::c_int as usize] + maxs[2 as libc::c_int as usize]) as libc::c_double)
-            as crate::src::qcommon::q_shared::vec_t;
+            as vec_t;
         origin[1 as libc::c_int as usize] = (0.5f64
             * (mins[1 as libc::c_int as usize] + maxs[1 as libc::c_int as usize]) as libc::c_double)
-            as crate::src::qcommon::q_shared::vec_t;
+            as vec_t;
         // calculate distance so the flag nearly fills the box
         // assume heads are taller than wide
         len = (0.5f64
             * (maxs[2 as libc::c_int as usize] - mins[2 as libc::c_int as usize]) as libc::c_double)
             as libc::c_float; // len / tan( fov/2 )
         origin[0 as libc::c_int as usize] =
-            (len as libc::c_double / 0.268f64) as crate::src::qcommon::q_shared::vec_t;
+            (len as libc::c_double / 0.268f64) as vec_t;
         angles[1 as libc::c_int as usize] = (60 as libc::c_int as libc::c_double
-            * crate::stdlib::sin(crate::src::cgame::cg_main::cg.time as libc::c_double / 2000.0f64))
-            as crate::src::qcommon::q_shared::vec_t;
+            * crate::stdlib::sin(cg.time as libc::c_double / 2000.0f64))
+            as vec_t;
         if team == crate::bg_public_h::TEAM_RED as libc::c_int {
-            handle = crate::src::cgame::cg_main::cgs.media.redFlagModel
+            handle = cgs.media.redFlagModel
         } else if team == crate::bg_public_h::TEAM_BLUE as libc::c_int {
-            handle = crate::src::cgame::cg_main::cgs.media.blueFlagModel
+            handle = cgs.media.blueFlagModel
         } else if team == crate::bg_public_h::TEAM_FREE as libc::c_int {
-            handle = crate::src::cgame::cg_main::cgs.media.neutralFlagModel
+            handle = cgs.media.neutralFlagModel
         } else {
             return;
         }
@@ -666,7 +666,7 @@ pub unsafe extern "C" fn CG_DrawFlagModel(
             origin.as_mut_ptr(),
             angles.as_mut_ptr(),
         );
-    } else if crate::src::cgame::cg_main::cg_drawIcons.integer != 0 {
+    } else if cg_drawIcons.integer != 0 {
         let mut item: *mut crate::bg_public_h::gitem_t = 0 as *mut crate::bg_public_h::gitem_t;
         if team == crate::bg_public_h::TEAM_RED as libc::c_int {
             item = crate::src::game::bg_misc::BG_FindItemForPowerup(crate::bg_public_h::PW_REDFLAG)
@@ -682,12 +682,12 @@ pub unsafe extern "C" fn CG_DrawFlagModel(
             return;
         }
         if !item.is_null() {
-            crate::src::cgame::cg_drawtools::CG_DrawPic(
+            CG_DrawPic(
                 x,
                 y,
                 w,
                 h,
-                crate::src::cgame::cg_main::cg_items[item
+                cg_items[item
                     .offset_from(crate::src::game::bg_misc::bg_itemlist.as_mut_ptr())
                     as libc::c_long as usize]
                     .icon,
@@ -703,20 +703,20 @@ CG_DrawStatusBarHead
 */
 
 unsafe extern "C" fn CG_DrawStatusBarHead(mut x: libc::c_float) {
-    let mut angles: crate::src::qcommon::q_shared::vec3_t = [0.; 3];
+    let mut angles: vec3_t = [0.; 3];
     let mut size: libc::c_float = 0.;
     let mut stretch: libc::c_float = 0.;
     let mut frac: libc::c_float = 0.;
-    angles[2 as libc::c_int as usize] = 0 as libc::c_int as crate::src::qcommon::q_shared::vec_t;
+    angles[2 as libc::c_int as usize] = 0 as libc::c_int as vec_t;
     angles[1 as libc::c_int as usize] = angles[2 as libc::c_int as usize];
     angles[0 as libc::c_int as usize] = angles[1 as libc::c_int as usize];
-    if crate::src::cgame::cg_main::cg.damageTime != 0.
-        && crate::src::cgame::cg_main::cg.time as libc::c_float
-            - crate::src::cgame::cg_main::cg.damageTime
+    if cg.damageTime != 0.
+        && cg.time as libc::c_float
+            - cg.damageTime
             < 500 as libc::c_int as libc::c_float
     {
-        frac = (crate::src::cgame::cg_main::cg.time as libc::c_float
-            - crate::src::cgame::cg_main::cg.damageTime)
+        frac = (cg.time as libc::c_float
+            - cg.damageTime)
             / 500 as libc::c_int as libc::c_float;
         size = (48 as libc::c_int as libc::c_double
             * 1.25f64
@@ -726,11 +726,11 @@ unsafe extern "C" fn CG_DrawStatusBarHead(mut x: libc::c_float) {
         // kick in the direction of damage
         x = (x as libc::c_double
             - (stretch as libc::c_double * 0.5f64
-                + (crate::src::cgame::cg_main::cg.damageX * stretch) as libc::c_double * 0.5f64))
+                + (cg.damageX * stretch) as libc::c_double * 0.5f64))
             as libc::c_float;
-        crate::src::cgame::cg_main::cg.headStartYaw = 180 as libc::c_int as libc::c_float
-            + crate::src::cgame::cg_main::cg.damageX * 45 as libc::c_int as libc::c_float;
-        crate::src::cgame::cg_main::cg.headEndYaw = (180 as libc::c_int as libc::c_double
+        cg.headStartYaw = 180 as libc::c_int as libc::c_float
+            + cg.damageX * 45 as libc::c_int as libc::c_float;
+        cg.headEndYaw = (180 as libc::c_int as libc::c_double
             + 20 as libc::c_int as libc::c_double
                 * crate::stdlib::cos(
                     2.0f64
@@ -740,7 +740,7 @@ unsafe extern "C" fn CG_DrawStatusBarHead(mut x: libc::c_float) {
                             - 0.5f64)
                         * 3.14159265358979323846f64,
                 )) as libc::c_float;
-        crate::src::cgame::cg_main::cg.headEndPitch = (5 as libc::c_int as libc::c_double
+        cg.headEndPitch = (5 as libc::c_int as libc::c_double
             * crate::stdlib::cos(
                 2.0f64
                     * (((::libc::rand() & 0x7fff as libc::c_int) as libc::c_float
@@ -749,26 +749,26 @@ unsafe extern "C" fn CG_DrawStatusBarHead(mut x: libc::c_float) {
                         - 0.5f64)
                     * 3.14159265358979323846f64,
             )) as libc::c_float;
-        crate::src::cgame::cg_main::cg.headStartTime = crate::src::cgame::cg_main::cg.time;
-        crate::src::cgame::cg_main::cg.headEndTime =
-            ((crate::src::cgame::cg_main::cg.time + 100 as libc::c_int) as libc::c_float
+        cg.headStartTime = cg.time;
+        cg.headEndTime =
+            ((cg.time + 100 as libc::c_int) as libc::c_float
                 + (::libc::rand() & 0x7fff as libc::c_int) as libc::c_float
                     / 0x7fff as libc::c_int as libc::c_float
                     * 2000 as libc::c_int as libc::c_float) as libc::c_int
     } else {
-        if crate::src::cgame::cg_main::cg.time >= crate::src::cgame::cg_main::cg.headEndTime {
+        if cg.time >= cg.headEndTime {
             // select a new head angle
-            crate::src::cgame::cg_main::cg.headStartYaw = crate::src::cgame::cg_main::cg.headEndYaw;
-            crate::src::cgame::cg_main::cg.headStartPitch =
-                crate::src::cgame::cg_main::cg.headEndPitch;
-            crate::src::cgame::cg_main::cg.headStartTime =
-                crate::src::cgame::cg_main::cg.headEndTime;
-            crate::src::cgame::cg_main::cg.headEndTime =
-                ((crate::src::cgame::cg_main::cg.time + 100 as libc::c_int) as libc::c_float
+            cg.headStartYaw = cg.headEndYaw;
+            cg.headStartPitch =
+                cg.headEndPitch;
+            cg.headStartTime =
+                cg.headEndTime;
+            cg.headEndTime =
+                ((cg.time + 100 as libc::c_int) as libc::c_float
                     + (::libc::rand() & 0x7fff as libc::c_int) as libc::c_float
                         / 0x7fff as libc::c_int as libc::c_float
                         * 2000 as libc::c_int as libc::c_float) as libc::c_int;
-            crate::src::cgame::cg_main::cg.headEndYaw = (180 as libc::c_int as libc::c_double
+            cg.headEndYaw = (180 as libc::c_int as libc::c_double
                 + 20 as libc::c_int as libc::c_double
                     * crate::stdlib::cos(
                         2.0f64
@@ -778,7 +778,7 @@ unsafe extern "C" fn CG_DrawStatusBarHead(mut x: libc::c_float) {
                                 - 0.5f64)
                             * 3.14159265358979323846f64,
                     )) as libc::c_float;
-            crate::src::cgame::cg_main::cg.headEndPitch = (5 as libc::c_int as libc::c_double
+            cg.headEndPitch = (5 as libc::c_int as libc::c_double
                 * crate::stdlib::cos(
                     2.0f64
                         * (((::libc::rand() & 0x7fff as libc::c_int) as libc::c_float
@@ -791,29 +791,29 @@ unsafe extern "C" fn CG_DrawStatusBarHead(mut x: libc::c_float) {
         size = (48 as libc::c_int as libc::c_double * 1.25f64) as libc::c_float
     }
     // if the server was frozen for a while we may have a bad head start time
-    if crate::src::cgame::cg_main::cg.headStartTime > crate::src::cgame::cg_main::cg.time {
-        crate::src::cgame::cg_main::cg.headStartTime = crate::src::cgame::cg_main::cg.time
+    if cg.headStartTime > cg.time {
+        cg.headStartTime = cg.time
     }
-    frac = (crate::src::cgame::cg_main::cg.time - crate::src::cgame::cg_main::cg.headStartTime)
+    frac = (cg.time - cg.headStartTime)
         as libc::c_float
-        / (crate::src::cgame::cg_main::cg.headEndTime
-            - crate::src::cgame::cg_main::cg.headStartTime) as libc::c_float;
+        / (cg.headEndTime
+            - cg.headStartTime) as libc::c_float;
     frac = frac
         * frac
         * (3 as libc::c_int as libc::c_float - 2 as libc::c_int as libc::c_float * frac);
-    angles[1 as libc::c_int as usize] = crate::src::cgame::cg_main::cg.headStartYaw
-        + (crate::src::cgame::cg_main::cg.headEndYaw - crate::src::cgame::cg_main::cg.headStartYaw)
+    angles[1 as libc::c_int as usize] = cg.headStartYaw
+        + (cg.headEndYaw - cg.headStartYaw)
             * frac;
-    angles[0 as libc::c_int as usize] = crate::src::cgame::cg_main::cg.headStartPitch
-        + (crate::src::cgame::cg_main::cg.headEndPitch
-            - crate::src::cgame::cg_main::cg.headStartPitch)
+    angles[0 as libc::c_int as usize] = cg.headStartPitch
+        + (cg.headEndPitch
+            - cg.headStartPitch)
             * frac;
     CG_DrawHead(
         x,
         480 as libc::c_int as libc::c_float - size,
         size,
         size,
-        (*crate::src::cgame::cg_main::cg.snap).ps.clientNum,
+        (*cg.snap).ps.clientNum,
         angles.as_mut_ptr(),
     );
 }
@@ -832,7 +832,7 @@ unsafe extern "C" fn CG_DrawStatusBarFlag(mut x: libc::c_float, mut team: libc::
         48 as libc::c_int as libc::c_float,
         48 as libc::c_int as libc::c_float,
         team,
-        crate::src::qcommon::q_shared::qfalse,
+        qfalse,
     );
 }
 // MISSIONPACK
@@ -852,30 +852,30 @@ pub unsafe extern "C" fn CG_DrawTeamBackground(
     mut alpha: libc::c_float,
     mut team: libc::c_int,
 ) {
-    let mut hcolor: crate::src::qcommon::q_shared::vec4_t = [0.; 4];
+    let mut hcolor: vec4_t = [0.; 4];
     hcolor[3 as libc::c_int as usize] = alpha;
     if team == crate::bg_public_h::TEAM_RED as libc::c_int {
         hcolor[0 as libc::c_int as usize] =
-            1 as libc::c_int as crate::src::qcommon::q_shared::vec_t;
+            1 as libc::c_int as vec_t;
         hcolor[1 as libc::c_int as usize] =
-            0 as libc::c_int as crate::src::qcommon::q_shared::vec_t;
-        hcolor[2 as libc::c_int as usize] = 0 as libc::c_int as crate::src::qcommon::q_shared::vec_t
+            0 as libc::c_int as vec_t;
+        hcolor[2 as libc::c_int as usize] = 0 as libc::c_int as vec_t
     } else if team == crate::bg_public_h::TEAM_BLUE as libc::c_int {
         hcolor[0 as libc::c_int as usize] =
-            0 as libc::c_int as crate::src::qcommon::q_shared::vec_t;
+            0 as libc::c_int as vec_t;
         hcolor[1 as libc::c_int as usize] =
-            0 as libc::c_int as crate::src::qcommon::q_shared::vec_t;
-        hcolor[2 as libc::c_int as usize] = 1 as libc::c_int as crate::src::qcommon::q_shared::vec_t
+            0 as libc::c_int as vec_t;
+        hcolor[2 as libc::c_int as usize] = 1 as libc::c_int as vec_t
     } else {
         return;
     }
     crate::src::cgame::cg_syscalls::trap_R_SetColor(hcolor.as_mut_ptr());
-    crate::src::cgame::cg_drawtools::CG_DrawPic(
+    CG_DrawPic(
         x as libc::c_float,
         y as libc::c_float,
         w as libc::c_float,
         h as libc::c_float,
-        crate::src::cgame::cg_main::cgs.media.teamStatusBar,
+        cgs.media.teamStatusBar,
     );
     crate::src::cgame::cg_syscalls::trap_R_SetColor(0 as *const libc::c_float);
 }
@@ -889,19 +889,19 @@ CG_DrawStatusBar
 unsafe extern "C" fn CG_DrawStatusBar() {
     let mut color: libc::c_int = 0; // health > 100
     let mut cent: *mut crate::cg_local_h::centity_t = 0 as *mut crate::cg_local_h::centity_t;
-    let mut ps: *mut crate::src::qcommon::q_shared::playerState_t =
-        0 as *mut crate::src::qcommon::q_shared::playerState_t;
+    let mut ps: *mut playerState_t =
+        0 as *mut playerState_t;
     let mut value: libc::c_int = 0;
-    let mut hcolor: crate::src::qcommon::q_shared::vec4_t = [0.; 4];
-    let mut angles: crate::src::qcommon::q_shared::vec3_t = [0.; 3];
-    let mut origin: crate::src::qcommon::q_shared::vec3_t = [0.; 3];
+    let mut hcolor: vec4_t = [0.; 4];
+    let mut angles: vec3_t = [0.; 3];
+    let mut origin: vec3_t = [0.; 3];
     static mut colors: [[libc::c_float; 4]; 4] = [
         [1.0f32, 0.69f32, 0.0f32, 1.0f32],
         [1.0f32, 0.2f32, 0.2f32, 1.0f32],
         [0.5f32, 0.5f32, 0.5f32, 1.0f32],
         [1.0f32, 1.0f32, 1.0f32, 1.0f32],
     ];
-    if crate::src::cgame::cg_main::cg_drawStatus.integer == 0 as libc::c_int {
+    if cg_drawStatus.integer == 0 as libc::c_int {
         return;
     }
     // draw the team background
@@ -911,40 +911,40 @@ unsafe extern "C" fn CG_DrawStatusBar() {
         640 as libc::c_int,
         60 as libc::c_int,
         0.33f32,
-        (*crate::src::cgame::cg_main::cg.snap).ps.persistant
+        (*cg.snap).ps.persistant
             [crate::bg_public_h::PERS_TEAM as libc::c_int as usize],
     );
-    cent = &mut *crate::src::cgame::cg_main::cg_entities
+    cent = &mut *cg_entities
         .as_mut_ptr()
-        .offset((*crate::src::cgame::cg_main::cg.snap).ps.clientNum as isize)
+        .offset((*cg.snap).ps.clientNum as isize)
         as *mut crate::cg_local_h::centity_t;
-    ps = &mut (*crate::src::cgame::cg_main::cg.snap).ps;
-    angles[2 as libc::c_int as usize] = 0 as libc::c_int as crate::src::qcommon::q_shared::vec_t;
+    ps = &mut (*cg.snap).ps;
+    angles[2 as libc::c_int as usize] = 0 as libc::c_int as vec_t;
     angles[1 as libc::c_int as usize] = angles[2 as libc::c_int as usize];
     angles[0 as libc::c_int as usize] = angles[1 as libc::c_int as usize];
     // draw any 3D icons first, so the changes back to 2D are minimized
     if (*cent).currentState.weapon != 0
-        && crate::src::cgame::cg_main::cg_weapons[(*cent).currentState.weapon as usize].ammoModel
+        && cg_weapons[(*cent).currentState.weapon as usize].ammoModel
             != 0
     {
         origin[0 as libc::c_int as usize] =
-            70 as libc::c_int as crate::src::qcommon::q_shared::vec_t;
+            70 as libc::c_int as vec_t;
         origin[1 as libc::c_int as usize] =
-            0 as libc::c_int as crate::src::qcommon::q_shared::vec_t;
+            0 as libc::c_int as vec_t;
         origin[2 as libc::c_int as usize] =
-            0 as libc::c_int as crate::src::qcommon::q_shared::vec_t;
+            0 as libc::c_int as vec_t;
         angles[1 as libc::c_int as usize] = (90 as libc::c_int as libc::c_double
             + 20 as libc::c_int as libc::c_double
                 * crate::stdlib::sin(
-                    crate::src::cgame::cg_main::cg.time as libc::c_double / 1000.0f64,
+                    cg.time as libc::c_double / 1000.0f64,
                 ))
-            as crate::src::qcommon::q_shared::vec_t;
+            as vec_t;
         CG_Draw3DModel(
             (32 as libc::c_int * 3 as libc::c_int + 4 as libc::c_int) as libc::c_float,
             432 as libc::c_int as libc::c_float,
             48 as libc::c_int as libc::c_float,
             48 as libc::c_int as libc::c_float,
-            crate::src::cgame::cg_main::cg_weapons[(*cent).currentState.weapon as usize].ammoModel,
+            cg_weapons[(*cent).currentState.weapon as usize].ammoModel,
             0 as libc::c_int,
             origin.as_mut_ptr(),
             angles.as_mut_ptr(),
@@ -954,7 +954,7 @@ unsafe extern "C" fn CG_DrawStatusBar() {
         (185 as libc::c_int + 32 as libc::c_int * 3 as libc::c_int + 4 as libc::c_int)
             as libc::c_float,
     );
-    if crate::src::cgame::cg_main::cg.predictedPlayerState.powerups
+    if cg.predictedPlayerState.powerups
         [crate::bg_public_h::PW_REDFLAG as libc::c_int as usize]
         != 0
     {
@@ -965,7 +965,7 @@ unsafe extern "C" fn CG_DrawStatusBar() {
                 + 48 as libc::c_int) as libc::c_float,
             crate::bg_public_h::TEAM_RED as libc::c_int,
         );
-    } else if crate::src::cgame::cg_main::cg.predictedPlayerState.powerups
+    } else if cg.predictedPlayerState.powerups
         [crate::bg_public_h::PW_BLUEFLAG as libc::c_int as usize]
         != 0
     {
@@ -976,7 +976,7 @@ unsafe extern "C" fn CG_DrawStatusBar() {
                 + 48 as libc::c_int) as libc::c_float,
             crate::bg_public_h::TEAM_BLUE as libc::c_int,
         );
-    } else if crate::src::cgame::cg_main::cg.predictedPlayerState.powerups
+    } else if cg.predictedPlayerState.powerups
         [crate::bg_public_h::PW_NEUTRALFLAG as libc::c_int as usize]
         != 0
     {
@@ -990,22 +990,22 @@ unsafe extern "C" fn CG_DrawStatusBar() {
     }
     if (*ps).stats[crate::bg_public_h::STAT_ARMOR as libc::c_int as usize] != 0 {
         origin[0 as libc::c_int as usize] =
-            90 as libc::c_int as crate::src::qcommon::q_shared::vec_t;
+            90 as libc::c_int as vec_t;
         origin[1 as libc::c_int as usize] =
-            0 as libc::c_int as crate::src::qcommon::q_shared::vec_t;
+            0 as libc::c_int as vec_t;
         origin[2 as libc::c_int as usize] =
-            -(10 as libc::c_int) as crate::src::qcommon::q_shared::vec_t;
+            -(10 as libc::c_int) as vec_t;
         angles[1 as libc::c_int as usize] =
-            (((crate::src::cgame::cg_main::cg.time & 2047 as libc::c_int) * 360 as libc::c_int)
+            (((cg.time & 2047 as libc::c_int) * 360 as libc::c_int)
                 as libc::c_double
-                / 2048.0f64) as crate::src::qcommon::q_shared::vec_t;
+                / 2048.0f64) as vec_t;
         CG_Draw3DModel(
             (370 as libc::c_int + 32 as libc::c_int * 3 as libc::c_int + 4 as libc::c_int)
                 as libc::c_float,
             432 as libc::c_int as libc::c_float,
             48 as libc::c_int as libc::c_float,
             48 as libc::c_int as libc::c_float,
-            crate::src::cgame::cg_main::cgs.media.armorModel,
+            cgs.media.armorModel,
             0 as libc::c_int,
             origin.as_mut_ptr(),
             angles.as_mut_ptr(),
@@ -1017,11 +1017,11 @@ unsafe extern "C" fn CG_DrawStatusBar() {
     if (*cent).currentState.weapon != 0 {
         value = (*ps).ammo[(*cent).currentState.weapon as usize];
         if value > -(1 as libc::c_int) {
-            if crate::src::cgame::cg_main::cg
+            if cg
                 .predictedPlayerState
                 .weaponstate
                 == crate::bg_public_h::WEAPON_FIRING as libc::c_int
-                && crate::src::cgame::cg_main::cg
+                && cg
                     .predictedPlayerState
                     .weaponTime
                     > 100 as libc::c_int
@@ -1045,15 +1045,15 @@ unsafe extern "C" fn CG_DrawStatusBar() {
             );
             crate::src::cgame::cg_syscalls::trap_R_SetColor(0 as *const libc::c_float);
             // if we didn't draw a 3D icon, draw a 2D icon for ammo
-            if crate::src::cgame::cg_main::cg_draw3dIcons.integer == 0
-                && crate::src::cgame::cg_main::cg_drawIcons.integer != 0
+            if cg_draw3dIcons.integer == 0
+                && cg_drawIcons.integer != 0
             {
-                let mut icon: crate::src::qcommon::q_shared::qhandle_t = 0;
-                icon = crate::src::cgame::cg_main::cg_weapons
-                    [crate::src::cgame::cg_main::cg.predictedPlayerState.weapon as usize]
+                let mut icon: qhandle_t = 0;
+                icon = cg_weapons
+                    [cg.predictedPlayerState.weapon as usize]
                     .ammoIcon;
                 if icon != 0 {
-                    crate::src::cgame::cg_drawtools::CG_DrawPic(
+                    CG_DrawPic(
                         (32 as libc::c_int * 3 as libc::c_int + 4 as libc::c_int) as libc::c_float,
                         432 as libc::c_int as libc::c_float,
                         48 as libc::c_int as libc::c_float,
@@ -1079,7 +1079,7 @@ unsafe extern "C" fn CG_DrawStatusBar() {
         );
     // green
     } else if value > 0 as libc::c_int {
-        color = crate::src::cgame::cg_main::cg.time >> 8 as libc::c_int & 1 as libc::c_int; // flash
+        color = cg.time >> 8 as libc::c_int & 1 as libc::c_int; // flash
         crate::src::cgame::cg_syscalls::trap_R_SetColor(colors[color as usize].as_mut_ptr());
     } else {
         crate::src::cgame::cg_syscalls::trap_R_SetColor(
@@ -1094,7 +1094,7 @@ unsafe extern "C" fn CG_DrawStatusBar() {
         3 as libc::c_int,
         value,
     );
-    crate::src::cgame::cg_drawtools::CG_ColorForHealth(hcolor.as_mut_ptr());
+    CG_ColorForHealth(hcolor.as_mut_ptr());
     crate::src::cgame::cg_syscalls::trap_R_SetColor(hcolor.as_mut_ptr());
     //
     // armor
@@ -1112,16 +1112,16 @@ unsafe extern "C" fn CG_DrawStatusBar() {
         );
         crate::src::cgame::cg_syscalls::trap_R_SetColor(0 as *const libc::c_float);
         // if we didn't draw a 3D icon, draw a 2D icon for armor
-        if crate::src::cgame::cg_main::cg_draw3dIcons.integer == 0
-            && crate::src::cgame::cg_main::cg_drawIcons.integer != 0
+        if cg_draw3dIcons.integer == 0
+            && cg_drawIcons.integer != 0
         {
-            crate::src::cgame::cg_drawtools::CG_DrawPic(
+            CG_DrawPic(
                 (370 as libc::c_int + 32 as libc::c_int * 3 as libc::c_int + 4 as libc::c_int)
                     as libc::c_float,
                 432 as libc::c_int as libc::c_float,
                 48 as libc::c_int as libc::c_float,
                 48 as libc::c_int as libc::c_float,
-                crate::src::cgame::cg_main::cgs.media.armorIcon,
+                cgs.media.armorIcon,
             );
         }
     };
@@ -1143,41 +1143,41 @@ CG_DrawAttacker
 unsafe extern "C" fn CG_DrawAttacker(mut y: libc::c_float) -> libc::c_float {
     let mut t: libc::c_int = 0;
     let mut size: libc::c_float = 0.;
-    let mut angles: crate::src::qcommon::q_shared::vec3_t = [0.; 3];
+    let mut angles: vec3_t = [0.; 3];
     let mut info: *const libc::c_char = 0 as *const libc::c_char;
     let mut name: *const libc::c_char = 0 as *const libc::c_char;
     let mut clientNum: libc::c_int = 0;
-    if crate::src::cgame::cg_main::cg.predictedPlayerState.stats
+    if cg.predictedPlayerState.stats
         [crate::bg_public_h::STAT_HEALTH as libc::c_int as usize]
         <= 0 as libc::c_int
     {
         return y;
     }
-    if crate::src::cgame::cg_main::cg.attackerTime == 0 {
+    if cg.attackerTime == 0 {
         return y;
     }
-    clientNum = crate::src::cgame::cg_main::cg
+    clientNum = cg
         .predictedPlayerState
         .persistant[crate::bg_public_h::PERS_ATTACKER as libc::c_int as usize];
     if clientNum < 0 as libc::c_int
         || clientNum >= 64 as libc::c_int
-        || clientNum == (*crate::src::cgame::cg_main::cg.snap).ps.clientNum
+        || clientNum == (*cg.snap).ps.clientNum
     {
         return y;
     }
-    if crate::src::cgame::cg_main::cgs.clientinfo[clientNum as usize].infoValid as u64 == 0 {
-        crate::src::cgame::cg_main::cg.attackerTime = 0 as libc::c_int;
+    if cgs.clientinfo[clientNum as usize].infoValid as u64 == 0 {
+        cg.attackerTime = 0 as libc::c_int;
         return y;
     }
-    t = crate::src::cgame::cg_main::cg.time - crate::src::cgame::cg_main::cg.attackerTime;
+    t = cg.time - cg.attackerTime;
     if t > 10000 as libc::c_int {
-        crate::src::cgame::cg_main::cg.attackerTime = 0 as libc::c_int;
+        cg.attackerTime = 0 as libc::c_int;
         return y;
     }
     size = (48 as libc::c_int as libc::c_double * 1.25f64) as libc::c_float;
-    angles[0 as libc::c_int as usize] = 0 as libc::c_int as crate::src::qcommon::q_shared::vec_t;
-    angles[1 as libc::c_int as usize] = 180 as libc::c_int as crate::src::qcommon::q_shared::vec_t;
-    angles[2 as libc::c_int as usize] = 0 as libc::c_int as crate::src::qcommon::q_shared::vec_t;
+    angles[0 as libc::c_int as usize] = 0 as libc::c_int as vec_t;
+    angles[1 as libc::c_int as usize] = 180 as libc::c_int as vec_t;
+    angles[2 as libc::c_int as usize] = 0 as libc::c_int as vec_t;
     CG_DrawHead(
         640 as libc::c_int as libc::c_float - size,
         y,
@@ -1186,16 +1186,16 @@ unsafe extern "C" fn CG_DrawAttacker(mut y: libc::c_float) -> libc::c_float {
         clientNum,
         angles.as_mut_ptr(),
     );
-    info = crate::src::cgame::cg_main::CG_ConfigString(
+    info = CG_ConfigString(
         32 as libc::c_int + 256 as libc::c_int + 256 as libc::c_int + clientNum,
     );
-    name = crate::src::qcommon::q_shared::Info_ValueForKey(
+    name = Info_ValueForKey(
         info,
         b"n\x00" as *const u8 as *const libc::c_char,
     );
     y += size;
-    crate::src::cgame::cg_drawtools::CG_DrawBigString(
-        640 as libc::c_int - crate::src::qcommon::q_shared::Q_PrintStrlen(name) * 16 as libc::c_int,
+    CG_DrawBigString(
+        640 as libc::c_int - Q_PrintStrlen(name) * 16 as libc::c_int,
         y as libc::c_int,
         name,
         0.5f64 as libc::c_float,
@@ -1211,14 +1211,14 @@ CG_DrawSnapshot
 unsafe extern "C" fn CG_DrawSnapshot(mut y: libc::c_float) -> libc::c_float {
     let mut s: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut w: libc::c_int = 0;
-    s = crate::src::qcommon::q_shared::va(
+    s = va(
         b"time:%i snap:%i cmd:%i\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-        (*crate::src::cgame::cg_main::cg.snap).serverTime,
-        crate::src::cgame::cg_main::cg.latestSnapshotNum,
-        crate::src::cgame::cg_main::cgs.serverCommandSequence,
+        (*cg.snap).serverTime,
+        cg.latestSnapshotNum,
+        cgs.serverCommandSequence,
     );
-    w = crate::src::cgame::cg_drawtools::CG_DrawStrlen(s) * 16 as libc::c_int;
-    crate::src::cgame::cg_drawtools::CG_DrawBigString(
+    w = CG_DrawStrlen(s) * 16 as libc::c_int;
+    CG_DrawBigString(
         635 as libc::c_int - w,
         (y + 2 as libc::c_int as libc::c_float) as libc::c_int,
         s,
@@ -1257,12 +1257,12 @@ unsafe extern "C" fn CG_DrawFPS(mut y: libc::c_float) -> libc::c_float {
             total = 1 as libc::c_int
         }
         fps = 1000 as libc::c_int * 4 as libc::c_int / total;
-        s = crate::src::qcommon::q_shared::va(
+        s = va(
             b"%ifps\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             fps,
         );
-        w = crate::src::cgame::cg_drawtools::CG_DrawStrlen(s) * 16 as libc::c_int;
-        crate::src::cgame::cg_drawtools::CG_DrawBigString(
+        w = CG_DrawStrlen(s) * 16 as libc::c_int;
+        CG_DrawBigString(
             635 as libc::c_int - w,
             (y + 2 as libc::c_int as libc::c_float) as libc::c_int,
             s,
@@ -1284,20 +1284,20 @@ unsafe extern "C" fn CG_DrawTimer(mut y: libc::c_float) -> libc::c_float {
     let mut seconds: libc::c_int = 0;
     let mut tens: libc::c_int = 0;
     let mut msec: libc::c_int = 0;
-    msec = crate::src::cgame::cg_main::cg.time - crate::src::cgame::cg_main::cgs.levelStartTime;
+    msec = cg.time - cgs.levelStartTime;
     seconds = msec / 1000 as libc::c_int;
     mins = seconds / 60 as libc::c_int;
     seconds -= mins * 60 as libc::c_int;
     tens = seconds / 10 as libc::c_int;
     seconds -= tens * 10 as libc::c_int;
-    s = crate::src::qcommon::q_shared::va(
+    s = va(
         b"%i:%i%i\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         mins,
         tens,
         seconds,
     );
-    w = crate::src::cgame::cg_drawtools::CG_DrawStrlen(s) * 16 as libc::c_int;
-    crate::src::cgame::cg_drawtools::CG_DrawBigString(
+    w = CG_DrawStrlen(s) * 16 as libc::c_int;
+    CG_DrawBigString(
         635 as libc::c_int - w,
         (y + 2 as libc::c_int as libc::c_float) as libc::c_int,
         s,
@@ -1313,8 +1313,8 @@ CG_DrawTeamOverlay
 
 unsafe extern "C" fn CG_DrawTeamOverlay(
     mut y: libc::c_float,
-    mut right: crate::src::qcommon::q_shared::qboolean,
-    mut upper: crate::src::qcommon::q_shared::qboolean,
+    mut right: qboolean,
+    mut upper: qboolean,
 ) -> libc::c_float {
     let mut x: libc::c_int = 0;
     let mut w: libc::c_int = 0;
@@ -1324,7 +1324,7 @@ unsafe extern "C" fn CG_DrawTeamOverlay(
     let mut j: libc::c_int = 0;
     let mut len: libc::c_int = 0;
     let mut p: *const libc::c_char = 0 as *const libc::c_char;
-    let mut hcolor: crate::src::qcommon::q_shared::vec4_t = [0.; 4];
+    let mut hcolor: vec4_t = [0.; 4];
     let mut pwidth: libc::c_int = 0;
     let mut lwidth: libc::c_int = 0;
     let mut plyrs: libc::c_int = 0;
@@ -1333,13 +1333,13 @@ unsafe extern "C" fn CG_DrawTeamOverlay(
     let mut item: *mut crate::bg_public_h::gitem_t = 0 as *mut crate::bg_public_h::gitem_t;
     let mut ret_y: libc::c_int = 0;
     let mut count: libc::c_int = 0;
-    if crate::src::cgame::cg_main::cg_drawTeamOverlay.integer == 0 {
+    if cg_drawTeamOverlay.integer == 0 {
         return y;
     }
-    if (*crate::src::cgame::cg_main::cg.snap).ps.persistant
+    if (*cg.snap).ps.persistant
         [crate::bg_public_h::PERS_TEAM as libc::c_int as usize]
         != crate::bg_public_h::TEAM_RED as libc::c_int
-        && (*crate::src::cgame::cg_main::cg.snap).ps.persistant
+        && (*cg.snap).ps.persistant
             [crate::bg_public_h::PERS_TEAM as libc::c_int as usize]
             != crate::bg_public_h::TEAM_BLUE as libc::c_int
     {
@@ -1356,18 +1356,18 @@ unsafe extern "C" fn CG_DrawTeamOverlay(
     };
     i = 0 as libc::c_int;
     while i < count {
-        ci = crate::src::cgame::cg_main::cgs
+        ci = cgs
             .clientinfo
             .as_mut_ptr()
             .offset(sortedTeamPlayers[i as usize] as isize);
         if (*ci).infoValid as libc::c_uint != 0
             && (*ci).team as libc::c_uint
-                == (*crate::src::cgame::cg_main::cg.snap).ps.persistant
+                == (*cg.snap).ps.persistant
                     [crate::bg_public_h::PERS_TEAM as libc::c_int as usize]
                     as libc::c_uint
         {
             plyrs += 1;
-            len = crate::src::cgame::cg_drawtools::CG_DrawStrlen((*ci).name.as_mut_ptr());
+            len = CG_DrawStrlen((*ci).name.as_mut_ptr());
             if len > pwidth {
                 pwidth = len
             }
@@ -1384,11 +1384,11 @@ unsafe extern "C" fn CG_DrawTeamOverlay(
     lwidth = 0 as libc::c_int; // if ( cg.snap->ps.persistant[PERS_TEAM] == TEAM_BLUE )
     i = 1 as libc::c_int;
     while i < 64 as libc::c_int {
-        p = crate::src::cgame::cg_main::CG_ConfigString(
+        p = CG_ConfigString(
             32 as libc::c_int + 256 as libc::c_int + 256 as libc::c_int + 64 as libc::c_int + i,
         );
         if !p.is_null() && *p as libc::c_int != 0 {
-            len = crate::src::cgame::cg_drawtools::CG_DrawStrlen(p);
+            len = CG_DrawStrlen(p);
             if len > lwidth {
                 lwidth = len
             }
@@ -1411,7 +1411,7 @@ unsafe extern "C" fn CG_DrawTeamOverlay(
         y -= h as libc::c_float;
         ret_y = y as libc::c_int
     }
-    if (*crate::src::cgame::cg_main::cg.snap).ps.persistant
+    if (*cg.snap).ps.persistant
         [crate::bg_public_h::PERS_TEAM as libc::c_int as usize]
         == crate::bg_public_h::TEAM_RED as libc::c_int
     {
@@ -1426,44 +1426,44 @@ unsafe extern "C" fn CG_DrawTeamOverlay(
         hcolor[3 as libc::c_int as usize] = 0.33f32
     }
     crate::src::cgame::cg_syscalls::trap_R_SetColor(hcolor.as_mut_ptr());
-    crate::src::cgame::cg_drawtools::CG_DrawPic(
+    CG_DrawPic(
         x as libc::c_float,
         y,
         w as libc::c_float,
         h as libc::c_float,
-        crate::src::cgame::cg_main::cgs.media.teamStatusBar,
+        cgs.media.teamStatusBar,
     );
     crate::src::cgame::cg_syscalls::trap_R_SetColor(0 as *const libc::c_float);
     i = 0 as libc::c_int;
     while i < count {
-        ci = crate::src::cgame::cg_main::cgs
+        ci = cgs
             .clientinfo
             .as_mut_ptr()
             .offset(sortedTeamPlayers[i as usize] as isize);
         if (*ci).infoValid as libc::c_uint != 0
             && (*ci).team as libc::c_uint
-                == (*crate::src::cgame::cg_main::cg.snap).ps.persistant
+                == (*cg.snap).ps.persistant
                     [crate::bg_public_h::PERS_TEAM as libc::c_int as usize]
                     as libc::c_uint
         {
-            hcolor[3 as libc::c_int as usize] = 1.0f64 as crate::src::qcommon::q_shared::vec_t;
+            hcolor[3 as libc::c_int as usize] = 1.0f64 as vec_t;
             hcolor[2 as libc::c_int as usize] = hcolor[3 as libc::c_int as usize];
             hcolor[1 as libc::c_int as usize] = hcolor[2 as libc::c_int as usize];
             hcolor[0 as libc::c_int as usize] = hcolor[1 as libc::c_int as usize];
             xx = x + 8 as libc::c_int;
-            crate::src::cgame::cg_drawtools::CG_DrawStringExt(
+            CG_DrawStringExt(
                 xx,
                 y as libc::c_int,
                 (*ci).name.as_mut_ptr(),
                 hcolor.as_mut_ptr(),
-                crate::src::qcommon::q_shared::qfalse,
-                crate::src::qcommon::q_shared::qfalse,
+                qfalse,
+                qfalse,
                 8 as libc::c_int,
                 16 as libc::c_int / 2 as libc::c_int,
                 12 as libc::c_int,
             );
             if lwidth != 0 {
-                p = crate::src::cgame::cg_main::CG_ConfigString(
+                p = CG_ConfigString(
                     32 as libc::c_int
                         + 256 as libc::c_int
                         + 256 as libc::c_int
@@ -1479,24 +1479,24 @@ unsafe extern "C" fn CG_DrawTeamOverlay(
                 //				xx = x + TINYCHAR_WIDTH * 2 + TINYCHAR_WIDTH * pwidth +
                 //					((lwidth/2 - len/2) * TINYCHAR_WIDTH);
                 xx = x + 8 as libc::c_int * 2 as libc::c_int + 8 as libc::c_int * pwidth;
-                crate::src::cgame::cg_drawtools::CG_DrawStringExt(
+                CG_DrawStringExt(
                     xx,
                     y as libc::c_int,
                     p,
                     hcolor.as_mut_ptr(),
-                    crate::src::qcommon::q_shared::qfalse,
-                    crate::src::qcommon::q_shared::qfalse,
+                    qfalse,
+                    qfalse,
                     8 as libc::c_int,
                     16 as libc::c_int / 2 as libc::c_int,
                     16 as libc::c_int,
                 );
             }
-            crate::src::cgame::cg_drawtools::CG_GetColorForHealth(
+            CG_GetColorForHealth(
                 (*ci).health,
                 (*ci).armor,
                 hcolor.as_mut_ptr(),
             );
-            crate::src::qcommon::q_shared::Com_sprintf(
+            Com_sprintf(
                 st.as_mut_ptr(),
                 ::std::mem::size_of::<[libc::c_char; 16]>() as libc::c_ulong as libc::c_int,
                 b"%3i %3i\x00" as *const u8 as *const libc::c_char,
@@ -1507,34 +1507,34 @@ unsafe extern "C" fn CG_DrawTeamOverlay(
                 + 8 as libc::c_int * 3 as libc::c_int
                 + 8 as libc::c_int * pwidth
                 + 8 as libc::c_int * lwidth;
-            crate::src::cgame::cg_drawtools::CG_DrawStringExt(
+            CG_DrawStringExt(
                 xx,
                 y as libc::c_int,
                 st.as_mut_ptr(),
                 hcolor.as_mut_ptr(),
-                crate::src::qcommon::q_shared::qfalse,
-                crate::src::qcommon::q_shared::qfalse,
+                qfalse,
+                qfalse,
                 8 as libc::c_int,
                 16 as libc::c_int / 2 as libc::c_int,
                 0 as libc::c_int,
             );
             // draw weapon icon
             xx += 8 as libc::c_int * 3 as libc::c_int;
-            if crate::src::cgame::cg_main::cg_weapons[(*ci).curWeapon as usize].weaponIcon != 0 {
-                crate::src::cgame::cg_drawtools::CG_DrawPic(
+            if cg_weapons[(*ci).curWeapon as usize].weaponIcon != 0 {
+                CG_DrawPic(
                     xx as libc::c_float,
                     y,
                     8 as libc::c_int as libc::c_float,
                     (16 as libc::c_int / 2 as libc::c_int) as libc::c_float,
-                    crate::src::cgame::cg_main::cg_weapons[(*ci).curWeapon as usize].weaponIcon,
+                    cg_weapons[(*ci).curWeapon as usize].weaponIcon,
                 );
             } else {
-                crate::src::cgame::cg_drawtools::CG_DrawPic(
+                CG_DrawPic(
                     xx as libc::c_float,
                     y,
                     8 as libc::c_int as libc::c_float,
                     (16 as libc::c_int / 2 as libc::c_int) as libc::c_float,
-                    crate::src::cgame::cg_main::cgs.media.deferShader,
+                    cgs.media.deferShader,
                 );
             }
             // Draw powerup icons
@@ -1550,7 +1550,7 @@ unsafe extern "C" fn CG_DrawTeamOverlay(
                         j as crate::bg_public_h::powerup_t,
                     ) as *mut crate::bg_public_h::gitem_s;
                     if !item.is_null() {
-                        crate::src::cgame::cg_drawtools::CG_DrawPic(
+                        CG_DrawPic(
                             xx as libc::c_float,
                             y,
                             8 as libc::c_int as libc::c_float,
@@ -1580,34 +1580,34 @@ CG_DrawUpperRight
 =====================
 */
 
-unsafe extern "C" fn CG_DrawUpperRight(mut stereoFrame: crate::tr_types_h::stereoFrame_t) {
+unsafe extern "C" fn CG_DrawUpperRight(mut stereoFrame: stereoFrame_t) {
     let mut y: libc::c_float = 0.;
     y = 0 as libc::c_int as libc::c_float;
-    if crate::src::cgame::cg_main::cgs.gametype as libc::c_uint
+    if cgs.gametype as libc::c_uint
         >= crate::bg_public_h::GT_TEAM as libc::c_int as libc::c_uint
-        && crate::src::cgame::cg_main::cg_drawTeamOverlay.integer == 1 as libc::c_int
+        && cg_drawTeamOverlay.integer == 1 as libc::c_int
     {
         y = CG_DrawTeamOverlay(
             y,
-            crate::src::qcommon::q_shared::qtrue,
-            crate::src::qcommon::q_shared::qtrue,
+            qtrue,
+            qtrue,
         )
     }
-    if crate::src::cgame::cg_main::cg_drawSnapshot.integer != 0 {
+    if cg_drawSnapshot.integer != 0 {
         y = CG_DrawSnapshot(y)
     }
-    if crate::src::cgame::cg_main::cg_drawFPS.integer != 0
+    if cg_drawFPS.integer != 0
         && (stereoFrame as libc::c_uint
-            == crate::tr_types_h::STEREO_CENTER as libc::c_int as libc::c_uint
+            == STEREO_CENTER as libc::c_int as libc::c_uint
             || stereoFrame as libc::c_uint
-                == crate::tr_types_h::STEREO_RIGHT as libc::c_int as libc::c_uint)
+                == STEREO_RIGHT as libc::c_int as libc::c_uint)
     {
         y = CG_DrawFPS(y)
     }
-    if crate::src::cgame::cg_main::cg_drawTimer.integer != 0 {
+    if cg_drawTimer.integer != 0 {
         y = CG_DrawTimer(y)
     }
-    if crate::src::cgame::cg_main::cg_drawAttacker.integer != 0 {
+    if cg_drawAttacker.integer != 0 {
         CG_DrawAttacker(y);
     };
 }
@@ -1634,15 +1634,15 @@ unsafe extern "C" fn CG_DrawScores(mut y: libc::c_float) -> libc::c_float {
     let mut x: libc::c_int = 0;
     let mut w: libc::c_int = 0;
     let mut v: libc::c_int = 0;
-    let mut color: crate::src::qcommon::q_shared::vec4_t = [0.; 4];
+    let mut color: vec4_t = [0.; 4];
     let mut y1: libc::c_float = 0.;
     let mut item: *mut crate::bg_public_h::gitem_t = 0 as *mut crate::bg_public_h::gitem_t;
-    s1 = crate::src::cgame::cg_main::cgs.scores1;
-    s2 = crate::src::cgame::cg_main::cgs.scores2;
+    s1 = cgs.scores1;
+    s2 = cgs.scores2;
     y -= (16 as libc::c_int + 8 as libc::c_int) as libc::c_float;
     y1 = y;
     // draw from the right side to left
-    if crate::src::cgame::cg_main::cgs.gametype as libc::c_uint
+    if cgs.gametype as libc::c_uint
         >= crate::bg_public_h::GT_TEAM as libc::c_int as libc::c_uint
     {
         x = 640 as libc::c_int;
@@ -1650,39 +1650,39 @@ unsafe extern "C" fn CG_DrawScores(mut y: libc::c_float) -> libc::c_float {
         color[1 as libc::c_int as usize] = 0.0f32;
         color[2 as libc::c_int as usize] = 1.0f32;
         color[3 as libc::c_int as usize] = 0.33f32;
-        s = crate::src::qcommon::q_shared::va(
+        s = va(
             b"%2i\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             s2,
         );
-        w = crate::src::cgame::cg_drawtools::CG_DrawStrlen(s) * 16 as libc::c_int
+        w = CG_DrawStrlen(s) * 16 as libc::c_int
             + 8 as libc::c_int;
         x -= w;
-        crate::src::cgame::cg_drawtools::CG_FillRect(
+        CG_FillRect(
             x as libc::c_float,
             y - 4 as libc::c_int as libc::c_float,
             w as libc::c_float,
             (16 as libc::c_int + 8 as libc::c_int) as libc::c_float,
             color.as_mut_ptr(),
         );
-        if (*crate::src::cgame::cg_main::cg.snap).ps.persistant
+        if (*cg.snap).ps.persistant
             [crate::bg_public_h::PERS_TEAM as libc::c_int as usize]
             == crate::bg_public_h::TEAM_BLUE as libc::c_int
         {
-            crate::src::cgame::cg_drawtools::CG_DrawPic(
+            CG_DrawPic(
                 x as libc::c_float,
                 y - 4 as libc::c_int as libc::c_float,
                 w as libc::c_float,
                 (16 as libc::c_int + 8 as libc::c_int) as libc::c_float,
-                crate::src::cgame::cg_main::cgs.media.selectShader,
+                cgs.media.selectShader,
             );
         }
-        crate::src::cgame::cg_drawtools::CG_DrawBigString(
+        CG_DrawBigString(
             x + 4 as libc::c_int,
             y as libc::c_int,
             s,
             1.0f32,
         );
-        if crate::src::cgame::cg_main::cgs.gametype as libc::c_uint
+        if cgs.gametype as libc::c_uint
             == crate::bg_public_h::GT_CTF as libc::c_int as libc::c_uint
         {
             // Display flag status
@@ -1690,16 +1690,16 @@ unsafe extern "C" fn CG_DrawScores(mut y: libc::c_float) -> libc::c_float {
                 as *mut crate::bg_public_h::gitem_s;
             if !item.is_null() {
                 y1 = y - 16 as libc::c_int as libc::c_float - 8 as libc::c_int as libc::c_float;
-                if crate::src::cgame::cg_main::cgs.blueflag >= 0 as libc::c_int
-                    && crate::src::cgame::cg_main::cgs.blueflag <= 2 as libc::c_int
+                if cgs.blueflag >= 0 as libc::c_int
+                    && cgs.blueflag <= 2 as libc::c_int
                 {
-                    crate::src::cgame::cg_drawtools::CG_DrawPic(
+                    CG_DrawPic(
                         x as libc::c_float,
                         y1 - 4 as libc::c_int as libc::c_float,
                         w as libc::c_float,
                         (16 as libc::c_int + 8 as libc::c_int) as libc::c_float,
-                        crate::src::cgame::cg_main::cgs.media.blueFlagShader
-                            [crate::src::cgame::cg_main::cgs.blueflag as usize],
+                        cgs.media.blueFlagShader
+                            [cgs.blueflag as usize],
                     );
                 }
             }
@@ -1708,39 +1708,39 @@ unsafe extern "C" fn CG_DrawScores(mut y: libc::c_float) -> libc::c_float {
         color[1 as libc::c_int as usize] = 0.0f32;
         color[2 as libc::c_int as usize] = 0.0f32;
         color[3 as libc::c_int as usize] = 0.33f32;
-        s = crate::src::qcommon::q_shared::va(
+        s = va(
             b"%2i\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             s1,
         );
-        w = crate::src::cgame::cg_drawtools::CG_DrawStrlen(s) * 16 as libc::c_int
+        w = CG_DrawStrlen(s) * 16 as libc::c_int
             + 8 as libc::c_int;
         x -= w;
-        crate::src::cgame::cg_drawtools::CG_FillRect(
+        CG_FillRect(
             x as libc::c_float,
             y - 4 as libc::c_int as libc::c_float,
             w as libc::c_float,
             (16 as libc::c_int + 8 as libc::c_int) as libc::c_float,
             color.as_mut_ptr(),
         );
-        if (*crate::src::cgame::cg_main::cg.snap).ps.persistant
+        if (*cg.snap).ps.persistant
             [crate::bg_public_h::PERS_TEAM as libc::c_int as usize]
             == crate::bg_public_h::TEAM_RED as libc::c_int
         {
-            crate::src::cgame::cg_drawtools::CG_DrawPic(
+            CG_DrawPic(
                 x as libc::c_float,
                 y - 4 as libc::c_int as libc::c_float,
                 w as libc::c_float,
                 (16 as libc::c_int + 8 as libc::c_int) as libc::c_float,
-                crate::src::cgame::cg_main::cgs.media.selectShader,
+                cgs.media.selectShader,
             );
         }
-        crate::src::cgame::cg_drawtools::CG_DrawBigString(
+        CG_DrawBigString(
             x + 4 as libc::c_int,
             y as libc::c_int,
             s,
             1.0f32,
         );
-        if crate::src::cgame::cg_main::cgs.gametype as libc::c_uint
+        if cgs.gametype as libc::c_uint
             == crate::bg_public_h::GT_CTF as libc::c_int as libc::c_uint
         {
             // Display flag status
@@ -1748,36 +1748,36 @@ unsafe extern "C" fn CG_DrawScores(mut y: libc::c_float) -> libc::c_float {
                 as *mut crate::bg_public_h::gitem_s;
             if !item.is_null() {
                 y1 = y - 16 as libc::c_int as libc::c_float - 8 as libc::c_int as libc::c_float;
-                if crate::src::cgame::cg_main::cgs.redflag >= 0 as libc::c_int
-                    && crate::src::cgame::cg_main::cgs.redflag <= 2 as libc::c_int
+                if cgs.redflag >= 0 as libc::c_int
+                    && cgs.redflag <= 2 as libc::c_int
                 {
-                    crate::src::cgame::cg_drawtools::CG_DrawPic(
+                    CG_DrawPic(
                         x as libc::c_float,
                         y1 - 4 as libc::c_int as libc::c_float,
                         w as libc::c_float,
                         (16 as libc::c_int + 8 as libc::c_int) as libc::c_float,
-                        crate::src::cgame::cg_main::cgs.media.redFlagShader
-                            [crate::src::cgame::cg_main::cgs.redflag as usize],
+                        cgs.media.redFlagShader
+                            [cgs.redflag as usize],
                     );
                 }
             }
         }
-        if crate::src::cgame::cg_main::cgs.gametype as libc::c_uint
+        if cgs.gametype as libc::c_uint
             >= crate::bg_public_h::GT_CTF as libc::c_int as libc::c_uint
         {
-            v = crate::src::cgame::cg_main::cgs.capturelimit
+            v = cgs.capturelimit
         } else {
-            v = crate::src::cgame::cg_main::cgs.fraglimit
+            v = cgs.fraglimit
         }
         if v != 0 {
-            s = crate::src::qcommon::q_shared::va(
+            s = va(
                 b"%2i\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 v,
             );
-            w = crate::src::cgame::cg_drawtools::CG_DrawStrlen(s) * 16 as libc::c_int
+            w = CG_DrawStrlen(s) * 16 as libc::c_int
                 + 8 as libc::c_int;
             x -= w;
-            crate::src::cgame::cg_drawtools::CG_DrawBigString(
+            CG_DrawBigString(
                 x + 4 as libc::c_int,
                 y as libc::c_int,
                 s,
@@ -1785,25 +1785,25 @@ unsafe extern "C" fn CG_DrawScores(mut y: libc::c_float) -> libc::c_float {
             );
         }
     } else {
-        let mut spectator: crate::src::qcommon::q_shared::qboolean =
-            crate::src::qcommon::q_shared::qfalse;
+        let mut spectator: qboolean =
+            qfalse;
         x = 640 as libc::c_int;
-        score = (*crate::src::cgame::cg_main::cg.snap).ps.persistant
+        score = (*cg.snap).ps.persistant
             [crate::bg_public_h::PERS_SCORE as libc::c_int as usize];
-        spectator = ((*crate::src::cgame::cg_main::cg.snap).ps.persistant
+        spectator = ((*cg.snap).ps.persistant
             [crate::bg_public_h::PERS_TEAM as libc::c_int as usize]
             == crate::bg_public_h::TEAM_SPECTATOR as libc::c_int) as libc::c_int
-            as crate::src::qcommon::q_shared::qboolean;
+            as qboolean;
         // always show your score in the second box if not in first place
         if s1 != score {
             s2 = score
         }
         if s2 != -(9999 as libc::c_int) {
-            s = crate::src::qcommon::q_shared::va(
+            s = va(
                 b"%2i\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 s2,
             );
-            w = crate::src::cgame::cg_drawtools::CG_DrawStrlen(s) * 16 as libc::c_int
+            w = CG_DrawStrlen(s) * 16 as libc::c_int
                 + 8 as libc::c_int;
             x -= w;
             if spectator as u64 == 0 && score == s2 && score != s1 {
@@ -1811,26 +1811,26 @@ unsafe extern "C" fn CG_DrawScores(mut y: libc::c_float) -> libc::c_float {
                 color[1 as libc::c_int as usize] = 0.0f32;
                 color[2 as libc::c_int as usize] = 0.0f32;
                 color[3 as libc::c_int as usize] = 0.33f32;
-                crate::src::cgame::cg_drawtools::CG_FillRect(
+                CG_FillRect(
                     x as libc::c_float,
                     y - 4 as libc::c_int as libc::c_float,
                     w as libc::c_float,
                     (16 as libc::c_int + 8 as libc::c_int) as libc::c_float,
                     color.as_mut_ptr(),
                 );
-                crate::src::cgame::cg_drawtools::CG_DrawPic(
+                CG_DrawPic(
                     x as libc::c_float,
                     y - 4 as libc::c_int as libc::c_float,
                     w as libc::c_float,
                     (16 as libc::c_int + 8 as libc::c_int) as libc::c_float,
-                    crate::src::cgame::cg_main::cgs.media.selectShader,
+                    cgs.media.selectShader,
                 );
             } else {
                 color[0 as libc::c_int as usize] = 0.5f32;
                 color[1 as libc::c_int as usize] = 0.5f32;
                 color[2 as libc::c_int as usize] = 0.5f32;
                 color[3 as libc::c_int as usize] = 0.33f32;
-                crate::src::cgame::cg_drawtools::CG_FillRect(
+                CG_FillRect(
                     x as libc::c_float,
                     y - 4 as libc::c_int as libc::c_float,
                     w as libc::c_float,
@@ -1838,7 +1838,7 @@ unsafe extern "C" fn CG_DrawScores(mut y: libc::c_float) -> libc::c_float {
                     color.as_mut_ptr(),
                 );
             }
-            crate::src::cgame::cg_drawtools::CG_DrawBigString(
+            CG_DrawBigString(
                 x + 4 as libc::c_int,
                 y as libc::c_int,
                 s,
@@ -1847,11 +1847,11 @@ unsafe extern "C" fn CG_DrawScores(mut y: libc::c_float) -> libc::c_float {
         }
         // first place
         if s1 != -(9999 as libc::c_int) {
-            s = crate::src::qcommon::q_shared::va(
+            s = va(
                 b"%2i\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 s1,
             );
-            w = crate::src::cgame::cg_drawtools::CG_DrawStrlen(s) * 16 as libc::c_int
+            w = CG_DrawStrlen(s) * 16 as libc::c_int
                 + 8 as libc::c_int;
             x -= w;
             if spectator as u64 == 0 && score == s1 {
@@ -1859,26 +1859,26 @@ unsafe extern "C" fn CG_DrawScores(mut y: libc::c_float) -> libc::c_float {
                 color[1 as libc::c_int as usize] = 0.0f32;
                 color[2 as libc::c_int as usize] = 1.0f32;
                 color[3 as libc::c_int as usize] = 0.33f32;
-                crate::src::cgame::cg_drawtools::CG_FillRect(
+                CG_FillRect(
                     x as libc::c_float,
                     y - 4 as libc::c_int as libc::c_float,
                     w as libc::c_float,
                     (16 as libc::c_int + 8 as libc::c_int) as libc::c_float,
                     color.as_mut_ptr(),
                 );
-                crate::src::cgame::cg_drawtools::CG_DrawPic(
+                CG_DrawPic(
                     x as libc::c_float,
                     y - 4 as libc::c_int as libc::c_float,
                     w as libc::c_float,
                     (16 as libc::c_int + 8 as libc::c_int) as libc::c_float,
-                    crate::src::cgame::cg_main::cgs.media.selectShader,
+                    cgs.media.selectShader,
                 );
             } else {
                 color[0 as libc::c_int as usize] = 0.5f32;
                 color[1 as libc::c_int as usize] = 0.5f32;
                 color[2 as libc::c_int as usize] = 0.5f32;
                 color[3 as libc::c_int as usize] = 0.33f32;
-                crate::src::cgame::cg_drawtools::CG_FillRect(
+                CG_FillRect(
                     x as libc::c_float,
                     y - 4 as libc::c_int as libc::c_float,
                     w as libc::c_float,
@@ -1886,22 +1886,22 @@ unsafe extern "C" fn CG_DrawScores(mut y: libc::c_float) -> libc::c_float {
                     color.as_mut_ptr(),
                 );
             }
-            crate::src::cgame::cg_drawtools::CG_DrawBigString(
+            CG_DrawBigString(
                 x + 4 as libc::c_int,
                 y as libc::c_int,
                 s,
                 1.0f32,
             );
         }
-        if crate::src::cgame::cg_main::cgs.fraglimit != 0 {
-            s = crate::src::qcommon::q_shared::va(
+        if cgs.fraglimit != 0 {
+            s = va(
                 b"%2i\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-                crate::src::cgame::cg_main::cgs.fraglimit,
+                cgs.fraglimit,
             );
-            w = crate::src::cgame::cg_drawtools::CG_DrawStrlen(s) * 16 as libc::c_int
+            w = CG_DrawStrlen(s) * 16 as libc::c_int
                 + 8 as libc::c_int;
             x -= w;
-            crate::src::cgame::cg_drawtools::CG_DrawBigString(
+            CG_DrawBigString(
                 x + 4 as libc::c_int,
                 y as libc::c_int,
                 s,
@@ -1925,8 +1925,8 @@ unsafe extern "C" fn CG_DrawPowerups(mut y: libc::c_float) -> libc::c_float {
     let mut j: libc::c_int = 0;
     let mut k: libc::c_int = 0;
     let mut active: libc::c_int = 0;
-    let mut ps: *mut crate::src::qcommon::q_shared::playerState_t =
-        0 as *mut crate::src::qcommon::q_shared::playerState_t;
+    let mut ps: *mut playerState_t =
+        0 as *mut playerState_t;
     let mut t: libc::c_int = 0;
     let mut item: *mut crate::bg_public_h::gitem_t = 0 as *mut crate::bg_public_h::gitem_t;
     let mut x: libc::c_int = 0;
@@ -1937,7 +1937,7 @@ unsafe extern "C" fn CG_DrawPowerups(mut y: libc::c_float) -> libc::c_float {
         [0.2f32, 1.0f32, 0.2f32, 1.0f32],
         [1.0f32, 0.2f32, 0.2f32, 1.0f32],
     ];
-    ps = &mut (*crate::src::cgame::cg_main::cg.snap).ps;
+    ps = &mut (*cg.snap).ps;
     if (*ps).stats[crate::bg_public_h::STAT_HEALTH as libc::c_int as usize] <= 0 as libc::c_int {
         return y;
     }
@@ -1949,7 +1949,7 @@ unsafe extern "C" fn CG_DrawPowerups(mut y: libc::c_float) -> libc::c_float {
             // ZOID--don't draw if the power up has unlimited time
             // This is true of the CTF flags
             if !((*ps).powerups[i as usize] == 2147483647 as libc::c_int) {
-                t = (*ps).powerups[i as usize] - crate::src::cgame::cg_main::cg.time;
+                t = (*ps).powerups[i as usize] - cg.time;
                 if !(t <= 0 as libc::c_int) {
                     // insert into the list
                     j = 0 as libc::c_int;
@@ -1993,11 +1993,11 @@ unsafe extern "C" fn CG_DrawPowerups(mut y: libc::c_float) -> libc::c_float {
                 sortedTime[i as usize] / 1000 as libc::c_int,
             );
             t = (*ps).powerups[sorted[i as usize] as usize];
-            if t - crate::src::cgame::cg_main::cg.time >= 5 as libc::c_int * 1000 as libc::c_int {
+            if t - cg.time >= 5 as libc::c_int * 1000 as libc::c_int {
                 crate::src::cgame::cg_syscalls::trap_R_SetColor(0 as *const libc::c_float);
             } else {
-                let mut modulate: crate::src::qcommon::q_shared::vec4_t = [0.; 4];
-                f = (t - crate::src::cgame::cg_main::cg.time) as libc::c_float
+                let mut modulate: vec4_t = [0.; 4];
+                f = (t - cg.time) as libc::c_float
                     / 1000 as libc::c_int as libc::c_float;
                 f -= f as libc::c_int as libc::c_float;
                 modulate[3 as libc::c_int as usize] = f;
@@ -2006,13 +2006,13 @@ unsafe extern "C" fn CG_DrawPowerups(mut y: libc::c_float) -> libc::c_float {
                 modulate[0 as libc::c_int as usize] = modulate[1 as libc::c_int as usize];
                 crate::src::cgame::cg_syscalls::trap_R_SetColor(modulate.as_mut_ptr());
             }
-            if crate::src::cgame::cg_main::cg.powerupActive == sorted[i as usize]
-                && crate::src::cgame::cg_main::cg.time - crate::src::cgame::cg_main::cg.powerupTime
+            if cg.powerupActive == sorted[i as usize]
+                && cg.time - cg.powerupTime
                     < 200 as libc::c_int
             {
                 f = (1.0f64
-                    - ((crate::src::cgame::cg_main::cg.time as libc::c_float
-                        - crate::src::cgame::cg_main::cg.powerupTime as libc::c_float)
+                    - ((cg.time as libc::c_float
+                        - cg.powerupTime as libc::c_float)
                         / 200 as libc::c_int as libc::c_float)
                         as libc::c_double) as libc::c_float;
                 size = (48 as libc::c_int as libc::c_double
@@ -2021,7 +2021,7 @@ unsafe extern "C" fn CG_DrawPowerups(mut y: libc::c_float) -> libc::c_float {
             } else {
                 size = 48 as libc::c_int as libc::c_float
             }
-            crate::src::cgame::cg_drawtools::CG_DrawPic(
+            CG_DrawPic(
                 640 as libc::c_int as libc::c_float - size,
                 y + (48 as libc::c_int / 2 as libc::c_int) as libc::c_float
                     - size / 2 as libc::c_int as libc::c_float,
@@ -2046,14 +2046,14 @@ CG_DrawLowerRight
 unsafe extern "C" fn CG_DrawLowerRight() {
     let mut y: libc::c_float = 0.;
     y = (480 as libc::c_int - 48 as libc::c_int) as libc::c_float;
-    if crate::src::cgame::cg_main::cgs.gametype as libc::c_uint
+    if cgs.gametype as libc::c_uint
         >= crate::bg_public_h::GT_TEAM as libc::c_int as libc::c_uint
-        && crate::src::cgame::cg_main::cg_drawTeamOverlay.integer == 2 as libc::c_int
+        && cg_drawTeamOverlay.integer == 2 as libc::c_int
     {
         y = CG_DrawTeamOverlay(
             y,
-            crate::src::qcommon::q_shared::qtrue,
-            crate::src::qcommon::q_shared::qfalse,
+            qtrue,
+            qfalse,
         )
     }
     y = CG_DrawScores(y);
@@ -2069,30 +2069,30 @@ CG_DrawPickupItem
 unsafe extern "C" fn CG_DrawPickupItem(mut y: libc::c_int) -> libc::c_int {
     let mut value: libc::c_int = 0;
     let mut fadeColor: *mut libc::c_float = 0 as *mut libc::c_float;
-    if (*crate::src::cgame::cg_main::cg.snap).ps.stats
+    if (*cg.snap).ps.stats
         [crate::bg_public_h::STAT_HEALTH as libc::c_int as usize]
         <= 0 as libc::c_int
     {
         return y;
     }
     y -= 48 as libc::c_int;
-    value = crate::src::cgame::cg_main::cg.itemPickup;
+    value = cg.itemPickup;
     if value != 0 {
-        fadeColor = crate::src::cgame::cg_drawtools::CG_FadeColor(
-            crate::src::cgame::cg_main::cg.itemPickupTime,
+        fadeColor = CG_FadeColor(
+            cg.itemPickupTime,
             3000 as libc::c_int,
         );
         if !fadeColor.is_null() {
             crate::src::cgame::cg_weapons::CG_RegisterItemVisuals(value);
             crate::src::cgame::cg_syscalls::trap_R_SetColor(fadeColor);
-            crate::src::cgame::cg_drawtools::CG_DrawPic(
+            CG_DrawPic(
                 8 as libc::c_int as libc::c_float,
                 y as libc::c_float,
                 48 as libc::c_int as libc::c_float,
                 48 as libc::c_int as libc::c_float,
-                crate::src::cgame::cg_main::cg_items[value as usize].icon,
+                cg_items[value as usize].icon,
             );
-            crate::src::cgame::cg_drawtools::CG_DrawBigString(
+            CG_DrawBigString(
                 48 as libc::c_int + 16 as libc::c_int,
                 y + (48 as libc::c_int / 2 as libc::c_int - 16 as libc::c_int / 2 as libc::c_int),
                 (*crate::src::game::bg_misc::bg_itemlist
@@ -2117,14 +2117,14 @@ CG_DrawLowerLeft
 unsafe extern "C" fn CG_DrawLowerLeft() {
     let mut y: libc::c_float = 0.;
     y = (480 as libc::c_int - 48 as libc::c_int) as libc::c_float;
-    if crate::src::cgame::cg_main::cgs.gametype as libc::c_uint
+    if cgs.gametype as libc::c_uint
         >= crate::bg_public_h::GT_TEAM as libc::c_int as libc::c_uint
-        && crate::src::cgame::cg_main::cg_drawTeamOverlay.integer == 3 as libc::c_int
+        && cg_drawTeamOverlay.integer == 3 as libc::c_int
     {
         y = CG_DrawTeamOverlay(
             y,
-            crate::src::qcommon::q_shared::qfalse,
-            crate::src::qcommon::q_shared::qfalse,
+            qfalse,
+            qfalse,
         )
     }
     CG_DrawPickupItem(y as libc::c_int);
@@ -2140,32 +2140,32 @@ CG_DrawTeamInfo
 unsafe extern "C" fn CG_DrawTeamInfo() {
     let mut h: libc::c_int = 0;
     let mut i: libc::c_int = 0;
-    let mut hcolor: crate::src::qcommon::q_shared::vec4_t = [0.; 4];
+    let mut hcolor: vec4_t = [0.; 4];
     let mut chatHeight: libc::c_int = 0;
     // bottom end
-    if crate::src::cgame::cg_main::cg_teamChatHeight.integer < 8 as libc::c_int {
-        chatHeight = crate::src::cgame::cg_main::cg_teamChatHeight.integer
+    if cg_teamChatHeight.integer < 8 as libc::c_int {
+        chatHeight = cg_teamChatHeight.integer
     } else {
         chatHeight = 8 as libc::c_int
     } // disabled
     if chatHeight <= 0 as libc::c_int {
         return;
     }
-    if crate::src::cgame::cg_main::cgs.teamLastChatPos
-        != crate::src::cgame::cg_main::cgs.teamChatPos
+    if cgs.teamLastChatPos
+        != cgs.teamChatPos
     {
-        if crate::src::cgame::cg_main::cg.time
-            - crate::src::cgame::cg_main::cgs.teamChatMsgTimes
-                [(crate::src::cgame::cg_main::cgs.teamLastChatPos % chatHeight) as usize]
-            > crate::src::cgame::cg_main::cg_teamChatTime.integer
+        if cg.time
+            - cgs.teamChatMsgTimes
+                [(cgs.teamLastChatPos % chatHeight) as usize]
+            > cg_teamChatTime.integer
         {
-            crate::src::cgame::cg_main::cgs.teamLastChatPos += 1
+            cgs.teamLastChatPos += 1
         }
-        h = (crate::src::cgame::cg_main::cgs.teamChatPos
-            - crate::src::cgame::cg_main::cgs.teamLastChatPos)
+        h = (cgs.teamChatPos
+            - cgs.teamLastChatPos)
             * (16 as libc::c_int / 2 as libc::c_int);
-        if crate::src::cgame::cg_main::cgs.clientinfo
-            [crate::src::cgame::cg_main::cg.clientNum as usize]
+        if cgs.clientinfo
+            [cg.clientNum as usize]
             .team as libc::c_uint
             == crate::bg_public_h::TEAM_RED as libc::c_int as libc::c_uint
         {
@@ -2173,8 +2173,8 @@ unsafe extern "C" fn CG_DrawTeamInfo() {
             hcolor[1 as libc::c_int as usize] = 0.0f32;
             hcolor[2 as libc::c_int as usize] = 0.0f32;
             hcolor[3 as libc::c_int as usize] = 0.33f32
-        } else if crate::src::cgame::cg_main::cgs.clientinfo
-            [crate::src::cgame::cg_main::cg.clientNum as usize]
+        } else if cgs.clientinfo
+            [cg.clientNum as usize]
             .team as libc::c_uint
             == crate::bg_public_h::TEAM_BLUE as libc::c_int as libc::c_uint
         {
@@ -2189,30 +2189,30 @@ unsafe extern "C" fn CG_DrawTeamInfo() {
             hcolor[3 as libc::c_int as usize] = 0.33f32
         }
         crate::src::cgame::cg_syscalls::trap_R_SetColor(hcolor.as_mut_ptr());
-        crate::src::cgame::cg_drawtools::CG_DrawPic(
+        CG_DrawPic(
             0 as libc::c_int as libc::c_float,
             (420 as libc::c_int - h) as libc::c_float,
             640 as libc::c_int as libc::c_float,
             h as libc::c_float,
-            crate::src::cgame::cg_main::cgs.media.teamStatusBar,
+            cgs.media.teamStatusBar,
         );
         crate::src::cgame::cg_syscalls::trap_R_SetColor(0 as *const libc::c_float);
         hcolor[2 as libc::c_int as usize] = 1.0f32;
         hcolor[1 as libc::c_int as usize] = hcolor[2 as libc::c_int as usize];
         hcolor[0 as libc::c_int as usize] = hcolor[1 as libc::c_int as usize];
         hcolor[3 as libc::c_int as usize] = 1.0f32;
-        i = crate::src::cgame::cg_main::cgs.teamChatPos - 1 as libc::c_int;
-        while i >= crate::src::cgame::cg_main::cgs.teamLastChatPos {
-            crate::src::cgame::cg_drawtools::CG_DrawStringExt(
+        i = cgs.teamChatPos - 1 as libc::c_int;
+        while i >= cgs.teamLastChatPos {
+            CG_DrawStringExt(
                 0 as libc::c_int + 8 as libc::c_int,
                 420 as libc::c_int
-                    - (crate::src::cgame::cg_main::cgs.teamChatPos - i)
+                    - (cgs.teamChatPos - i)
                         * (16 as libc::c_int / 2 as libc::c_int),
-                crate::src::cgame::cg_main::cgs.teamChatMsgs[(i % chatHeight) as usize]
+                cgs.teamChatMsgs[(i % chatHeight) as usize]
                     .as_mut_ptr(),
                 hcolor.as_mut_ptr(),
-                crate::src::qcommon::q_shared::qfalse,
-                crate::src::qcommon::q_shared::qfalse,
+                qfalse,
+                qfalse,
                 8 as libc::c_int,
                 16 as libc::c_int / 2 as libc::c_int,
                 0 as libc::c_int,
@@ -2230,16 +2230,16 @@ CG_DrawHoldableItem
 
 unsafe extern "C" fn CG_DrawHoldableItem() {
     let mut value: libc::c_int = 0;
-    value = (*crate::src::cgame::cg_main::cg.snap).ps.stats
+    value = (*cg.snap).ps.stats
         [crate::bg_public_h::STAT_HOLDABLE_ITEM as libc::c_int as usize];
     if value != 0 {
         crate::src::cgame::cg_weapons::CG_RegisterItemVisuals(value);
-        crate::src::cgame::cg_drawtools::CG_DrawPic(
+        CG_DrawPic(
             (640 as libc::c_int - 48 as libc::c_int) as libc::c_float,
             ((480 as libc::c_int - 48 as libc::c_int) / 2 as libc::c_int) as libc::c_float,
             48 as libc::c_int as libc::c_float,
             48 as libc::c_int as libc::c_float,
-            crate::src::cgame::cg_main::cg_items[value as usize].icon,
+            cg_items[value as usize].icon,
         );
     };
 }
@@ -2258,34 +2258,34 @@ unsafe extern "C" fn CG_DrawReward() {
     let mut x: libc::c_float = 0.;
     let mut y: libc::c_float = 0.;
     let mut buf: [libc::c_char; 32] = [0; 32];
-    if crate::src::cgame::cg_main::cg_drawRewards.integer == 0 {
+    if cg_drawRewards.integer == 0 {
         return;
     }
-    color = crate::src::cgame::cg_drawtools::CG_FadeColor(
-        crate::src::cgame::cg_main::cg.rewardTime,
+    color = CG_FadeColor(
+        cg.rewardTime,
         3000 as libc::c_int,
     );
     if color.is_null() {
-        if crate::src::cgame::cg_main::cg.rewardStack > 0 as libc::c_int {
+        if cg.rewardStack > 0 as libc::c_int {
             i = 0 as libc::c_int;
-            while i < crate::src::cgame::cg_main::cg.rewardStack {
-                crate::src::cgame::cg_main::cg.rewardSound[i as usize] =
-                    crate::src::cgame::cg_main::cg.rewardSound[(i + 1 as libc::c_int) as usize];
-                crate::src::cgame::cg_main::cg.rewardShader[i as usize] =
-                    crate::src::cgame::cg_main::cg.rewardShader[(i + 1 as libc::c_int) as usize];
-                crate::src::cgame::cg_main::cg.rewardCount[i as usize] =
-                    crate::src::cgame::cg_main::cg.rewardCount[(i + 1 as libc::c_int) as usize];
+            while i < cg.rewardStack {
+                cg.rewardSound[i as usize] =
+                    cg.rewardSound[(i + 1 as libc::c_int) as usize];
+                cg.rewardShader[i as usize] =
+                    cg.rewardShader[(i + 1 as libc::c_int) as usize];
+                cg.rewardCount[i as usize] =
+                    cg.rewardCount[(i + 1 as libc::c_int) as usize];
                 i += 1
             }
-            crate::src::cgame::cg_main::cg.rewardTime = crate::src::cgame::cg_main::cg.time;
-            crate::src::cgame::cg_main::cg.rewardStack -= 1;
-            color = crate::src::cgame::cg_drawtools::CG_FadeColor(
-                crate::src::cgame::cg_main::cg.rewardTime,
+            cg.rewardTime = cg.time;
+            cg.rewardStack -= 1;
+            color = CG_FadeColor(
+                cg.rewardTime,
                 3000 as libc::c_int,
             );
             crate::src::cgame::cg_syscalls::trap_S_StartLocalSound(
-                crate::src::cgame::cg_main::cg.rewardSound[0 as libc::c_int as usize],
-                crate::src::qcommon::q_shared::CHAN_ANNOUNCER as libc::c_int,
+                cg.rewardSound[0 as libc::c_int as usize],
+                CHAN_ANNOUNCER as libc::c_int,
             );
         } else {
             return;
@@ -2306,48 +2306,48 @@ unsafe extern "C" fn CG_DrawReward() {
 
     count = cg.rewardCount[0] - count*10;		// number of small rewards to draw
     */
-    if crate::src::cgame::cg_main::cg.rewardCount[0 as libc::c_int as usize] >= 10 as libc::c_int {
+    if cg.rewardCount[0 as libc::c_int as usize] >= 10 as libc::c_int {
         y = 56 as libc::c_int as libc::c_float;
         x = (320 as libc::c_int - 48 as libc::c_int / 2 as libc::c_int) as libc::c_float;
-        crate::src::cgame::cg_drawtools::CG_DrawPic(
+        CG_DrawPic(
             x,
             y,
             (48 as libc::c_int - 4 as libc::c_int) as libc::c_float,
             (48 as libc::c_int - 4 as libc::c_int) as libc::c_float,
-            crate::src::cgame::cg_main::cg.rewardShader[0 as libc::c_int as usize],
+            cg.rewardShader[0 as libc::c_int as usize],
         );
-        crate::src::qcommon::q_shared::Com_sprintf(
+        Com_sprintf(
             buf.as_mut_ptr(),
             ::std::mem::size_of::<[libc::c_char; 32]>() as libc::c_ulong as libc::c_int,
             b"%d\x00" as *const u8 as *const libc::c_char,
-            crate::src::cgame::cg_main::cg.rewardCount[0 as libc::c_int as usize],
+            cg.rewardCount[0 as libc::c_int as usize],
         );
         x = ((640 as libc::c_int
-            - 8 as libc::c_int * crate::src::cgame::cg_drawtools::CG_DrawStrlen(buf.as_mut_ptr()))
+            - 8 as libc::c_int * CG_DrawStrlen(buf.as_mut_ptr()))
             / 2 as libc::c_int) as libc::c_float;
-        crate::src::cgame::cg_drawtools::CG_DrawStringExt(
+        CG_DrawStringExt(
             x as libc::c_int,
             (y + 48 as libc::c_int as libc::c_float) as libc::c_int,
             buf.as_mut_ptr(),
             color,
-            crate::src::qcommon::q_shared::qfalse,
-            crate::src::qcommon::q_shared::qtrue,
+            qfalse,
+            qtrue,
             8 as libc::c_int,
             16 as libc::c_int,
             0 as libc::c_int,
         );
     } else {
-        count = crate::src::cgame::cg_main::cg.rewardCount[0 as libc::c_int as usize];
+        count = cg.rewardCount[0 as libc::c_int as usize];
         y = 56 as libc::c_int as libc::c_float;
         x = (320 as libc::c_int - count * 48 as libc::c_int / 2 as libc::c_int) as libc::c_float;
         i = 0 as libc::c_int;
         while i < count {
-            crate::src::cgame::cg_drawtools::CG_DrawPic(
+            CG_DrawPic(
                 x,
                 y,
                 (48 as libc::c_int - 4 as libc::c_int) as libc::c_float,
                 (48 as libc::c_int - 4 as libc::c_int) as libc::c_float,
-                crate::src::cgame::cg_main::cg.rewardShader[0 as libc::c_int as usize],
+                cg.rewardShader[0 as libc::c_int as usize],
             );
             x += 48 as libc::c_int as libc::c_float;
             i += 1
@@ -2376,7 +2376,7 @@ Adds the current interpolate / extrapolate bar for this frame
 pub unsafe extern "C" fn CG_AddLagometerFrameInfo() {
     let mut offset: libc::c_int = 0;
     offset =
-        crate::src::cgame::cg_main::cg.time - crate::src::cgame::cg_main::cg.latestSnapshotTime;
+        cg.time - cg.latestSnapshotTime;
     lagometer.frameSamples
         [(lagometer.frameCount & 128 as libc::c_int - 1 as libc::c_int) as usize] = offset;
     lagometer.frameCount += 1;
@@ -2424,8 +2424,8 @@ unsafe extern "C" fn CG_DrawDisconnect() {
     let mut x: libc::c_float = 0.;
     let mut y: libc::c_float = 0.;
     let mut cmdNum: libc::c_int = 0;
-    let mut cmd: crate::src::qcommon::q_shared::usercmd_t =
-        crate::src::qcommon::q_shared::usercmd_t {
+    let mut cmd: usercmd_t =
+        usercmd_t {
             serverTime: 0,
             angles: [0; 3],
             buttons: 0,
@@ -2441,30 +2441,30 @@ unsafe extern "C" fn CG_DrawDisconnect() {
         + 1 as libc::c_int;
     crate::src::cgame::cg_syscalls::trap_GetUserCmd(
         cmdNum,
-        &mut cmd as *mut _ as *mut crate::src::qcommon::q_shared::usercmd_s,
+        &mut cmd as *mut _ as *mut usercmd_s,
     );
-    if cmd.serverTime <= (*crate::src::cgame::cg_main::cg.snap).ps.commandTime
-        || cmd.serverTime > crate::src::cgame::cg_main::cg.time
+    if cmd.serverTime <= (*cg.snap).ps.commandTime
+        || cmd.serverTime > cg.time
     {
         // special check for map_restart
         return;
     }
     // also add text in center of screen
     s = b"Connection Interrupted\x00" as *const u8 as *const libc::c_char;
-    w = crate::src::cgame::cg_drawtools::CG_DrawStrlen(s) * 16 as libc::c_int;
-    crate::src::cgame::cg_drawtools::CG_DrawBigString(
+    w = CG_DrawStrlen(s) * 16 as libc::c_int;
+    CG_DrawBigString(
         320 as libc::c_int - w / 2 as libc::c_int,
         100 as libc::c_int,
         s,
         1.0f32,
     );
     // blink the icon
-    if crate::src::cgame::cg_main::cg.time >> 9 as libc::c_int & 1 as libc::c_int != 0 {
+    if cg.time >> 9 as libc::c_int & 1 as libc::c_int != 0 {
         return;
     }
     x = (640 as libc::c_int - 48 as libc::c_int) as libc::c_float;
     y = (480 as libc::c_int - 48 as libc::c_int) as libc::c_float;
-    crate::src::cgame::cg_drawtools::CG_DrawPic(
+    CG_DrawPic(
         x,
         y,
         48 as libc::c_int as libc::c_float,
@@ -2494,8 +2494,8 @@ unsafe extern "C" fn CG_DrawLagometer() {
     let mut range: libc::c_float = 0.;
     let mut color: libc::c_int = 0;
     let mut vscale: libc::c_float = 0.;
-    if crate::src::cgame::cg_main::cg_lagometer.integer == 0
-        || crate::src::cgame::cg_main::cgs.localServer as libc::c_uint != 0
+    if cg_lagometer.integer == 0
+        || cgs.localServer as libc::c_uint != 0
     {
         CG_DrawDisconnect();
         return;
@@ -2506,18 +2506,18 @@ unsafe extern "C" fn CG_DrawLagometer() {
     x = 640 as libc::c_int - 48 as libc::c_int;
     y = 480 as libc::c_int - 48 as libc::c_int;
     crate::src::cgame::cg_syscalls::trap_R_SetColor(0 as *const libc::c_float);
-    crate::src::cgame::cg_drawtools::CG_DrawPic(
+    CG_DrawPic(
         x as libc::c_float,
         y as libc::c_float,
         48 as libc::c_int as libc::c_float,
         48 as libc::c_int as libc::c_float,
-        crate::src::cgame::cg_main::cgs.media.lagometerShader,
+        cgs.media.lagometerShader,
     );
     ax = x as libc::c_float;
     ay = y as libc::c_float;
     aw = 48 as libc::c_int as libc::c_float;
     ah = 48 as libc::c_int as libc::c_float;
-    crate::src::cgame::cg_drawtools::CG_AdjustFrom640(&mut ax, &mut ay, &mut aw, &mut ah);
+    CG_AdjustFrom640(&mut ax, &mut ay, &mut aw, &mut ah);
     color = -(1 as libc::c_int);
     range = ah / 3 as libc::c_int as libc::c_float;
     mid = ay + range;
@@ -2532,7 +2532,7 @@ unsafe extern "C" fn CG_DrawLagometer() {
             if color != 1 as libc::c_int {
                 color = 1 as libc::c_int;
                 crate::src::cgame::cg_syscalls::trap_R_SetColor(
-                    crate::src::qcommon::q_math::g_color_table
+                    g_color_table
                         [('3' as i32 - '0' as i32 & 0x7 as libc::c_int) as usize]
                         .as_mut_ptr(),
                 );
@@ -2549,13 +2549,13 @@ unsafe extern "C" fn CG_DrawLagometer() {
                 0 as libc::c_int as libc::c_float,
                 0 as libc::c_int as libc::c_float,
                 0 as libc::c_int as libc::c_float,
-                crate::src::cgame::cg_main::cgs.media.whiteShader,
+                cgs.media.whiteShader,
             );
         } else if v < 0 as libc::c_int as libc::c_float {
             if color != 2 as libc::c_int {
                 color = 2 as libc::c_int;
                 crate::src::cgame::cg_syscalls::trap_R_SetColor(
-                    crate::src::qcommon::q_math::g_color_table
+                    g_color_table
                         [('4' as i32 - '0' as i32 & 0x7 as libc::c_int) as usize]
                         .as_mut_ptr(),
                 );
@@ -2573,7 +2573,7 @@ unsafe extern "C" fn CG_DrawLagometer() {
                 0 as libc::c_int as libc::c_float,
                 0 as libc::c_int as libc::c_float,
                 0 as libc::c_int as libc::c_float,
-                crate::src::cgame::cg_main::cgs.media.whiteShader,
+                cgs.media.whiteShader,
             );
         }
         a += 1
@@ -2590,7 +2590,7 @@ unsafe extern "C" fn CG_DrawLagometer() {
                 if color != 5 as libc::c_int {
                     color = 5 as libc::c_int;
                     crate::src::cgame::cg_syscalls::trap_R_SetColor(
-                        crate::src::qcommon::q_math::g_color_table
+                        g_color_table
                             [('3' as i32 - '0' as i32 & 0x7 as libc::c_int) as usize]
                             .as_mut_ptr(),
                     );
@@ -2598,7 +2598,7 @@ unsafe extern "C" fn CG_DrawLagometer() {
             } else if color != 3 as libc::c_int {
                 color = 3 as libc::c_int;
                 crate::src::cgame::cg_syscalls::trap_R_SetColor(
-                    crate::src::qcommon::q_math::g_color_table
+                    g_color_table
                         [('2' as i32 - '0' as i32 & 0x7 as libc::c_int) as usize]
                         .as_mut_ptr(),
                 );
@@ -2616,13 +2616,13 @@ unsafe extern "C" fn CG_DrawLagometer() {
                 0 as libc::c_int as libc::c_float,
                 0 as libc::c_int as libc::c_float,
                 0 as libc::c_int as libc::c_float,
-                crate::src::cgame::cg_main::cgs.media.whiteShader,
+                cgs.media.whiteShader,
             );
         } else if v < 0 as libc::c_int as libc::c_float {
             if color != 4 as libc::c_int {
                 color = 4 as libc::c_int;
                 crate::src::cgame::cg_syscalls::trap_R_SetColor(
-                    crate::src::qcommon::q_math::g_color_table
+                    g_color_table
                         [('1' as i32 - '0' as i32 & 0x7 as libc::c_int) as usize]
                         .as_mut_ptr(),
                 );
@@ -2636,16 +2636,16 @@ unsafe extern "C" fn CG_DrawLagometer() {
                 0 as libc::c_int as libc::c_float,
                 0 as libc::c_int as libc::c_float,
                 0 as libc::c_int as libc::c_float,
-                crate::src::cgame::cg_main::cgs.media.whiteShader,
+                cgs.media.whiteShader,
             );
         }
         a += 1
     }
     crate::src::cgame::cg_syscalls::trap_R_SetColor(0 as *const libc::c_float);
-    if crate::src::cgame::cg_main::cg_nopredict.integer != 0
-        || crate::src::cgame::cg_main::cg_synchronousClients.integer != 0
+    if cg_nopredict.integer != 0
+        || cg_synchronousClients.integer != 0
     {
-        crate::src::cgame::cg_drawtools::CG_DrawBigString(
+        CG_DrawBigString(
             x,
             y,
             b"snc\x00" as *const u8 as *const libc::c_char,
@@ -2677,20 +2677,20 @@ pub unsafe extern "C" fn CG_CenterPrint(
     mut charWidth: libc::c_int,
 ) {
     let mut s: *mut libc::c_char = 0 as *mut libc::c_char;
-    crate::src::qcommon::q_shared::Q_strncpyz(
-        crate::src::cgame::cg_main::cg.centerPrint.as_mut_ptr(),
+    Q_strncpyz(
+        cg.centerPrint.as_mut_ptr(),
         str,
         ::std::mem::size_of::<[libc::c_char; 1024]>() as libc::c_ulong as libc::c_int,
     );
-    crate::src::cgame::cg_main::cg.centerPrintTime = crate::src::cgame::cg_main::cg.time;
-    crate::src::cgame::cg_main::cg.centerPrintY = y;
-    crate::src::cgame::cg_main::cg.centerPrintCharWidth = charWidth;
+    cg.centerPrintTime = cg.time;
+    cg.centerPrintY = y;
+    cg.centerPrintCharWidth = charWidth;
     // count the number of lines for centering
-    crate::src::cgame::cg_main::cg.centerPrintLines = 1 as libc::c_int;
-    s = crate::src::cgame::cg_main::cg.centerPrint.as_mut_ptr();
+    cg.centerPrintLines = 1 as libc::c_int;
+    s = cg.centerPrint.as_mut_ptr();
     while *s != 0 {
         if *s as libc::c_int == '\n' as i32 {
-            crate::src::cgame::cg_main::cg.centerPrintLines += 1
+            cg.centerPrintLines += 1
         }
         s = s.offset(1)
     }
@@ -2708,21 +2708,21 @@ unsafe extern "C" fn CG_DrawCenterString() {
     let mut y: libc::c_int = 0;
     let mut w: libc::c_int = 0;
     let mut color: *mut libc::c_float = 0 as *mut libc::c_float;
-    if crate::src::cgame::cg_main::cg.centerPrintTime == 0 {
+    if cg.centerPrintTime == 0 {
         return;
     }
-    color = crate::src::cgame::cg_drawtools::CG_FadeColor(
-        crate::src::cgame::cg_main::cg.centerPrintTime,
-        (1000 as libc::c_int as libc::c_float * crate::src::cgame::cg_main::cg_centertime.value)
+    color = CG_FadeColor(
+        cg.centerPrintTime,
+        (1000 as libc::c_int as libc::c_float * cg_centertime.value)
             as libc::c_int,
     );
     if color.is_null() {
         return;
     }
     crate::src::cgame::cg_syscalls::trap_R_SetColor(color);
-    start = crate::src::cgame::cg_main::cg.centerPrint.as_mut_ptr();
-    y = crate::src::cgame::cg_main::cg.centerPrintY
-        - crate::src::cgame::cg_main::cg.centerPrintLines * 16 as libc::c_int / 2 as libc::c_int;
+    start = cg.centerPrint.as_mut_ptr();
+    y = cg.centerPrintY
+        - cg.centerPrintLines * 16 as libc::c_int / 2 as libc::c_int;
     loop {
         let mut linebuffer: [libc::c_char; 1024] = [0; 1024];
         l = 0 as libc::c_int;
@@ -2736,23 +2736,23 @@ unsafe extern "C" fn CG_DrawCenterString() {
             l += 1
         }
         linebuffer[l as usize] = 0 as libc::c_int as libc::c_char;
-        w = crate::src::cgame::cg_main::cg.centerPrintCharWidth
-            * crate::src::cgame::cg_drawtools::CG_DrawStrlen(linebuffer.as_mut_ptr());
+        w = cg.centerPrintCharWidth
+            * CG_DrawStrlen(linebuffer.as_mut_ptr());
         x = (640 as libc::c_int - w) / 2 as libc::c_int;
-        crate::src::cgame::cg_drawtools::CG_DrawStringExt(
+        CG_DrawStringExt(
             x,
             y,
             linebuffer.as_mut_ptr(),
             color,
-            crate::src::qcommon::q_shared::qfalse,
-            crate::src::qcommon::q_shared::qtrue,
-            crate::src::cgame::cg_main::cg.centerPrintCharWidth,
-            (crate::src::cgame::cg_main::cg.centerPrintCharWidth as libc::c_double * 1.5f64)
+            qfalse,
+            qtrue,
+            cg.centerPrintCharWidth,
+            (cg.centerPrintCharWidth as libc::c_double * 1.5f64)
                 as libc::c_int,
             0 as libc::c_int,
         );
         y = (y as libc::c_double
-            + crate::src::cgame::cg_main::cg.centerPrintCharWidth as libc::c_double * 1.5f64)
+            + cg.centerPrintCharWidth as libc::c_double * 1.5f64)
             as libc::c_int;
         while *start as libc::c_int != 0 && *start as libc::c_int != '\n' as i32 {
             start = start.offset(1)
@@ -2780,58 +2780,58 @@ CG_DrawCrosshair
 unsafe extern "C" fn CG_DrawCrosshair() {
     let mut w: libc::c_float = 0.;
     let mut h: libc::c_float = 0.;
-    let mut hShader: crate::src::qcommon::q_shared::qhandle_t = 0;
+    let mut hShader: qhandle_t = 0;
     let mut f: libc::c_float = 0.;
     let mut x: libc::c_float = 0.;
     let mut y: libc::c_float = 0.;
     let mut ca: libc::c_int = 0;
-    if crate::src::cgame::cg_main::cg_drawCrosshair.integer == 0 {
+    if cg_drawCrosshair.integer == 0 {
         return;
     }
-    if (*crate::src::cgame::cg_main::cg.snap).ps.persistant
+    if (*cg.snap).ps.persistant
         [crate::bg_public_h::PERS_TEAM as libc::c_int as usize]
         == crate::bg_public_h::TEAM_SPECTATOR as libc::c_int
     {
         return;
     }
-    if crate::src::cgame::cg_main::cg.renderingThirdPerson as u64 != 0 {
+    if cg.renderingThirdPerson as u64 != 0 {
         return;
     }
     // set color based on health
-    if crate::src::cgame::cg_main::cg_crosshairHealth.integer != 0 {
-        let mut hcolor: crate::src::qcommon::q_shared::vec4_t = [0.; 4];
-        crate::src::cgame::cg_drawtools::CG_ColorForHealth(hcolor.as_mut_ptr());
+    if cg_crosshairHealth.integer != 0 {
+        let mut hcolor: vec4_t = [0.; 4];
+        CG_ColorForHealth(hcolor.as_mut_ptr());
         crate::src::cgame::cg_syscalls::trap_R_SetColor(hcolor.as_mut_ptr());
     } else {
         crate::src::cgame::cg_syscalls::trap_R_SetColor(0 as *const libc::c_float);
     }
-    h = crate::src::cgame::cg_main::cg_crosshairSize.value;
+    h = cg_crosshairSize.value;
     w = h;
     // pulse the size of the crosshair when picking up items
-    f = (crate::src::cgame::cg_main::cg.time - crate::src::cgame::cg_main::cg.itemPickupBlendTime)
+    f = (cg.time - cg.itemPickupBlendTime)
         as libc::c_float;
     if f > 0 as libc::c_int as libc::c_float && f < 200 as libc::c_int as libc::c_float {
         f /= 200 as libc::c_int as libc::c_float;
         w *= 1 as libc::c_int as libc::c_float + f;
         h *= 1 as libc::c_int as libc::c_float + f
     }
-    x = crate::src::cgame::cg_main::cg_crosshairX.integer as libc::c_float;
-    y = crate::src::cgame::cg_main::cg_crosshairY.integer as libc::c_float;
-    crate::src::cgame::cg_drawtools::CG_AdjustFrom640(&mut x, &mut y, &mut w, &mut h);
-    ca = crate::src::cgame::cg_main::cg_drawCrosshair.integer;
+    x = cg_crosshairX.integer as libc::c_float;
+    y = cg_crosshairY.integer as libc::c_float;
+    CG_AdjustFrom640(&mut x, &mut y, &mut w, &mut h);
+    ca = cg_drawCrosshair.integer;
     if ca < 0 as libc::c_int {
         ca = 0 as libc::c_int
     }
     hShader =
-        crate::src::cgame::cg_main::cgs.media.crosshairShader[(ca % 10 as libc::c_int) as usize];
+        cgs.media.crosshairShader[(ca % 10 as libc::c_int) as usize];
     crate::src::cgame::cg_syscalls::trap_R_DrawStretchPic(
-        ((x + crate::src::cgame::cg_main::cg.refdef.x as libc::c_float) as libc::c_double
+        ((x + cg.refdef.x as libc::c_float) as libc::c_double
             + 0.5f64
-                * (crate::src::cgame::cg_main::cg.refdef.width as libc::c_float - w)
+                * (cg.refdef.width as libc::c_float - w)
                     as libc::c_double) as libc::c_float,
-        ((y + crate::src::cgame::cg_main::cg.refdef.y as libc::c_float) as libc::c_double
+        ((y + cg.refdef.y as libc::c_float) as libc::c_double
             + 0.5f64
-                * (crate::src::cgame::cg_main::cg.refdef.height as libc::c_float - h)
+                * (cg.refdef.height as libc::c_float - h)
                     as libc::c_double) as libc::c_float,
         w,
         h,
@@ -2851,16 +2851,16 @@ CG_DrawCrosshair3D
 
 unsafe extern "C" fn CG_DrawCrosshair3D() {
     let mut w: libc::c_float = 0.;
-    let mut hShader: crate::src::qcommon::q_shared::qhandle_t = 0;
+    let mut hShader: qhandle_t = 0;
     let mut f: libc::c_float = 0.;
     let mut ca: libc::c_int = 0;
-    let mut trace: crate::src::qcommon::q_shared::trace_t =
-        crate::src::qcommon::q_shared::trace_t {
-            allsolid: crate::src::qcommon::q_shared::qfalse,
-            startsolid: crate::src::qcommon::q_shared::qfalse,
+    let mut trace: trace_t =
+        trace_t {
+            allsolid: qfalse,
+            startsolid: qfalse,
             fraction: 0.,
             endpos: [0.; 3],
-            plane: crate::src::qcommon::q_shared::cplane_t {
+            plane: cplane_t {
                 normal: [0.; 3],
                 dist: 0.,
                 type_0: 0,
@@ -2871,20 +2871,20 @@ unsafe extern "C" fn CG_DrawCrosshair3D() {
             contents: 0,
             entityNum: 0,
         };
-    let mut endpos: crate::src::qcommon::q_shared::vec3_t = [0.; 3];
+    let mut endpos: vec3_t = [0.; 3];
     let mut stereoSep: libc::c_float = 0.;
     let mut zProj: libc::c_float = 0.;
     let mut maxdist: libc::c_float = 0.;
     let mut xmax: libc::c_float = 0.;
     let mut rendererinfos: [libc::c_char; 128] = [0; 128];
-    let mut ent: crate::tr_types_h::refEntity_t = crate::tr_types_h::refEntity_t {
-        reType: crate::tr_types_h::RT_MODEL,
+    let mut ent: refEntity_t = refEntity_t {
+        reType: RT_MODEL,
         renderfx: 0,
         hModel: 0,
         lightingOrigin: [0.; 3],
         shadowPlane: 0.,
         axis: [[0.; 3]; 3],
-        nonNormalizedAxes: crate::src::qcommon::q_shared::qfalse,
+        nonNormalizedAxes: qfalse,
         origin: [0.; 3],
         frame: 0,
         oldorigin: [0.; 3],
@@ -2899,32 +2899,32 @@ unsafe extern "C" fn CG_DrawCrosshair3D() {
         radius: 0.,
         rotation: 0.,
     };
-    if crate::src::cgame::cg_main::cg_drawCrosshair.integer == 0 {
+    if cg_drawCrosshair.integer == 0 {
         return;
     }
-    if (*crate::src::cgame::cg_main::cg.snap).ps.persistant
+    if (*cg.snap).ps.persistant
         [crate::bg_public_h::PERS_TEAM as libc::c_int as usize]
         == crate::bg_public_h::TEAM_SPECTATOR as libc::c_int
     {
         return;
     }
-    if crate::src::cgame::cg_main::cg.renderingThirdPerson as u64 != 0 {
+    if cg.renderingThirdPerson as u64 != 0 {
         return;
     }
-    w = crate::src::cgame::cg_main::cg_crosshairSize.value;
+    w = cg_crosshairSize.value;
     // pulse the size of the crosshair when picking up items
-    f = (crate::src::cgame::cg_main::cg.time - crate::src::cgame::cg_main::cg.itemPickupBlendTime)
+    f = (cg.time - cg.itemPickupBlendTime)
         as libc::c_float;
     if f > 0 as libc::c_int as libc::c_float && f < 200 as libc::c_int as libc::c_float {
         f /= 200 as libc::c_int as libc::c_float;
         w *= 1 as libc::c_int as libc::c_float + f
     }
-    ca = crate::src::cgame::cg_main::cg_drawCrosshair.integer;
+    ca = cg_drawCrosshair.integer;
     if ca < 0 as libc::c_int {
         ca = 0 as libc::c_int
     }
     hShader =
-        crate::src::cgame::cg_main::cgs.media.crosshairShader[(ca % 10 as libc::c_int) as usize];
+        cgs.media.crosshairShader[(ca % 10 as libc::c_int) as usize];
     // Use a different method rendering the crosshair so players don't see two of them when
     // focusing their eyes at distant objects with high stereo separation
     // We are going to trace to the next shootable object and place the crosshair in front of it.
@@ -2943,45 +2943,45 @@ unsafe extern "C" fn CG_DrawCrosshair3D() {
     stereoSep = (zProj as libc::c_double / atof(rendererinfos.as_mut_ptr())) as libc::c_float;
     xmax = (zProj as libc::c_double
         * crate::stdlib::tan(
-            crate::src::cgame::cg_main::cg.refdef.fov_x as libc::c_double
+            cg.refdef.fov_x as libc::c_double
                 * 3.14159265358979323846f64
                 / 360.0f32 as libc::c_double,
         )) as libc::c_float;
     // let the trace run through until a change in stereo separation of the crosshair becomes less than one pixel.
     maxdist =
-        crate::src::cgame::cg_main::cgs.glconfig.vidWidth as libc::c_float * stereoSep * zProj
+        cgs.glconfig.vidWidth as libc::c_float * stereoSep * zProj
             / (2 as libc::c_int as libc::c_float * xmax);
-    endpos[0 as libc::c_int as usize] = crate::src::cgame::cg_main::cg.refdef.vieworg
+    endpos[0 as libc::c_int as usize] = cg.refdef.vieworg
         [0 as libc::c_int as usize]
-        + crate::src::cgame::cg_main::cg.refdef.viewaxis[0 as libc::c_int as usize]
+        + cg.refdef.viewaxis[0 as libc::c_int as usize]
             [0 as libc::c_int as usize]
             * maxdist;
-    endpos[1 as libc::c_int as usize] = crate::src::cgame::cg_main::cg.refdef.vieworg
+    endpos[1 as libc::c_int as usize] = cg.refdef.vieworg
         [1 as libc::c_int as usize]
-        + crate::src::cgame::cg_main::cg.refdef.viewaxis[0 as libc::c_int as usize]
+        + cg.refdef.viewaxis[0 as libc::c_int as usize]
             [1 as libc::c_int as usize]
             * maxdist;
-    endpos[2 as libc::c_int as usize] = crate::src::cgame::cg_main::cg.refdef.vieworg
+    endpos[2 as libc::c_int as usize] = cg.refdef.vieworg
         [2 as libc::c_int as usize]
-        + crate::src::cgame::cg_main::cg.refdef.viewaxis[0 as libc::c_int as usize]
+        + cg.refdef.viewaxis[0 as libc::c_int as usize]
             [2 as libc::c_int as usize]
             * maxdist;
     crate::src::cgame::cg_predict::CG_Trace(
-        &mut trace as *mut _ as *mut crate::src::qcommon::q_shared::trace_t,
-        crate::src::cgame::cg_main::cg.refdef.vieworg.as_mut_ptr()
-            as *const crate::src::qcommon::q_shared::vec_t,
-        0 as *const crate::src::qcommon::q_shared::vec_t,
-        0 as *const crate::src::qcommon::q_shared::vec_t,
-        endpos.as_mut_ptr() as *const crate::src::qcommon::q_shared::vec_t,
+        &mut trace as *mut _ as *mut trace_t,
+        cg.refdef.vieworg.as_mut_ptr()
+            as *const vec_t,
+        0 as *const vec_t,
+        0 as *const vec_t,
+        endpos.as_mut_ptr() as *const vec_t,
         0 as libc::c_int,
         1 as libc::c_int | 0x2000000 as libc::c_int | 0x4000000 as libc::c_int,
     );
     crate::stdlib::memset(
-        &mut ent as *mut crate::tr_types_h::refEntity_t as *mut libc::c_void,
+        &mut ent as *mut refEntity_t as *mut libc::c_void,
         0 as libc::c_int,
-        ::std::mem::size_of::<crate::tr_types_h::refEntity_t>() as libc::c_ulong,
+        ::std::mem::size_of::<refEntity_t>() as libc::c_ulong,
     );
-    ent.reType = crate::tr_types_h::RT_SPRITE;
+    ent.reType = RT_SPRITE;
     ent.renderfx = 0x8 as libc::c_int | 0x10 as libc::c_int;
     ent.origin[0 as libc::c_int as usize] = trace.endpos[0 as libc::c_int as usize];
     ent.origin[1 as libc::c_int as usize] = trace.endpos[1 as libc::c_int as usize];
@@ -2990,7 +2990,7 @@ unsafe extern "C" fn CG_DrawCrosshair3D() {
     ent.radius = w / 640 as libc::c_int as libc::c_float * xmax * trace.fraction * maxdist / zProj;
     ent.customShader = hShader;
     crate::src::cgame::cg_syscalls::trap_R_AddRefEntityToScene(
-        &mut ent as *mut _ as *const crate::tr_types_h::refEntity_t,
+        &mut ent as *mut _ as *const refEntity_t,
     );
 }
 /*
@@ -3000,13 +3000,13 @@ CG_ScanForCrosshairEntity
 */
 
 unsafe extern "C" fn CG_ScanForCrosshairEntity() {
-    let mut trace: crate::src::qcommon::q_shared::trace_t =
-        crate::src::qcommon::q_shared::trace_t {
-            allsolid: crate::src::qcommon::q_shared::qfalse,
-            startsolid: crate::src::qcommon::q_shared::qfalse,
+    let mut trace: trace_t =
+        trace_t {
+            allsolid: qfalse,
+            startsolid: qfalse,
             fraction: 0.,
             endpos: [0.; 3],
-            plane: crate::src::qcommon::q_shared::cplane_t {
+            plane: cplane_t {
                 normal: [0.; 3],
                 dist: 0.,
                 type_0: 0,
@@ -3017,36 +3017,36 @@ unsafe extern "C" fn CG_ScanForCrosshairEntity() {
             contents: 0,
             entityNum: 0,
         };
-    let mut start: crate::src::qcommon::q_shared::vec3_t = [0.; 3];
-    let mut end: crate::src::qcommon::q_shared::vec3_t = [0.; 3];
+    let mut start: vec3_t = [0.; 3];
+    let mut end: vec3_t = [0.; 3];
     let mut content: libc::c_int = 0;
     start[0 as libc::c_int as usize] =
-        crate::src::cgame::cg_main::cg.refdef.vieworg[0 as libc::c_int as usize];
+        cg.refdef.vieworg[0 as libc::c_int as usize];
     start[1 as libc::c_int as usize] =
-        crate::src::cgame::cg_main::cg.refdef.vieworg[1 as libc::c_int as usize];
+        cg.refdef.vieworg[1 as libc::c_int as usize];
     start[2 as libc::c_int as usize] =
-        crate::src::cgame::cg_main::cg.refdef.vieworg[2 as libc::c_int as usize];
+        cg.refdef.vieworg[2 as libc::c_int as usize];
     end[0 as libc::c_int as usize] = start[0 as libc::c_int as usize]
-        + crate::src::cgame::cg_main::cg.refdef.viewaxis[0 as libc::c_int as usize]
+        + cg.refdef.viewaxis[0 as libc::c_int as usize]
             [0 as libc::c_int as usize]
             * 131072 as libc::c_int as libc::c_float;
     end[1 as libc::c_int as usize] = start[1 as libc::c_int as usize]
-        + crate::src::cgame::cg_main::cg.refdef.viewaxis[0 as libc::c_int as usize]
+        + cg.refdef.viewaxis[0 as libc::c_int as usize]
             [1 as libc::c_int as usize]
             * 131072 as libc::c_int as libc::c_float;
     end[2 as libc::c_int as usize] = start[2 as libc::c_int as usize]
-        + crate::src::cgame::cg_main::cg.refdef.viewaxis[0 as libc::c_int as usize]
+        + cg.refdef.viewaxis[0 as libc::c_int as usize]
             [2 as libc::c_int as usize]
             * 131072 as libc::c_int as libc::c_float;
     crate::src::cgame::cg_predict::CG_Trace(
-        &mut trace as *mut _ as *mut crate::src::qcommon::q_shared::trace_t,
-        start.as_mut_ptr() as *const crate::src::qcommon::q_shared::vec_t,
-        crate::src::qcommon::q_math::vec3_origin.as_mut_ptr()
-            as *const crate::src::qcommon::q_shared::vec_t,
-        crate::src::qcommon::q_math::vec3_origin.as_mut_ptr()
-            as *const crate::src::qcommon::q_shared::vec_t,
-        end.as_mut_ptr() as *const crate::src::qcommon::q_shared::vec_t,
-        (*crate::src::cgame::cg_main::cg.snap).ps.clientNum,
+        &mut trace as *mut _ as *mut trace_t,
+        start.as_mut_ptr() as *const vec_t,
+        vec3_origin.as_mut_ptr()
+            as *const vec_t,
+        vec3_origin.as_mut_ptr()
+            as *const vec_t,
+        end.as_mut_ptr() as *const vec_t,
+        (*cg.snap).ps.clientNum,
         1 as libc::c_int | 0x2000000 as libc::c_int,
     );
     if trace.entityNum >= 64 as libc::c_int {
@@ -3054,14 +3054,14 @@ unsafe extern "C" fn CG_ScanForCrosshairEntity() {
     }
     // if the player is in fog, don't show it
     content = crate::src::cgame::cg_predict::CG_PointContents(
-        trace.endpos.as_mut_ptr() as *const crate::src::qcommon::q_shared::vec_t,
+        trace.endpos.as_mut_ptr() as *const vec_t,
         0 as libc::c_int,
     );
     if content & 64 as libc::c_int != 0 {
         return;
     }
     // if the player is invisible, don't show it
-    if crate::src::cgame::cg_main::cg_entities[trace.entityNum as usize]
+    if cg_entities[trace.entityNum as usize]
         .currentState
         .powerups
         & (1 as libc::c_int) << crate::bg_public_h::PW_INVIS as libc::c_int
@@ -3070,8 +3070,8 @@ unsafe extern "C" fn CG_ScanForCrosshairEntity() {
         return;
     }
     // update the fade timer
-    crate::src::cgame::cg_main::cg.crosshairClientNum = trace.entityNum;
-    crate::src::cgame::cg_main::cg.crosshairClientTime = crate::src::cgame::cg_main::cg.time;
+    cg.crosshairClientNum = trace.entityNum;
+    cg.crosshairClientTime = cg.time;
 }
 /*
 =====================
@@ -3083,32 +3083,32 @@ unsafe extern "C" fn CG_DrawCrosshairNames() {
     let mut color: *mut libc::c_float = 0 as *mut libc::c_float;
     let mut name: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut w: libc::c_float = 0.;
-    if crate::src::cgame::cg_main::cg_drawCrosshair.integer == 0 {
+    if cg_drawCrosshair.integer == 0 {
         return;
     }
-    if crate::src::cgame::cg_main::cg_drawCrosshairNames.integer == 0 {
+    if cg_drawCrosshairNames.integer == 0 {
         return;
     }
-    if crate::src::cgame::cg_main::cg.renderingThirdPerson as u64 != 0 {
+    if cg.renderingThirdPerson as u64 != 0 {
         return;
     }
     // scan the known entities to see if the crosshair is sighted on one
     CG_ScanForCrosshairEntity();
     // draw the name of the player being looked at
-    color = crate::src::cgame::cg_drawtools::CG_FadeColor(
-        crate::src::cgame::cg_main::cg.crosshairClientTime,
+    color = CG_FadeColor(
+        cg.crosshairClientTime,
         1000 as libc::c_int,
     );
     if color.is_null() {
         crate::src::cgame::cg_syscalls::trap_R_SetColor(0 as *const libc::c_float);
         return;
     }
-    name = crate::src::cgame::cg_main::cgs.clientinfo
-        [crate::src::cgame::cg_main::cg.crosshairClientNum as usize]
+    name = cgs.clientinfo
+        [cg.crosshairClientNum as usize]
         .name
         .as_mut_ptr();
-    w = (crate::src::cgame::cg_drawtools::CG_DrawStrlen(name) * 16 as libc::c_int) as libc::c_float;
-    crate::src::cgame::cg_drawtools::CG_DrawBigString(
+    w = (CG_DrawStrlen(name) * 16 as libc::c_int) as libc::c_float;
+    CG_DrawBigString(
         (320 as libc::c_int as libc::c_float - w / 2 as libc::c_int as libc::c_float)
             as libc::c_int,
         170 as libc::c_int,
@@ -3125,25 +3125,25 @@ CG_DrawSpectator
 */
 
 unsafe extern "C" fn CG_DrawSpectator() {
-    crate::src::cgame::cg_drawtools::CG_DrawBigString(
+    CG_DrawBigString(
         320 as libc::c_int - 9 as libc::c_int * 8 as libc::c_int,
         440 as libc::c_int,
         b"SPECTATOR\x00" as *const u8 as *const libc::c_char,
         1.0f32,
     );
-    if crate::src::cgame::cg_main::cgs.gametype as libc::c_uint
+    if cgs.gametype as libc::c_uint
         == crate::bg_public_h::GT_TOURNAMENT as libc::c_int as libc::c_uint
     {
-        crate::src::cgame::cg_drawtools::CG_DrawBigString(
+        CG_DrawBigString(
             320 as libc::c_int - 15 as libc::c_int * 8 as libc::c_int,
             460 as libc::c_int,
             b"waiting to play\x00" as *const u8 as *const libc::c_char,
             1.0f32,
         );
-    } else if crate::src::cgame::cg_main::cgs.gametype as libc::c_uint
+    } else if cgs.gametype as libc::c_uint
         >= crate::bg_public_h::GT_TEAM as libc::c_int as libc::c_uint
     {
-        crate::src::cgame::cg_drawtools::CG_DrawBigString(
+        CG_DrawBigString(
             320 as libc::c_int - 39 as libc::c_int * 8 as libc::c_int,
             460 as libc::c_int,
             b"press ESC and use the JOIN menu to play\x00" as *const u8 as *const libc::c_char,
@@ -3160,31 +3160,31 @@ CG_DrawVote
 unsafe extern "C" fn CG_DrawVote() {
     let mut s: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut sec: libc::c_int = 0;
-    if crate::src::cgame::cg_main::cgs.voteTime == 0 {
+    if cgs.voteTime == 0 {
         return;
     }
     // play a talk beep whenever it is modified
-    if crate::src::cgame::cg_main::cgs.voteModified as u64 != 0 {
-        crate::src::cgame::cg_main::cgs.voteModified = crate::src::qcommon::q_shared::qfalse;
+    if cgs.voteModified as u64 != 0 {
+        cgs.voteModified = qfalse;
         crate::src::cgame::cg_syscalls::trap_S_StartLocalSound(
-            crate::src::cgame::cg_main::cgs.media.talkSound,
-            crate::src::qcommon::q_shared::CHAN_LOCAL_SOUND as libc::c_int,
+            cgs.media.talkSound,
+            CHAN_LOCAL_SOUND as libc::c_int,
         );
     }
     sec = (30000 as libc::c_int
-        - (crate::src::cgame::cg_main::cg.time - crate::src::cgame::cg_main::cgs.voteTime))
+        - (cg.time - cgs.voteTime))
         / 1000 as libc::c_int;
     if sec < 0 as libc::c_int {
         sec = 0 as libc::c_int
     }
-    s = crate::src::qcommon::q_shared::va(
+    s = va(
         b"VOTE(%i):%s yes:%i no:%i\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         sec,
-        crate::src::cgame::cg_main::cgs.voteString.as_mut_ptr(),
-        crate::src::cgame::cg_main::cgs.voteYes,
-        crate::src::cgame::cg_main::cgs.voteNo,
+        cgs.voteString.as_mut_ptr(),
+        cgs.voteYes,
+        cgs.voteNo,
     );
-    crate::src::cgame::cg_drawtools::CG_DrawSmallString(
+    CG_DrawSmallString(
         0 as libc::c_int,
         58 as libc::c_int,
         s,
@@ -3201,13 +3201,13 @@ unsafe extern "C" fn CG_DrawTeamVote() {
     let mut s: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut sec: libc::c_int = 0;
     let mut cs_offset: libc::c_int = 0;
-    if crate::src::cgame::cg_main::cgs.clientinfo[crate::src::cgame::cg_main::cg.clientNum as usize]
+    if cgs.clientinfo[cg.clientNum as usize]
         .team as libc::c_uint
         == crate::bg_public_h::TEAM_RED as libc::c_int as libc::c_uint
     {
         cs_offset = 0 as libc::c_int
-    } else if crate::src::cgame::cg_main::cgs.clientinfo
-        [crate::src::cgame::cg_main::cg.clientNum as usize]
+    } else if cgs.clientinfo
+        [cg.clientNum as usize]
         .team as libc::c_uint
         == crate::bg_public_h::TEAM_BLUE as libc::c_int as libc::c_uint
     {
@@ -3215,34 +3215,34 @@ unsafe extern "C" fn CG_DrawTeamVote() {
     } else {
         return;
     }
-    if crate::src::cgame::cg_main::cgs.teamVoteTime[cs_offset as usize] == 0 {
+    if cgs.teamVoteTime[cs_offset as usize] == 0 {
         return;
     }
     // play a talk beep whenever it is modified
-    if crate::src::cgame::cg_main::cgs.teamVoteModified[cs_offset as usize] as u64 != 0 {
-        crate::src::cgame::cg_main::cgs.teamVoteModified[cs_offset as usize] =
-            crate::src::qcommon::q_shared::qfalse;
+    if cgs.teamVoteModified[cs_offset as usize] as u64 != 0 {
+        cgs.teamVoteModified[cs_offset as usize] =
+            qfalse;
         crate::src::cgame::cg_syscalls::trap_S_StartLocalSound(
-            crate::src::cgame::cg_main::cgs.media.talkSound,
-            crate::src::qcommon::q_shared::CHAN_LOCAL_SOUND as libc::c_int,
+            cgs.media.talkSound,
+            CHAN_LOCAL_SOUND as libc::c_int,
         );
     }
     sec = (30000 as libc::c_int
-        - (crate::src::cgame::cg_main::cg.time
-            - crate::src::cgame::cg_main::cgs.teamVoteTime[cs_offset as usize]))
+        - (cg.time
+            - cgs.teamVoteTime[cs_offset as usize]))
         / 1000 as libc::c_int;
     if sec < 0 as libc::c_int {
         sec = 0 as libc::c_int
     }
-    s = crate::src::qcommon::q_shared::va(
+    s = va(
         b"TEAMVOTE(%i):%s yes:%i no:%i\x00" as *const u8 as *const libc::c_char
             as *mut libc::c_char,
         sec,
-        crate::src::cgame::cg_main::cgs.teamVoteString[cs_offset as usize].as_mut_ptr(),
-        crate::src::cgame::cg_main::cgs.teamVoteYes[cs_offset as usize],
-        crate::src::cgame::cg_main::cgs.teamVoteNo[cs_offset as usize],
+        cgs.teamVoteString[cs_offset as usize].as_mut_ptr(),
+        cgs.teamVoteYes[cs_offset as usize],
+        cgs.teamVoteNo[cs_offset as usize],
     );
-    crate::src::cgame::cg_drawtools::CG_DrawSmallString(
+    CG_DrawSmallString(
         0 as libc::c_int,
         90 as libc::c_int,
         s,
@@ -3250,7 +3250,7 @@ unsafe extern "C" fn CG_DrawTeamVote() {
     );
 }
 
-unsafe extern "C" fn CG_DrawScoreboard() -> crate::src::qcommon::q_shared::qboolean {
+unsafe extern "C" fn CG_DrawScoreboard() -> qboolean {
     return crate::src::cgame::cg_scoreboard::CG_DrawOldScoreboard();
 }
 /*
@@ -3261,14 +3261,14 @@ CG_DrawIntermission
 
 unsafe extern "C" fn CG_DrawIntermission() {
     //	int key;
-    if crate::src::cgame::cg_main::cgs.gametype as libc::c_uint
+    if cgs.gametype as libc::c_uint
         == crate::bg_public_h::GT_SINGLE_PLAYER as libc::c_int as libc::c_uint
     {
         CG_DrawCenterString();
         return;
     }
-    crate::src::cgame::cg_main::cg.scoreFadeTime = crate::src::cgame::cg_main::cg.time;
-    crate::src::cgame::cg_main::cg.scoreBoardShowing = CG_DrawScoreboard();
+    cg.scoreFadeTime = cg.time;
+    cg.scoreBoardShowing = CG_DrawScoreboard();
 }
 /*
 =================
@@ -3276,43 +3276,43 @@ CG_DrawFollow
 =================
 */
 
-unsafe extern "C" fn CG_DrawFollow() -> crate::src::qcommon::q_shared::qboolean {
+unsafe extern "C" fn CG_DrawFollow() -> qboolean {
     let mut x: libc::c_float = 0.;
-    let mut color: crate::src::qcommon::q_shared::vec4_t = [0.; 4];
+    let mut color: vec4_t = [0.; 4];
     let mut name: *const libc::c_char = 0 as *const libc::c_char;
-    if (*crate::src::cgame::cg_main::cg.snap).ps.pm_flags & 4096 as libc::c_int == 0 {
-        return crate::src::qcommon::q_shared::qfalse;
+    if (*cg.snap).ps.pm_flags & 4096 as libc::c_int == 0 {
+        return qfalse;
     }
-    color[0 as libc::c_int as usize] = 1 as libc::c_int as crate::src::qcommon::q_shared::vec_t;
-    color[1 as libc::c_int as usize] = 1 as libc::c_int as crate::src::qcommon::q_shared::vec_t;
-    color[2 as libc::c_int as usize] = 1 as libc::c_int as crate::src::qcommon::q_shared::vec_t;
-    color[3 as libc::c_int as usize] = 1 as libc::c_int as crate::src::qcommon::q_shared::vec_t;
-    crate::src::cgame::cg_drawtools::CG_DrawBigString(
+    color[0 as libc::c_int as usize] = 1 as libc::c_int as vec_t;
+    color[1 as libc::c_int as usize] = 1 as libc::c_int as vec_t;
+    color[2 as libc::c_int as usize] = 1 as libc::c_int as vec_t;
+    color[3 as libc::c_int as usize] = 1 as libc::c_int as vec_t;
+    CG_DrawBigString(
         320 as libc::c_int - 9 as libc::c_int * 8 as libc::c_int,
         24 as libc::c_int,
         b"following\x00" as *const u8 as *const libc::c_char,
         1.0f32,
     );
-    name = crate::src::cgame::cg_main::cgs.clientinfo
-        [(*crate::src::cgame::cg_main::cg.snap).ps.clientNum as usize]
+    name = cgs.clientinfo
+        [(*cg.snap).ps.clientNum as usize]
         .name
         .as_mut_ptr();
     x = (0.5f64
         * (640 as libc::c_int
-            - 32 as libc::c_int * crate::src::cgame::cg_drawtools::CG_DrawStrlen(name))
+            - 32 as libc::c_int * CG_DrawStrlen(name))
             as libc::c_double) as libc::c_float;
-    crate::src::cgame::cg_drawtools::CG_DrawStringExt(
+    CG_DrawStringExt(
         x as libc::c_int,
         40 as libc::c_int,
         name,
         color.as_mut_ptr(),
-        crate::src::qcommon::q_shared::qtrue,
-        crate::src::qcommon::q_shared::qtrue,
+        qtrue,
+        qtrue,
         32 as libc::c_int,
         48 as libc::c_int,
         0 as libc::c_int,
     );
-    return crate::src::qcommon::q_shared::qtrue;
+    return qtrue;
 }
 /*
 =================
@@ -3323,19 +3323,19 @@ CG_DrawAmmoWarning
 unsafe extern "C" fn CG_DrawAmmoWarning() {
     let mut s: *const libc::c_char = 0 as *const libc::c_char;
     let mut w: libc::c_int = 0;
-    if crate::src::cgame::cg_main::cg_drawAmmoWarning.integer == 0 as libc::c_int {
+    if cg_drawAmmoWarning.integer == 0 as libc::c_int {
         return;
     }
-    if crate::src::cgame::cg_main::cg.lowAmmoWarning == 0 {
+    if cg.lowAmmoWarning == 0 {
         return;
     }
-    if crate::src::cgame::cg_main::cg.lowAmmoWarning == 2 as libc::c_int {
+    if cg.lowAmmoWarning == 2 as libc::c_int {
         s = b"OUT OF AMMO\x00" as *const u8 as *const libc::c_char
     } else {
         s = b"LOW AMMO WARNING\x00" as *const u8 as *const libc::c_char
     }
-    w = crate::src::cgame::cg_drawtools::CG_DrawStrlen(s) * 16 as libc::c_int;
-    crate::src::cgame::cg_drawtools::CG_DrawBigString(
+    w = CG_DrawStrlen(s) * 16 as libc::c_int;
+    CG_DrawBigString(
         320 as libc::c_int - w / 2 as libc::c_int,
         64 as libc::c_int,
         s,
@@ -3356,42 +3356,42 @@ unsafe extern "C" fn CG_DrawWarmup() {
     let mut ci1: *mut crate::cg_local_h::clientInfo_t = 0 as *mut crate::cg_local_h::clientInfo_t;
     let mut ci2: *mut crate::cg_local_h::clientInfo_t = 0 as *mut crate::cg_local_h::clientInfo_t;
     let mut s: *const libc::c_char = 0 as *const libc::c_char;
-    sec = crate::src::cgame::cg_main::cg.warmup;
+    sec = cg.warmup;
     if sec == 0 {
         return;
     }
     if sec < 0 as libc::c_int {
         s = b"Waiting for players\x00" as *const u8 as *const libc::c_char;
-        w = crate::src::cgame::cg_drawtools::CG_DrawStrlen(s) * 16 as libc::c_int;
-        crate::src::cgame::cg_drawtools::CG_DrawBigString(
+        w = CG_DrawStrlen(s) * 16 as libc::c_int;
+        CG_DrawBigString(
             320 as libc::c_int - w / 2 as libc::c_int,
             24 as libc::c_int,
             s,
             1.0f32,
         );
-        crate::src::cgame::cg_main::cg.warmupCount = 0 as libc::c_int;
+        cg.warmupCount = 0 as libc::c_int;
         return;
     }
-    if crate::src::cgame::cg_main::cgs.gametype as libc::c_uint
+    if cgs.gametype as libc::c_uint
         == crate::bg_public_h::GT_TOURNAMENT as libc::c_int as libc::c_uint
     {
         // find the two active players
         ci1 = 0 as *mut crate::cg_local_h::clientInfo_t;
         ci2 = 0 as *mut crate::cg_local_h::clientInfo_t;
         i = 0 as libc::c_int;
-        while i < crate::src::cgame::cg_main::cgs.maxclients {
-            if crate::src::cgame::cg_main::cgs.clientinfo[i as usize].infoValid as libc::c_uint != 0
-                && crate::src::cgame::cg_main::cgs.clientinfo[i as usize].team as libc::c_uint
+        while i < cgs.maxclients {
+            if cgs.clientinfo[i as usize].infoValid as libc::c_uint != 0
+                && cgs.clientinfo[i as usize].team as libc::c_uint
                     == crate::bg_public_h::TEAM_FREE as libc::c_int as libc::c_uint
             {
                 if ci1.is_null() {
-                    ci1 = &mut *crate::src::cgame::cg_main::cgs
+                    ci1 = &mut *cgs
                         .clientinfo
                         .as_mut_ptr()
                         .offset(i as isize)
                         as *mut crate::cg_local_h::clientInfo_t
                 } else {
-                    ci2 = &mut *crate::src::cgame::cg_main::cgs
+                    ci2 = &mut *cgs
                         .clientinfo
                         .as_mut_ptr()
                         .offset(i as isize)
@@ -3401,110 +3401,110 @@ unsafe extern "C" fn CG_DrawWarmup() {
             i += 1
         }
         if !ci1.is_null() && !ci2.is_null() {
-            s = crate::src::qcommon::q_shared::va(
+            s = va(
                 b"%s vs %s\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 (*ci1).name.as_mut_ptr(),
                 (*ci2).name.as_mut_ptr(),
             );
-            w = crate::src::cgame::cg_drawtools::CG_DrawStrlen(s);
+            w = CG_DrawStrlen(s);
             if w > 640 as libc::c_int / 32 as libc::c_int {
                 cw = 640 as libc::c_int / w
             } else {
                 cw = 32 as libc::c_int
             }
-            crate::src::cgame::cg_drawtools::CG_DrawStringExt(
+            CG_DrawStringExt(
                 320 as libc::c_int - w * cw / 2 as libc::c_int,
                 20 as libc::c_int,
                 s,
-                crate::src::qcommon::q_math::colorWhite.as_mut_ptr(),
-                crate::src::qcommon::q_shared::qfalse,
-                crate::src::qcommon::q_shared::qtrue,
+                colorWhite.as_mut_ptr(),
+                qfalse,
+                qtrue,
                 cw,
                 (cw as libc::c_float * 1.5f32) as libc::c_int,
                 0 as libc::c_int,
             );
         }
     } else {
-        if crate::src::cgame::cg_main::cgs.gametype as libc::c_uint
+        if cgs.gametype as libc::c_uint
             == crate::bg_public_h::GT_FFA as libc::c_int as libc::c_uint
         {
             s = b"Free For All\x00" as *const u8 as *const libc::c_char
-        } else if crate::src::cgame::cg_main::cgs.gametype as libc::c_uint
+        } else if cgs.gametype as libc::c_uint
             == crate::bg_public_h::GT_TEAM as libc::c_int as libc::c_uint
         {
             s = b"Team Deathmatch\x00" as *const u8 as *const libc::c_char
-        } else if crate::src::cgame::cg_main::cgs.gametype as libc::c_uint
+        } else if cgs.gametype as libc::c_uint
             == crate::bg_public_h::GT_CTF as libc::c_int as libc::c_uint
         {
             s = b"Capture the Flag\x00" as *const u8 as *const libc::c_char
         } else {
             s = b"\x00" as *const u8 as *const libc::c_char
         }
-        w = crate::src::cgame::cg_drawtools::CG_DrawStrlen(s);
+        w = CG_DrawStrlen(s);
         if w > 640 as libc::c_int / 32 as libc::c_int {
             cw = 640 as libc::c_int / w
         } else {
             cw = 32 as libc::c_int
         }
-        crate::src::cgame::cg_drawtools::CG_DrawStringExt(
+        CG_DrawStringExt(
             320 as libc::c_int - w * cw / 2 as libc::c_int,
             25 as libc::c_int,
             s,
-            crate::src::qcommon::q_math::colorWhite.as_mut_ptr(),
-            crate::src::qcommon::q_shared::qfalse,
-            crate::src::qcommon::q_shared::qtrue,
+            colorWhite.as_mut_ptr(),
+            qfalse,
+            qtrue,
             cw,
             (cw as libc::c_float * 1.1f32) as libc::c_int,
             0 as libc::c_int,
         );
     }
-    sec = (sec - crate::src::cgame::cg_main::cg.time) / 1000 as libc::c_int;
+    sec = (sec - cg.time) / 1000 as libc::c_int;
     if sec < 0 as libc::c_int {
-        crate::src::cgame::cg_main::cg.warmup = 0 as libc::c_int;
+        cg.warmup = 0 as libc::c_int;
         sec = 0 as libc::c_int
     }
-    s = crate::src::qcommon::q_shared::va(
+    s = va(
         b"Starts in: %i\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         sec + 1 as libc::c_int,
     );
-    if sec != crate::src::cgame::cg_main::cg.warmupCount {
-        crate::src::cgame::cg_main::cg.warmupCount = sec;
+    if sec != cg.warmupCount {
+        cg.warmupCount = sec;
         match sec {
             0 => {
                 crate::src::cgame::cg_syscalls::trap_S_StartLocalSound(
-                    crate::src::cgame::cg_main::cgs.media.count1Sound,
-                    crate::src::qcommon::q_shared::CHAN_ANNOUNCER as libc::c_int,
+                    cgs.media.count1Sound,
+                    CHAN_ANNOUNCER as libc::c_int,
                 );
             }
             1 => {
                 crate::src::cgame::cg_syscalls::trap_S_StartLocalSound(
-                    crate::src::cgame::cg_main::cgs.media.count2Sound,
-                    crate::src::qcommon::q_shared::CHAN_ANNOUNCER as libc::c_int,
+                    cgs.media.count2Sound,
+                    CHAN_ANNOUNCER as libc::c_int,
                 );
             }
             2 => {
                 crate::src::cgame::cg_syscalls::trap_S_StartLocalSound(
-                    crate::src::cgame::cg_main::cgs.media.count3Sound,
-                    crate::src::qcommon::q_shared::CHAN_ANNOUNCER as libc::c_int,
+                    cgs.media.count3Sound,
+                    CHAN_ANNOUNCER as libc::c_int,
                 );
             }
             _ => {}
         }
     }
-    match crate::src::cgame::cg_main::cg.warmupCount {
+    match cg.warmupCount {
         0 => cw = 28 as libc::c_int,
         1 => cw = 24 as libc::c_int,
         2 => cw = 20 as libc::c_int,
         _ => cw = 16 as libc::c_int,
     }
-    w = crate::src::cgame::cg_drawtools::CG_DrawStrlen(s);
-    crate::src::cgame::cg_drawtools::CG_DrawStringExt(
+    w = CG_DrawStrlen(s);
+    CG_DrawStringExt(
         320 as libc::c_int - w * cw / 2 as libc::c_int,
         70 as libc::c_int,
         s,
-        crate::src::qcommon::q_math::colorWhite.as_mut_ptr(),
-        crate::src::qcommon::q_shared::qfalse,
-        crate::src::qcommon::q_shared::qtrue,
+        colorWhite.as_mut_ptr(),
+        qfalse,
+        qtrue,
         cw,
         (cw as libc::c_double * 1.5f64) as libc::c_int,
         0 as libc::c_int,
@@ -3517,15 +3517,15 @@ CG_Draw2D
 =================
 */
 
-unsafe extern "C" fn CG_Draw2D(mut stereoFrame: crate::tr_types_h::stereoFrame_t) {
+unsafe extern "C" fn CG_Draw2D(mut stereoFrame: stereoFrame_t) {
     // if we are taking a levelshot for the menu, don't draw anything
-    if crate::src::cgame::cg_main::cg.levelShot as u64 != 0 {
+    if cg.levelShot as u64 != 0 {
         return;
     }
-    if crate::src::cgame::cg_main::cg_draw2D.integer == 0 as libc::c_int {
+    if cg_draw2D.integer == 0 as libc::c_int {
         return;
     }
-    if (*crate::src::cgame::cg_main::cg.snap).ps.pm_type
+    if (*cg.snap).ps.pm_type
         == crate::bg_public_h::PM_INTERMISSION as libc::c_int
     {
         CG_DrawIntermission();
@@ -3536,26 +3536,26 @@ unsafe extern "C" fn CG_Draw2D(mut stereoFrame: crate::tr_types_h::stereoFrame_t
             return;
         }
     */
-    if (*crate::src::cgame::cg_main::cg.snap).ps.persistant
+    if (*cg.snap).ps.persistant
         [crate::bg_public_h::PERS_TEAM as libc::c_int as usize]
         == crate::bg_public_h::TEAM_SPECTATOR as libc::c_int
     {
         CG_DrawSpectator();
         if stereoFrame as libc::c_uint
-            == crate::tr_types_h::STEREO_CENTER as libc::c_int as libc::c_uint
+            == STEREO_CENTER as libc::c_int as libc::c_uint
         {
             CG_DrawCrosshair();
         }
         CG_DrawCrosshairNames();
-    } else if crate::src::cgame::cg_main::cg.showScores as u64 == 0
-        && (*crate::src::cgame::cg_main::cg.snap).ps.stats
+    } else if cg.showScores as u64 == 0
+        && (*cg.snap).ps.stats
             [crate::bg_public_h::STAT_HEALTH as libc::c_int as usize]
             > 0 as libc::c_int
     {
         CG_DrawStatusBar();
         CG_DrawAmmoWarning();
         if stereoFrame as libc::c_uint
-            == crate::tr_types_h::STEREO_CENTER as libc::c_int as libc::c_uint
+            == STEREO_CENTER as libc::c_int as libc::c_uint
         {
             CG_DrawCrosshair();
         }
@@ -3564,7 +3564,7 @@ unsafe extern "C" fn CG_Draw2D(mut stereoFrame: crate::tr_types_h::stereoFrame_t
         CG_DrawHoldableItem();
         CG_DrawReward();
     }
-    if crate::src::cgame::cg_main::cgs.gametype as libc::c_uint
+    if cgs.gametype as libc::c_uint
         >= crate::bg_public_h::GT_TEAM as libc::c_int as libc::c_uint
     {
         CG_DrawTeamInfo();
@@ -3580,8 +3580,8 @@ unsafe extern "C" fn CG_Draw2D(mut stereoFrame: crate::tr_types_h::stereoFrame_t
     }
     // don't draw any status if dead or the scoreboard is being explicitly shown
     // don't draw center string if scoreboard is up
-    crate::src::cgame::cg_main::cg.scoreBoardShowing = CG_DrawScoreboard();
-    if crate::src::cgame::cg_main::cg.scoreBoardShowing as u64 == 0 {
+    cg.scoreBoardShowing = CG_DrawScoreboard();
+    if cg.scoreBoardShowing as u64 == 0 {
         CG_DrawCenterString();
     };
 }
@@ -3594,30 +3594,30 @@ Perform all drawing needed to completely fill the screen
 */
 #[no_mangle]
 
-pub unsafe extern "C" fn CG_DrawActive(mut stereoView: crate::tr_types_h::stereoFrame_t) {
+pub unsafe extern "C" fn CG_DrawActive(mut stereoView: stereoFrame_t) {
     // optionally draw the info screen instead
-    if crate::src::cgame::cg_main::cg.snap.is_null() {
+    if cg.snap.is_null() {
         crate::src::cgame::cg_info::CG_DrawInformation();
         return;
     }
     // optionally draw the tournement scoreboard instead
-    if (*crate::src::cgame::cg_main::cg.snap).ps.persistant
+    if (*cg.snap).ps.persistant
         [crate::bg_public_h::PERS_TEAM as libc::c_int as usize]
         == crate::bg_public_h::TEAM_SPECTATOR as libc::c_int
-        && (*crate::src::cgame::cg_main::cg.snap).ps.pm_flags & 8192 as libc::c_int != 0
+        && (*cg.snap).ps.pm_flags & 8192 as libc::c_int != 0
     {
         crate::src::cgame::cg_scoreboard::CG_DrawTourneyScoreboard();
         return;
     }
     // clear around the rendered view if sized down
-    crate::src::cgame::cg_drawtools::CG_TileClear();
-    if stereoView as libc::c_uint != crate::tr_types_h::STEREO_CENTER as libc::c_int as libc::c_uint
+    CG_TileClear();
+    if stereoView as libc::c_uint != STEREO_CENTER as libc::c_int as libc::c_uint
     {
         CG_DrawCrosshair3D();
     }
     // draw 3D view
     crate::src::cgame::cg_syscalls::trap_R_RenderScene(
-        &mut crate::src::cgame::cg_main::cg.refdef as *mut _ as *const crate::tr_types_h::refdef_t,
+        &mut cg.refdef as *mut _ as *const refdef_t,
     );
     // draw status bar and other floating elements
     CG_Draw2D(stereoView);

--- a/quake3-rs/uix86_64/src/game/bg_misc.rs
+++ b/quake3-rs/uix86_64/src/game/bg_misc.rs
@@ -258,9 +258,9 @@ An item fires all of its targets when it is picked up.  If the toucher can't car
 */
 #[no_mangle]
 
-pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
+pub static mut bg_itemlist: [gitem_t; 37] = [
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: 0 as *const libc::c_char as *mut libc::c_char,
             pickup_sound: 0 as *const libc::c_char as *mut libc::c_char,
             world_model: [
@@ -272,7 +272,7 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
             icon: 0 as *const libc::c_char as *mut libc::c_char,
             pickup_name: 0 as *const libc::c_char as *mut libc::c_char,
             quantity: 0 as libc::c_int,
-            giType: crate::bg_public_h::IT_BAD,
+            giType: IT_BAD,
             giTag: 0 as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
@@ -280,7 +280,7 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"item_armor_shard\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             pickup_sound: b"sound/misc/ar1_pkup.wav\x00" as *const u8 as *const libc::c_char
@@ -297,7 +297,7 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
             pickup_name: b"Armor Shard\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             quantity: 5 as libc::c_int,
-            giType: crate::bg_public_h::IT_ARMOR,
+            giType: IT_ARMOR,
             giTag: 0 as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
@@ -305,7 +305,7 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"item_armor_combat\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             pickup_sound: b"sound/misc/ar2_pkup.wav\x00" as *const u8 as *const libc::c_char
@@ -321,7 +321,7 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
                 as *mut libc::c_char,
             pickup_name: b"Armor\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 50 as libc::c_int,
-            giType: crate::bg_public_h::IT_ARMOR,
+            giType: IT_ARMOR,
             giTag: 0 as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
@@ -329,7 +329,7 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"item_armor_body\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             pickup_sound: b"sound/misc/ar2_pkup.wav\x00" as *const u8 as *const libc::c_char
@@ -345,7 +345,7 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
             pickup_name: b"Heavy Armor\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             quantity: 100 as libc::c_int,
-            giType: crate::bg_public_h::IT_ARMOR,
+            giType: IT_ARMOR,
             giTag: 0 as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
@@ -353,7 +353,7 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"item_health_small\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             pickup_sound: b"sound/items/s_health.wav\x00" as *const u8 as *const libc::c_char
@@ -369,7 +369,7 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
             icon: b"icons/iconh_green\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_name: b"5 Health\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 5 as libc::c_int,
-            giType: crate::bg_public_h::IT_HEALTH,
+            giType: IT_HEALTH,
             giTag: 0 as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
@@ -377,7 +377,7 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"item_health\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_sound: b"sound/items/n_health.wav\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
@@ -393,7 +393,7 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
                 as *mut libc::c_char,
             pickup_name: b"25 Health\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 25 as libc::c_int,
-            giType: crate::bg_public_h::IT_HEALTH,
+            giType: IT_HEALTH,
             giTag: 0 as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
@@ -401,7 +401,7 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"item_health_large\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             pickup_sound: b"sound/items/l_health.wav\x00" as *const u8 as *const libc::c_char
@@ -417,7 +417,7 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
             icon: b"icons/iconh_red\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_name: b"50 Health\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 50 as libc::c_int,
-            giType: crate::bg_public_h::IT_HEALTH,
+            giType: IT_HEALTH,
             giTag: 0 as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
@@ -425,7 +425,7 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"item_health_mega\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             pickup_sound: b"sound/items/m_health.wav\x00" as *const u8 as *const libc::c_char
@@ -442,7 +442,7 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
             pickup_name: b"Mega Health\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             quantity: 100 as libc::c_int,
-            giType: crate::bg_public_h::IT_HEALTH,
+            giType: IT_HEALTH,
             giTag: 0 as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
@@ -450,7 +450,7 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"weapon_gauntlet\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             pickup_sound: b"sound/misc/w_pkup.wav\x00" as *const u8 as *const libc::c_char
@@ -466,15 +466,15 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
                 as *mut libc::c_char,
             pickup_name: b"Gauntlet\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 0 as libc::c_int,
-            giType: crate::bg_public_h::IT_WEAPON,
-            giTag: crate::bg_public_h::WP_GAUNTLET as libc::c_int,
+            giType: IT_WEAPON,
+            giTag: WP_GAUNTLET as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         };
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"weapon_shotgun\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             pickup_sound: b"sound/misc/w_pkup.wav\x00" as *const u8 as *const libc::c_char
@@ -490,15 +490,15 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
                 as *mut libc::c_char,
             pickup_name: b"Shotgun\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 10 as libc::c_int,
-            giType: crate::bg_public_h::IT_WEAPON,
-            giTag: crate::bg_public_h::WP_SHOTGUN as libc::c_int,
+            giType: IT_WEAPON,
+            giTag: WP_SHOTGUN as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         };
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"weapon_machinegun\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             pickup_sound: b"sound/misc/w_pkup.wav\x00" as *const u8 as *const libc::c_char
@@ -514,15 +514,15 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
                 as *mut libc::c_char,
             pickup_name: b"Machinegun\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 40 as libc::c_int,
-            giType: crate::bg_public_h::IT_WEAPON,
-            giTag: crate::bg_public_h::WP_MACHINEGUN as libc::c_int,
+            giType: IT_WEAPON,
+            giTag: WP_MACHINEGUN as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         };
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"weapon_grenadelauncher\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             pickup_sound: b"sound/misc/w_pkup.wav\x00" as *const u8 as *const libc::c_char
@@ -539,8 +539,8 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
             pickup_name: b"Grenade Launcher\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             quantity: 10 as libc::c_int,
-            giType: crate::bg_public_h::IT_WEAPON,
-            giTag: crate::bg_public_h::WP_GRENADE_LAUNCHER as libc::c_int,
+            giType: IT_WEAPON,
+            giTag: WP_GRENADE_LAUNCHER as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"sound/weapons/grenade/hgrenb1a.wav sound/weapons/grenade/hgrenb2a.wav\x00"
                 as *const u8 as *const libc::c_char as *mut libc::c_char,
@@ -548,7 +548,7 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"weapon_rocketlauncher\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             pickup_sound: b"sound/misc/w_pkup.wav\x00" as *const u8 as *const libc::c_char
@@ -565,15 +565,15 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
             pickup_name: b"Rocket Launcher\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             quantity: 10 as libc::c_int,
-            giType: crate::bg_public_h::IT_WEAPON,
-            giTag: crate::bg_public_h::WP_ROCKET_LAUNCHER as libc::c_int,
+            giType: IT_WEAPON,
+            giTag: WP_ROCKET_LAUNCHER as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         };
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"weapon_lightning\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             pickup_sound: b"sound/misc/w_pkup.wav\x00" as *const u8 as *const libc::c_char
@@ -590,15 +590,15 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
             pickup_name: b"Lightning Gun\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             quantity: 100 as libc::c_int,
-            giType: crate::bg_public_h::IT_WEAPON,
-            giTag: crate::bg_public_h::WP_LIGHTNING as libc::c_int,
+            giType: IT_WEAPON,
+            giTag: WP_LIGHTNING as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         };
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"weapon_railgun\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             pickup_sound: b"sound/misc/w_pkup.wav\x00" as *const u8 as *const libc::c_char
@@ -614,15 +614,15 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
                 as *mut libc::c_char,
             pickup_name: b"Railgun\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 10 as libc::c_int,
-            giType: crate::bg_public_h::IT_WEAPON,
-            giTag: crate::bg_public_h::WP_RAILGUN as libc::c_int,
+            giType: IT_WEAPON,
+            giTag: WP_RAILGUN as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         };
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"weapon_plasmagun\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             pickup_sound: b"sound/misc/w_pkup.wav\x00" as *const u8 as *const libc::c_char
@@ -638,15 +638,15 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
                 as *mut libc::c_char,
             pickup_name: b"Plasma Gun\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 50 as libc::c_int,
-            giType: crate::bg_public_h::IT_WEAPON,
-            giTag: crate::bg_public_h::WP_PLASMAGUN as libc::c_int,
+            giType: IT_WEAPON,
+            giTag: WP_PLASMAGUN as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         };
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"weapon_bfg\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_sound: b"sound/misc/w_pkup.wav\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
@@ -660,15 +660,15 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
             icon: b"icons/iconw_bfg\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_name: b"BFG10K\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 20 as libc::c_int,
-            giType: crate::bg_public_h::IT_WEAPON,
-            giTag: crate::bg_public_h::WP_BFG as libc::c_int,
+            giType: IT_WEAPON,
+            giTag: WP_BFG as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         };
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"weapon_grapplinghook\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             pickup_sound: b"sound/misc/w_pkup.wav\x00" as *const u8 as *const libc::c_char
@@ -685,15 +685,15 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
             pickup_name: b"Grappling Hook\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             quantity: 0 as libc::c_int,
-            giType: crate::bg_public_h::IT_WEAPON,
-            giTag: crate::bg_public_h::WP_GRAPPLING_HOOK as libc::c_int,
+            giType: IT_WEAPON,
+            giTag: WP_GRAPPLING_HOOK as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         };
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"ammo_shells\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_sound: b"sound/misc/am_pkup.wav\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
@@ -708,15 +708,15 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
                 as *mut libc::c_char,
             pickup_name: b"Shells\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 10 as libc::c_int,
-            giType: crate::bg_public_h::IT_AMMO,
-            giTag: crate::bg_public_h::WP_SHOTGUN as libc::c_int,
+            giType: IT_AMMO,
+            giTag: WP_SHOTGUN as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         };
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"ammo_bullets\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_sound: b"sound/misc/am_pkup.wav\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
@@ -731,15 +731,15 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
                 as *mut libc::c_char,
             pickup_name: b"Bullets\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 50 as libc::c_int,
-            giType: crate::bg_public_h::IT_AMMO,
-            giTag: crate::bg_public_h::WP_MACHINEGUN as libc::c_int,
+            giType: IT_AMMO,
+            giTag: WP_MACHINEGUN as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         };
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"ammo_grenades\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             pickup_sound: b"sound/misc/am_pkup.wav\x00" as *const u8 as *const libc::c_char
@@ -755,15 +755,15 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
                 as *mut libc::c_char,
             pickup_name: b"Grenades\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 5 as libc::c_int,
-            giType: crate::bg_public_h::IT_AMMO,
-            giTag: crate::bg_public_h::WP_GRENADE_LAUNCHER as libc::c_int,
+            giType: IT_AMMO,
+            giTag: WP_GRENADE_LAUNCHER as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         };
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"ammo_cells\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_sound: b"sound/misc/am_pkup.wav\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
@@ -778,15 +778,15 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
                 as *mut libc::c_char,
             pickup_name: b"Cells\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 30 as libc::c_int,
-            giType: crate::bg_public_h::IT_AMMO,
-            giTag: crate::bg_public_h::WP_PLASMAGUN as libc::c_int,
+            giType: IT_AMMO,
+            giTag: WP_PLASMAGUN as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         };
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"ammo_lightning\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             pickup_sound: b"sound/misc/am_pkup.wav\x00" as *const u8 as *const libc::c_char
@@ -802,15 +802,15 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
                 as *mut libc::c_char,
             pickup_name: b"Lightning\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 60 as libc::c_int,
-            giType: crate::bg_public_h::IT_AMMO,
-            giTag: crate::bg_public_h::WP_LIGHTNING as libc::c_int,
+            giType: IT_AMMO,
+            giTag: WP_LIGHTNING as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         };
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"ammo_rockets\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_sound: b"sound/misc/am_pkup.wav\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
@@ -825,15 +825,15 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
                 as *mut libc::c_char,
             pickup_name: b"Rockets\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 5 as libc::c_int,
-            giType: crate::bg_public_h::IT_AMMO,
-            giTag: crate::bg_public_h::WP_ROCKET_LAUNCHER as libc::c_int,
+            giType: IT_AMMO,
+            giTag: WP_ROCKET_LAUNCHER as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         };
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"ammo_slugs\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_sound: b"sound/misc/am_pkup.wav\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
@@ -848,15 +848,15 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
                 as *mut libc::c_char,
             pickup_name: b"Slugs\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 10 as libc::c_int,
-            giType: crate::bg_public_h::IT_AMMO,
-            giTag: crate::bg_public_h::WP_RAILGUN as libc::c_int,
+            giType: IT_AMMO,
+            giTag: WP_RAILGUN as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         };
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"ammo_bfg\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_sound: b"sound/misc/am_pkup.wav\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
@@ -870,15 +870,15 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
             icon: b"icons/icona_bfg\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_name: b"Bfg Ammo\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 15 as libc::c_int,
-            giType: crate::bg_public_h::IT_AMMO,
-            giTag: crate::bg_public_h::WP_BFG as libc::c_int,
+            giType: IT_AMMO,
+            giTag: WP_BFG as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         };
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"holdable_teleporter\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             pickup_sound: b"sound/items/holdable.wav\x00" as *const u8 as *const libc::c_char
@@ -894,15 +894,15 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
             pickup_name: b"Personal Teleporter\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             quantity: 60 as libc::c_int,
-            giType: crate::bg_public_h::IT_HOLDABLE,
-            giTag: crate::bg_public_h::HI_TELEPORTER as libc::c_int,
+            giType: IT_HOLDABLE,
+            giTag: HI_TELEPORTER as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         };
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"holdable_medkit\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             pickup_sound: b"sound/items/holdable.wav\x00" as *const u8 as *const libc::c_char
@@ -918,8 +918,8 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
             icon: b"icons/medkit\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_name: b"Medkit\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 60 as libc::c_int,
-            giType: crate::bg_public_h::IT_HOLDABLE,
-            giTag: crate::bg_public_h::HI_MEDKIT as libc::c_int,
+            giType: IT_HOLDABLE,
+            giTag: HI_MEDKIT as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"sound/items/use_medkit.wav\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
@@ -927,7 +927,7 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"item_quad\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_sound: b"sound/items/quaddamage.wav\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
@@ -943,8 +943,8 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
             pickup_name: b"Quad Damage\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             quantity: 30 as libc::c_int,
-            giType: crate::bg_public_h::IT_POWERUP,
-            giTag: crate::bg_public_h::PW_QUAD as libc::c_int,
+            giType: IT_POWERUP,
+            giTag: PW_QUAD as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"sound/items/damage2.wav sound/items/damage3.wav\x00" as *const u8
                 as *const libc::c_char as *mut libc::c_char,
@@ -952,7 +952,7 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"item_enviro\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_sound: b"sound/items/protect.wav\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
@@ -968,8 +968,8 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
             pickup_name: b"Battle Suit\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             quantity: 30 as libc::c_int,
-            giType: crate::bg_public_h::IT_POWERUP,
-            giTag: crate::bg_public_h::PW_BATTLESUIT as libc::c_int,
+            giType: IT_POWERUP,
+            giTag: PW_BATTLESUIT as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"sound/items/airout.wav sound/items/protect3.wav\x00" as *const u8
                 as *const libc::c_char as *mut libc::c_char,
@@ -977,7 +977,7 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"item_haste\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_sound: b"sound/items/haste.wav\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
@@ -992,15 +992,15 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
             icon: b"icons/haste\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_name: b"Speed\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 30 as libc::c_int,
-            giType: crate::bg_public_h::IT_POWERUP,
-            giTag: crate::bg_public_h::PW_HASTE as libc::c_int,
+            giType: IT_POWERUP,
+            giTag: PW_HASTE as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         };
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"item_invis\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_sound: b"sound/items/invisibility.wav\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
@@ -1016,15 +1016,15 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
             pickup_name: b"Invisibility\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             quantity: 30 as libc::c_int,
-            giType: crate::bg_public_h::IT_POWERUP,
-            giTag: crate::bg_public_h::PW_INVIS as libc::c_int,
+            giType: IT_POWERUP,
+            giTag: PW_INVIS as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         };
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"item_regen\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_sound: b"sound/items/regeneration.wav\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
@@ -1040,8 +1040,8 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
             pickup_name: b"Regeneration\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             quantity: 30 as libc::c_int,
-            giType: crate::bg_public_h::IT_POWERUP,
-            giTag: crate::bg_public_h::PW_REGEN as libc::c_int,
+            giType: IT_POWERUP,
+            giTag: PW_REGEN as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"sound/items/regen.wav\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
@@ -1049,7 +1049,7 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"item_flight\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_sound: b"sound/items/flight.wav\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
@@ -1064,8 +1064,8 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
             icon: b"icons/flight\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_name: b"Flight\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 60 as libc::c_int,
-            giType: crate::bg_public_h::IT_POWERUP,
-            giTag: crate::bg_public_h::PW_FLIGHT as libc::c_int,
+            giType: IT_POWERUP,
+            giTag: PW_FLIGHT as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"sound/items/flight.wav\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
@@ -1073,7 +1073,7 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"team_CTF_redflag\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             pickup_sound: 0 as *const libc::c_char as *mut libc::c_char,
@@ -1087,15 +1087,15 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
             icon: b"icons/iconf_red1\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_name: b"Red Flag\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 0 as libc::c_int,
-            giType: crate::bg_public_h::IT_TEAM,
-            giTag: crate::bg_public_h::PW_REDFLAG as libc::c_int,
+            giType: IT_TEAM,
+            giTag: PW_REDFLAG as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         };
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: b"team_CTF_blueflag\x00" as *const u8 as *const libc::c_char
                 as *mut libc::c_char,
             pickup_sound: 0 as *const libc::c_char as *mut libc::c_char,
@@ -1109,22 +1109,22 @@ pub static mut bg_itemlist: [crate::bg_public_h::gitem_t; 37] = [
             icon: b"icons/iconf_blu1\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             pickup_name: b"Blue Flag\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             quantity: 0 as libc::c_int,
-            giType: crate::bg_public_h::IT_TEAM,
-            giTag: crate::bg_public_h::PW_BLUEFLAG as libc::c_int,
+            giType: IT_TEAM,
+            giTag: PW_BLUEFLAG as libc::c_int,
             precaches: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             sounds: b"\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
         };
         init
     },
     {
-        let mut init = crate::bg_public_h::gitem_s {
+        let mut init = gitem_s {
             classname: 0 as *const libc::c_char as *mut libc::c_char,
             pickup_sound: 0 as *const libc::c_char as *mut libc::c_char,
             world_model: [0 as *const libc::c_char as *mut libc::c_char; 4],
             icon: 0 as *const libc::c_char as *mut libc::c_char,
             pickup_name: 0 as *const libc::c_char as *mut libc::c_char,
             quantity: 0,
-            giType: crate::bg_public_h::IT_BAD,
+            giType: IT_BAD,
             giTag: 0,
             precaches: 0 as *const libc::c_char as *mut libc::c_char,
             sounds: 0 as *const libc::c_char as *mut libc::c_char,
@@ -1144,25 +1144,25 @@ BG_FindItemForPowerup
 #[no_mangle]
 
 pub unsafe extern "C" fn BG_FindItemForPowerup(
-    mut pw: crate::bg_public_h::powerup_t,
-) -> *mut crate::bg_public_h::gitem_t {
+    mut pw: powerup_t,
+) -> *mut gitem_t {
     let mut i: libc::c_int = 0;
     i = 0 as libc::c_int;
     while i < bg_numItems {
         if (bg_itemlist[i as usize].giType as libc::c_uint
-            == crate::bg_public_h::IT_POWERUP as libc::c_int as libc::c_uint
+            == IT_POWERUP as libc::c_int as libc::c_uint
             || bg_itemlist[i as usize].giType as libc::c_uint
-                == crate::bg_public_h::IT_TEAM as libc::c_int as libc::c_uint
+                == IT_TEAM as libc::c_int as libc::c_uint
             || bg_itemlist[i as usize].giType as libc::c_uint
-                == crate::bg_public_h::IT_PERSISTANT_POWERUP as libc::c_int as libc::c_uint)
+                == IT_PERSISTANT_POWERUP as libc::c_int as libc::c_uint)
             && bg_itemlist[i as usize].giTag as libc::c_uint == pw as libc::c_uint
         {
             return &mut *bg_itemlist.as_mut_ptr().offset(i as isize)
-                as *mut crate::bg_public_h::gitem_t;
+                as *mut gitem_t;
         }
         i += 1
     }
-    return 0 as *mut crate::bg_public_h::gitem_t;
+    return 0 as *mut gitem_t;
 }
 /*
 ==============
@@ -1172,22 +1172,22 @@ BG_FindItemForHoldable
 #[no_mangle]
 
 pub unsafe extern "C" fn BG_FindItemForHoldable(
-    mut pw: crate::bg_public_h::holdable_t,
-) -> *mut crate::bg_public_h::gitem_t {
+    mut pw: holdable_t,
+) -> *mut gitem_t {
     let mut i: libc::c_int = 0;
     i = 0 as libc::c_int;
     while i < bg_numItems {
         if bg_itemlist[i as usize].giType as libc::c_uint
-            == crate::bg_public_h::IT_HOLDABLE as libc::c_int as libc::c_uint
+            == IT_HOLDABLE as libc::c_int as libc::c_uint
             && bg_itemlist[i as usize].giTag as libc::c_uint == pw as libc::c_uint
         {
             return &mut *bg_itemlist.as_mut_ptr().offset(i as isize)
-                as *mut crate::bg_public_h::gitem_t;
+                as *mut gitem_t;
         }
         i += 1
     }
-    crate::src::q3_ui::ui_atoms::Com_Error(
-        crate::src::qcommon::q_shared::ERR_DROP as libc::c_int,
+    Com_Error(
+        ERR_DROP as libc::c_int,
         b"HoldableItem not found\x00" as *const u8 as *const libc::c_char,
     );
 }
@@ -1200,21 +1200,21 @@ BG_FindItemForWeapon
 #[no_mangle]
 
 pub unsafe extern "C" fn BG_FindItemForWeapon(
-    mut weapon: crate::bg_public_h::weapon_t,
-) -> *mut crate::bg_public_h::gitem_t {
-    let mut it: *mut crate::bg_public_h::gitem_t = 0 as *mut crate::bg_public_h::gitem_t;
+    mut weapon: weapon_t,
+) -> *mut gitem_t {
+    let mut it: *mut gitem_t = 0 as *mut gitem_t;
     it = bg_itemlist.as_mut_ptr().offset(1 as libc::c_int as isize);
     while !(*it).classname.is_null() {
         if (*it).giType as libc::c_uint
-            == crate::bg_public_h::IT_WEAPON as libc::c_int as libc::c_uint
+            == IT_WEAPON as libc::c_int as libc::c_uint
             && (*it).giTag as libc::c_uint == weapon as libc::c_uint
         {
             return it;
         }
         it = it.offset(1)
     }
-    crate::src::q3_ui::ui_atoms::Com_Error(
-        crate::src::qcommon::q_shared::ERR_DROP as libc::c_int,
+    Com_Error(
+        ERR_DROP as libc::c_int,
         b"Couldn\'t find item for weapon %i\x00" as *const u8 as *const libc::c_char,
         weapon as libc::c_uint,
     );
@@ -1230,16 +1230,16 @@ BG_FindItem
 
 pub unsafe extern "C" fn BG_FindItem(
     mut pickupName: *const libc::c_char,
-) -> *mut crate::bg_public_h::gitem_t {
-    let mut it: *mut crate::bg_public_h::gitem_t = 0 as *mut crate::bg_public_h::gitem_t;
+) -> *mut gitem_t {
+    let mut it: *mut gitem_t = 0 as *mut gitem_t;
     it = bg_itemlist.as_mut_ptr().offset(1 as libc::c_int as isize);
     while !(*it).classname.is_null() {
-        if crate::src::qcommon::q_shared::Q_stricmp((*it).pickup_name, pickupName) == 0 {
+        if Q_stricmp((*it).pickup_name, pickupName) == 0 {
             return it;
         }
         it = it.offset(1)
     }
-    return 0 as *mut crate::bg_public_h::gitem_t;
+    return 0 as *mut gitem_t;
 }
 /*
 ============
@@ -1252,11 +1252,11 @@ grabbing them easier
 #[no_mangle]
 
 pub unsafe extern "C" fn BG_PlayerTouchesItem(
-    mut ps: *mut crate::src::qcommon::q_shared::playerState_t,
-    mut item: *mut crate::src::qcommon::q_shared::entityState_t,
+    mut ps: *mut playerState_t,
+    mut item: *mut entityState_t,
     mut atTime: libc::c_int,
-) -> crate::src::qcommon::q_shared::qboolean {
-    let mut origin: crate::src::qcommon::q_shared::vec3_t = [0.; 3];
+) -> qboolean {
+    let mut origin: vec3_t = [0.; 3];
     BG_EvaluateTrajectory(&mut (*item).pos, atTime, origin.as_mut_ptr());
     // we are ignoring ducked differences here
     if (*ps).origin[0 as libc::c_int as usize] - origin[0 as libc::c_int as usize]
@@ -1272,9 +1272,9 @@ pub unsafe extern "C" fn BG_PlayerTouchesItem(
         || (*ps).origin[2 as libc::c_int as usize] - origin[2 as libc::c_int as usize]
             < -(36 as libc::c_int) as libc::c_float
     {
-        return crate::src::qcommon::q_shared::qfalse;
+        return qfalse;
     }
-    return crate::src::qcommon::q_shared::qtrue;
+    return qtrue;
 }
 /*
 ================
@@ -1288,108 +1288,108 @@ This needs to be the same for client side prediction and server use.
 
 pub unsafe extern "C" fn BG_CanItemBeGrabbed(
     mut gametype: libc::c_int,
-    mut ent: *const crate::src::qcommon::q_shared::entityState_t,
-    mut ps: *const crate::src::qcommon::q_shared::playerState_t,
-) -> crate::src::qcommon::q_shared::qboolean {
-    let mut item: *mut crate::bg_public_h::gitem_t = 0 as *mut crate::bg_public_h::gitem_t; // weapons are always picked up
+    mut ent: *const entityState_t,
+    mut ps: *const playerState_t,
+) -> qboolean {
+    let mut item: *mut gitem_t = 0 as *mut gitem_t; // weapons are always picked up
     if (*ent).modelindex < 1 as libc::c_int || (*ent).modelindex >= bg_numItems {
-        crate::src::q3_ui::ui_atoms::Com_Error(
-            crate::src::qcommon::q_shared::ERR_DROP as libc::c_int,
+        Com_Error(
+            ERR_DROP as libc::c_int,
             b"BG_CanItemBeGrabbed: index out of range\x00" as *const u8 as *const libc::c_char,
         );
     }
     item = &mut *bg_itemlist.as_mut_ptr().offset((*ent).modelindex as isize)
-        as *mut crate::bg_public_h::gitem_t;
+        as *mut gitem_t;
     match (*item).giType as libc::c_uint {
-        1 => return crate::src::qcommon::q_shared::qtrue,
+        1 => return qtrue,
         2 => {
             if (*ps).ammo[(*item).giTag as usize] >= 200 as libc::c_int {
-                return crate::src::qcommon::q_shared::qfalse;
+                return qfalse;
                 // can't hold any more
             }
-            return crate::src::qcommon::q_shared::qtrue;
+            return qtrue;
         }
         3 => {
-            if (*ps).stats[crate::bg_public_h::STAT_ARMOR as libc::c_int as usize]
-                >= (*ps).stats[crate::bg_public_h::STAT_MAX_HEALTH as libc::c_int as usize]
+            if (*ps).stats[STAT_ARMOR as libc::c_int as usize]
+                >= (*ps).stats[STAT_MAX_HEALTH as libc::c_int as usize]
                     * 2 as libc::c_int
             {
-                return crate::src::qcommon::q_shared::qfalse;
+                return qfalse;
             }
-            return crate::src::qcommon::q_shared::qtrue;
+            return qtrue;
         }
         4 => {
             // small and mega healths will go over the max, otherwise
             // don't pick up if already at max
             if (*item).quantity == 5 as libc::c_int || (*item).quantity == 100 as libc::c_int {
-                if (*ps).stats[crate::bg_public_h::STAT_HEALTH as libc::c_int as usize]
-                    >= (*ps).stats[crate::bg_public_h::STAT_MAX_HEALTH as libc::c_int as usize]
+                if (*ps).stats[STAT_HEALTH as libc::c_int as usize]
+                    >= (*ps).stats[STAT_MAX_HEALTH as libc::c_int as usize]
                         * 2 as libc::c_int
                 {
-                    return crate::src::qcommon::q_shared::qfalse;
+                    return qfalse;
                 } // powerups are always picked up
-                return crate::src::qcommon::q_shared::qtrue;
+                return qtrue;
             }
-            if (*ps).stats[crate::bg_public_h::STAT_HEALTH as libc::c_int as usize]
-                >= (*ps).stats[crate::bg_public_h::STAT_MAX_HEALTH as libc::c_int as usize]
+            if (*ps).stats[STAT_HEALTH as libc::c_int as usize]
+                >= (*ps).stats[STAT_MAX_HEALTH as libc::c_int as usize]
             {
-                return crate::src::qcommon::q_shared::qfalse;
+                return qfalse;
             }
-            return crate::src::qcommon::q_shared::qtrue;
+            return qtrue;
         }
-        5 => return crate::src::qcommon::q_shared::qtrue,
+        5 => return qtrue,
         8 => {
             // team items, such as flags
-            if gametype == crate::bg_public_h::GT_CTF as libc::c_int {
+            if gametype == GT_CTF as libc::c_int {
                 // ent->modelindex2 is non-zero on items if they are dropped
                 // we need to know this because we can pick up our dropped flag (and return it)
                 // but we can't pick up our flag at base
-                if (*ps).persistant[crate::bg_public_h::PERS_TEAM as libc::c_int as usize]
-                    == crate::bg_public_h::TEAM_RED as libc::c_int
+                if (*ps).persistant[PERS_TEAM as libc::c_int as usize]
+                    == TEAM_RED as libc::c_int
                 {
-                    if (*item).giTag == crate::bg_public_h::PW_BLUEFLAG as libc::c_int
-                        || (*item).giTag == crate::bg_public_h::PW_REDFLAG as libc::c_int
+                    if (*item).giTag == PW_BLUEFLAG as libc::c_int
+                        || (*item).giTag == PW_REDFLAG as libc::c_int
                             && (*ent).modelindex2 != 0
-                        || (*item).giTag == crate::bg_public_h::PW_REDFLAG as libc::c_int
+                        || (*item).giTag == PW_REDFLAG as libc::c_int
                             && (*ps).powerups
-                                [crate::bg_public_h::PW_BLUEFLAG as libc::c_int as usize]
+                                [PW_BLUEFLAG as libc::c_int as usize]
                                 != 0
                     {
-                        return crate::src::qcommon::q_shared::qtrue;
+                        return qtrue;
                     }
-                } else if (*ps).persistant[crate::bg_public_h::PERS_TEAM as libc::c_int as usize]
-                    == crate::bg_public_h::TEAM_BLUE as libc::c_int
+                } else if (*ps).persistant[PERS_TEAM as libc::c_int as usize]
+                    == TEAM_BLUE as libc::c_int
                 {
-                    if (*item).giTag == crate::bg_public_h::PW_REDFLAG as libc::c_int
-                        || (*item).giTag == crate::bg_public_h::PW_BLUEFLAG as libc::c_int
+                    if (*item).giTag == PW_REDFLAG as libc::c_int
+                        || (*item).giTag == PW_BLUEFLAG as libc::c_int
                             && (*ent).modelindex2 != 0
-                        || (*item).giTag == crate::bg_public_h::PW_BLUEFLAG as libc::c_int
+                        || (*item).giTag == PW_BLUEFLAG as libc::c_int
                             && (*ps).powerups
-                                [crate::bg_public_h::PW_REDFLAG as libc::c_int as usize]
+                                [PW_REDFLAG as libc::c_int as usize]
                                 != 0
                     {
-                        return crate::src::qcommon::q_shared::qtrue;
+                        return qtrue;
                     }
                 }
             }
-            return crate::src::qcommon::q_shared::qfalse;
+            return qfalse;
         }
         6 => {
             // can only hold one item at a time
-            if (*ps).stats[crate::bg_public_h::STAT_HOLDABLE_ITEM as libc::c_int as usize] != 0 {
-                return crate::src::qcommon::q_shared::qfalse;
+            if (*ps).stats[STAT_HOLDABLE_ITEM as libc::c_int as usize] != 0 {
+                return qfalse;
             }
-            return crate::src::qcommon::q_shared::qtrue;
+            return qtrue;
         }
         0 => {
-            crate::src::q3_ui::ui_atoms::Com_Error(
-                crate::src::qcommon::q_shared::ERR_DROP as libc::c_int,
+            Com_Error(
+                ERR_DROP as libc::c_int,
                 b"BG_CanItemBeGrabbed: IT_BAD\x00" as *const u8 as *const libc::c_char,
             );
         }
         _ => {}
     }
-    return crate::src::qcommon::q_shared::qfalse;
+    return qfalse;
 }
 //======================================================================
 /*
@@ -1401,9 +1401,9 @@ BG_EvaluateTrajectory
 #[no_mangle]
 
 pub unsafe extern "C" fn BG_EvaluateTrajectory(
-    mut tr: *const crate::src::qcommon::q_shared::trajectory_t,
+    mut tr: *const trajectory_t,
     mut atTime: libc::c_int,
-    mut result: *mut crate::src::qcommon::q_shared::vec_t,
+    mut result: *mut vec_t,
 ) {
     let mut deltaTime: libc::c_float = 0.; // milliseconds to seconds
     let mut phase: libc::c_float = 0.; // milliseconds to seconds
@@ -1466,11 +1466,11 @@ pub unsafe extern "C" fn BG_EvaluateTrajectory(
                     * 800 as libc::c_int as libc::c_double
                     * deltaTime as libc::c_double
                     * deltaTime as libc::c_double)
-                as crate::src::qcommon::q_shared::vec_t
+                as vec_t
         }
         _ => {
-            crate::src::q3_ui::ui_atoms::Com_Error(
-                crate::src::qcommon::q_shared::ERR_DROP as libc::c_int,
+            Com_Error(
+                ERR_DROP as libc::c_int,
                 b"BG_EvaluateTrajectory: unknown trType: %i\x00" as *const u8
                     as *const libc::c_char,
                 (*tr).trType as libc::c_uint,
@@ -1488,16 +1488,16 @@ For determining velocity at a given time
 #[no_mangle]
 
 pub unsafe extern "C" fn BG_EvaluateTrajectoryDelta(
-    mut tr: *const crate::src::qcommon::q_shared::trajectory_t,
+    mut tr: *const trajectory_t,
     mut atTime: libc::c_int,
-    mut result: *mut crate::src::qcommon::q_shared::vec_t,
+    mut result: *mut vec_t,
 ) {
     let mut deltaTime: libc::c_float = 0.; // derivative of sin = cos
     let mut phase: libc::c_float = 0.; // milliseconds to seconds
     match (*tr).trType as libc::c_uint {
         0 | 1 => {
             let ref mut fresh1 = *result.offset(2 as libc::c_int as isize); // FIXME: local gravity...
-            *fresh1 = 0 as libc::c_int as crate::src::qcommon::q_shared::vec_t;
+            *fresh1 = 0 as libc::c_int as vec_t;
             let ref mut fresh2 = *result.offset(1 as libc::c_int as isize);
             *fresh2 = *fresh1;
             *result.offset(0 as libc::c_int as isize) = *fresh2
@@ -1526,7 +1526,7 @@ pub unsafe extern "C" fn BG_EvaluateTrajectoryDelta(
         3 => {
             if atTime > (*tr).trTime + (*tr).trDuration {
                 let ref mut fresh3 = *result.offset(2 as libc::c_int as isize);
-                *fresh3 = 0 as libc::c_int as crate::src::qcommon::q_shared::vec_t;
+                *fresh3 = 0 as libc::c_int as vec_t;
                 let ref mut fresh4 = *result.offset(1 as libc::c_int as isize);
                 *fresh4 = *fresh3;
                 *result.offset(0 as libc::c_int as isize) = *fresh4;
@@ -1545,8 +1545,8 @@ pub unsafe extern "C" fn BG_EvaluateTrajectoryDelta(
             *fresh5 -= 800 as libc::c_int as libc::c_float * deltaTime
         }
         _ => {
-            crate::src::q3_ui::ui_atoms::Com_Error(
-                crate::src::qcommon::q_shared::ERR_DROP as libc::c_int,
+            Com_Error(
+                ERR_DROP as libc::c_int,
                 b"BG_EvaluateTrajectoryDelta: unknown trType: %i\x00" as *const u8
                     as *const libc::c_char,
                 (*tr).trType as libc::c_uint,
@@ -1646,7 +1646,7 @@ pub static mut eventnames: [*mut libc::c_char; 83] = [
 pub unsafe extern "C" fn BG_AddPredictableEventToPlayerstate(
     mut newEvent: libc::c_int,
     mut eventParm: libc::c_int,
-    mut ps: *mut crate::src::qcommon::q_shared::playerState_t,
+    mut ps: *mut playerState_t,
 ) {
     (*ps).events[((*ps).eventSequence & 2 as libc::c_int - 1 as libc::c_int) as usize] = newEvent;
     (*ps).eventParms[((*ps).eventSequence & 2 as libc::c_int - 1 as libc::c_int) as usize] =
@@ -1661,28 +1661,28 @@ BG_TouchJumpPad
 #[no_mangle]
 
 pub unsafe extern "C" fn BG_TouchJumpPad(
-    mut ps: *mut crate::src::qcommon::q_shared::playerState_t,
-    mut jumppad: *mut crate::src::qcommon::q_shared::entityState_t,
+    mut ps: *mut playerState_t,
+    mut jumppad: *mut entityState_t,
 ) {
-    let mut angles: crate::src::qcommon::q_shared::vec3_t = [0.; 3];
+    let mut angles: vec3_t = [0.; 3];
     let mut p: libc::c_float = 0.;
     let mut effectNum: libc::c_int = 0;
     // spectators don't use jump pads
-    if (*ps).pm_type != crate::bg_public_h::PM_NORMAL as libc::c_int {
+    if (*ps).pm_type != PM_NORMAL as libc::c_int {
         return;
     }
     // flying characters don't hit bounce pads
-    if (*ps).powerups[crate::bg_public_h::PW_FLIGHT as libc::c_int as usize] != 0 {
+    if (*ps).powerups[PW_FLIGHT as libc::c_int as usize] != 0 {
         return;
     }
     // if we didn't hit this same jumppad the previous frame
     // then don't play the event sound again if we are in a fat trigger
     if (*ps).jumppad_ent != (*jumppad).number {
-        crate::src::qcommon::q_math::vectoangles(
-            (*jumppad).origin2.as_mut_ptr() as *const crate::src::qcommon::q_shared::vec_t,
+        vectoangles(
+            (*jumppad).origin2.as_mut_ptr() as *const vec_t,
             angles.as_mut_ptr(),
         );
-        p = crate::stdlib::fabs(crate::src::qcommon::q_math::AngleNormalize180(
+        p = crate::stdlib::fabs(AngleNormalize180(
             angles[0 as libc::c_int as usize],
         ) as libc::c_double) as libc::c_float;
         if p < 45 as libc::c_int as libc::c_float {
@@ -1691,7 +1691,7 @@ pub unsafe extern "C" fn BG_TouchJumpPad(
             effectNum = 1 as libc::c_int
         }
         BG_AddPredictableEventToPlayerstate(
-            crate::bg_public_h::EV_JUMP_PAD as libc::c_int,
+            EV_JUMP_PAD as libc::c_int,
             effectNum,
             ps,
         );
@@ -1715,65 +1715,65 @@ and after local prediction on the client
 #[no_mangle]
 
 pub unsafe extern "C" fn BG_PlayerStateToEntityState(
-    mut ps: *mut crate::src::qcommon::q_shared::playerState_t,
-    mut s: *mut crate::src::qcommon::q_shared::entityState_t,
-    mut snap: crate::src::qcommon::q_shared::qboolean,
+    mut ps: *mut playerState_t,
+    mut s: *mut entityState_t,
+    mut snap: qboolean,
 ) {
     let mut i: libc::c_int = 0;
-    if (*ps).pm_type == crate::bg_public_h::PM_INTERMISSION as libc::c_int
-        || (*ps).pm_type == crate::bg_public_h::PM_SPECTATOR as libc::c_int
+    if (*ps).pm_type == PM_INTERMISSION as libc::c_int
+        || (*ps).pm_type == PM_SPECTATOR as libc::c_int
     {
-        (*s).eType = crate::bg_public_h::ET_INVISIBLE as libc::c_int
-    } else if (*ps).stats[crate::bg_public_h::STAT_HEALTH as libc::c_int as usize]
+        (*s).eType = ET_INVISIBLE as libc::c_int
+    } else if (*ps).stats[STAT_HEALTH as libc::c_int as usize]
         <= -(40 as libc::c_int)
     {
-        (*s).eType = crate::bg_public_h::ET_INVISIBLE as libc::c_int
+        (*s).eType = ET_INVISIBLE as libc::c_int
     } else {
-        (*s).eType = crate::bg_public_h::ET_PLAYER as libc::c_int
+        (*s).eType = ET_PLAYER as libc::c_int
     }
     (*s).number = (*ps).clientNum;
-    (*s).pos.trType = crate::src::qcommon::q_shared::TR_INTERPOLATE;
+    (*s).pos.trType = TR_INTERPOLATE;
     (*s).pos.trBase[0 as libc::c_int as usize] = (*ps).origin[0 as libc::c_int as usize];
     (*s).pos.trBase[1 as libc::c_int as usize] = (*ps).origin[1 as libc::c_int as usize];
     (*s).pos.trBase[2 as libc::c_int as usize] = (*ps).origin[2 as libc::c_int as usize];
     if snap as u64 != 0 {
         (*s).pos.trBase[0 as libc::c_int as usize] = (*s).pos.trBase[0 as libc::c_int as usize]
             as libc::c_int
-            as crate::src::qcommon::q_shared::vec_t;
+            as vec_t;
         (*s).pos.trBase[1 as libc::c_int as usize] = (*s).pos.trBase[1 as libc::c_int as usize]
             as libc::c_int
-            as crate::src::qcommon::q_shared::vec_t;
+            as vec_t;
         (*s).pos.trBase[2 as libc::c_int as usize] = (*s).pos.trBase[2 as libc::c_int as usize]
             as libc::c_int
-            as crate::src::qcommon::q_shared::vec_t
+            as vec_t
     }
     // set the trDelta for flag direction
     (*s).pos.trDelta[0 as libc::c_int as usize] = (*ps).velocity[0 as libc::c_int as usize]; // ET_PLAYER looks here instead of at number
     (*s).pos.trDelta[1 as libc::c_int as usize] = (*ps).velocity[1 as libc::c_int as usize];
     (*s).pos.trDelta[2 as libc::c_int as usize] = (*ps).velocity[2 as libc::c_int as usize];
-    (*s).apos.trType = crate::src::qcommon::q_shared::TR_INTERPOLATE;
+    (*s).apos.trType = TR_INTERPOLATE;
     (*s).apos.trBase[0 as libc::c_int as usize] = (*ps).viewangles[0 as libc::c_int as usize];
     (*s).apos.trBase[1 as libc::c_int as usize] = (*ps).viewangles[1 as libc::c_int as usize];
     (*s).apos.trBase[2 as libc::c_int as usize] = (*ps).viewangles[2 as libc::c_int as usize];
     if snap as u64 != 0 {
         (*s).apos.trBase[0 as libc::c_int as usize] = (*s).apos.trBase[0 as libc::c_int as usize]
             as libc::c_int
-            as crate::src::qcommon::q_shared::vec_t;
+            as vec_t;
         (*s).apos.trBase[1 as libc::c_int as usize] = (*s).apos.trBase[1 as libc::c_int as usize]
             as libc::c_int
-            as crate::src::qcommon::q_shared::vec_t;
+            as vec_t;
         (*s).apos.trBase[2 as libc::c_int as usize] = (*s).apos.trBase[2 as libc::c_int as usize]
             as libc::c_int
-            as crate::src::qcommon::q_shared::vec_t
+            as vec_t
     }
     (*s).angles2[1 as libc::c_int as usize] =
-        (*ps).movementDir as crate::src::qcommon::q_shared::vec_t;
+        (*ps).movementDir as vec_t;
     (*s).legsAnim = (*ps).legsAnim;
     (*s).torsoAnim = (*ps).torsoAnim;
     (*s).clientNum = (*ps).clientNum;
     // so corpses can also reference the proper config
     (*s).eFlags = (*ps).eFlags;
-    if (*ps).stats[crate::bg_public_h::STAT_HEALTH as libc::c_int as usize] <= 0 as libc::c_int {
+    if (*ps).stats[STAT_HEALTH as libc::c_int as usize] <= 0 as libc::c_int {
         (*s).eFlags |= 0x1 as libc::c_int
     } else {
         (*s).eFlags &= !(0x1 as libc::c_int)
@@ -1816,38 +1816,38 @@ and after local prediction on the client
 #[no_mangle]
 
 pub unsafe extern "C" fn BG_PlayerStateToEntityStateExtraPolate(
-    mut ps: *mut crate::src::qcommon::q_shared::playerState_t,
-    mut s: *mut crate::src::qcommon::q_shared::entityState_t,
+    mut ps: *mut playerState_t,
+    mut s: *mut entityState_t,
     mut time: libc::c_int,
-    mut snap: crate::src::qcommon::q_shared::qboolean,
+    mut snap: qboolean,
 ) {
     let mut i: libc::c_int = 0;
-    if (*ps).pm_type == crate::bg_public_h::PM_INTERMISSION as libc::c_int
-        || (*ps).pm_type == crate::bg_public_h::PM_SPECTATOR as libc::c_int
+    if (*ps).pm_type == PM_INTERMISSION as libc::c_int
+        || (*ps).pm_type == PM_SPECTATOR as libc::c_int
     {
-        (*s).eType = crate::bg_public_h::ET_INVISIBLE as libc::c_int
-    } else if (*ps).stats[crate::bg_public_h::STAT_HEALTH as libc::c_int as usize]
+        (*s).eType = ET_INVISIBLE as libc::c_int
+    } else if (*ps).stats[STAT_HEALTH as libc::c_int as usize]
         <= -(40 as libc::c_int)
     {
-        (*s).eType = crate::bg_public_h::ET_INVISIBLE as libc::c_int
+        (*s).eType = ET_INVISIBLE as libc::c_int
     } else {
-        (*s).eType = crate::bg_public_h::ET_PLAYER as libc::c_int
+        (*s).eType = ET_PLAYER as libc::c_int
     }
     (*s).number = (*ps).clientNum;
-    (*s).pos.trType = crate::src::qcommon::q_shared::TR_LINEAR_STOP;
+    (*s).pos.trType = TR_LINEAR_STOP;
     (*s).pos.trBase[0 as libc::c_int as usize] = (*ps).origin[0 as libc::c_int as usize];
     (*s).pos.trBase[1 as libc::c_int as usize] = (*ps).origin[1 as libc::c_int as usize];
     (*s).pos.trBase[2 as libc::c_int as usize] = (*ps).origin[2 as libc::c_int as usize];
     if snap as u64 != 0 {
         (*s).pos.trBase[0 as libc::c_int as usize] = (*s).pos.trBase[0 as libc::c_int as usize]
             as libc::c_int
-            as crate::src::qcommon::q_shared::vec_t;
+            as vec_t;
         (*s).pos.trBase[1 as libc::c_int as usize] = (*s).pos.trBase[1 as libc::c_int as usize]
             as libc::c_int
-            as crate::src::qcommon::q_shared::vec_t;
+            as vec_t;
         (*s).pos.trBase[2 as libc::c_int as usize] = (*s).pos.trBase[2 as libc::c_int as usize]
             as libc::c_int
-            as crate::src::qcommon::q_shared::vec_t
+            as vec_t
     }
     // set the trDelta for flag direction and linear prediction
     (*s).pos.trDelta[0 as libc::c_int as usize] = (*ps).velocity[0 as libc::c_int as usize];
@@ -1857,29 +1857,29 @@ pub unsafe extern "C" fn BG_PlayerStateToEntityStateExtraPolate(
     (*s).pos.trTime = time;
     // set maximum extra polation time
     (*s).pos.trDuration = 50 as libc::c_int; // 1000 / sv_fps (default = 20)
-    (*s).apos.trType = crate::src::qcommon::q_shared::TR_INTERPOLATE; // ET_PLAYER looks here instead of at number
+    (*s).apos.trType = TR_INTERPOLATE; // ET_PLAYER looks here instead of at number
     (*s).apos.trBase[0 as libc::c_int as usize] = (*ps).viewangles[0 as libc::c_int as usize];
     (*s).apos.trBase[1 as libc::c_int as usize] = (*ps).viewangles[1 as libc::c_int as usize];
     (*s).apos.trBase[2 as libc::c_int as usize] = (*ps).viewangles[2 as libc::c_int as usize];
     if snap as u64 != 0 {
         (*s).apos.trBase[0 as libc::c_int as usize] = (*s).apos.trBase[0 as libc::c_int as usize]
             as libc::c_int
-            as crate::src::qcommon::q_shared::vec_t;
+            as vec_t;
         (*s).apos.trBase[1 as libc::c_int as usize] = (*s).apos.trBase[1 as libc::c_int as usize]
             as libc::c_int
-            as crate::src::qcommon::q_shared::vec_t;
+            as vec_t;
         (*s).apos.trBase[2 as libc::c_int as usize] = (*s).apos.trBase[2 as libc::c_int as usize]
             as libc::c_int
-            as crate::src::qcommon::q_shared::vec_t
+            as vec_t
     }
     (*s).angles2[1 as libc::c_int as usize] =
-        (*ps).movementDir as crate::src::qcommon::q_shared::vec_t;
+        (*ps).movementDir as vec_t;
     (*s).legsAnim = (*ps).legsAnim;
     (*s).torsoAnim = (*ps).torsoAnim;
     (*s).clientNum = (*ps).clientNum;
     // so corpses can also reference the proper config
     (*s).eFlags = (*ps).eFlags;
-    if (*ps).stats[crate::bg_public_h::STAT_HEALTH as libc::c_int as usize] <= 0 as libc::c_int {
+    if (*ps).stats[STAT_HEALTH as libc::c_int as usize] <= 0 as libc::c_int {
         (*s).eFlags |= 0x1 as libc::c_int
     } else {
         (*s).eFlags &= !(0x1 as libc::c_int)
@@ -1912,8 +1912,8 @@ pub unsafe extern "C" fn BG_PlayerStateToEntityStateExtraPolate(
     (*s).generic1 = (*ps).generic1;
 }
 unsafe extern "C" fn run_static_initializers() {
-    bg_numItems = (::std::mem::size_of::<[crate::bg_public_h::gitem_t; 37]>() as libc::c_ulong)
-        .wrapping_div(::std::mem::size_of::<crate::bg_public_h::gitem_t>() as libc::c_ulong)
+    bg_numItems = (::std::mem::size_of::<[gitem_t; 37]>() as libc::c_ulong)
+        .wrapping_div(::std::mem::size_of::<gitem_t>() as libc::c_ulong)
         .wrapping_sub(1 as libc::c_int as libc::c_ulong) as libc::c_int
 }
 #[used]


### PR DESCRIPTION
## Summary
- clean up redundant module paths in bg_misc and cg modules

## Testing
- `cargo +nightly-2019-12-05 build --release`

------
https://chatgpt.com/codex/tasks/task_e_68537f87f0588329ab1888df83027cf2