### PR TITLE
Remove redundant casts

### DIFF
--- a/quake3-rs/ioquake3/src/botlib/be_aas_route.rs
+++ b/quake3-rs/ioquake3/src/botlib/be_aas_route.rs
@@ -839,7 +839,7 @@ pub unsafe extern "C" fn AAS_CalculateAreaTravelTimes() {
         size = (size as libc::c_ulong).wrapping_add(
             ((*settings).numreachableareas as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<*mut u16>() as libc::c_ulong),
-        ) as i32 as i32;
+        ) as i32;
         //
         size = (size as libc::c_ulong).wrapping_add(
             ((*settings).numreachableareas as libc::c_ulong)
@@ -851,7 +851,7 @@ pub unsafe extern "C" fn AAS_CalculateAreaTravelTimes() {
                             .wrapping_sub(1 as i32 as libc::c_ulong),
                 )
                 .wrapping_mul(::std::mem::size_of::<u16>() as libc::c_ulong),
-        ) as i32 as i32;
+        ) as i32;
         i += 1
     }
     //allocate memory for the area travel times

--- a/quake3-rs/ioquake3/src/botlib/be_ai_chat.rs
+++ b/quake3-rs/ioquake3/src/botlib/be_ai_chat.rs
@@ -1148,7 +1148,7 @@ pub unsafe extern "C" fn BotLoadSynonyms(
                 {
                     size = (size as libc::c_ulong)
                         .wrapping_add(::std::mem::size_of::<bot_synonymlist_t>() as libc::c_ulong)
-                        as i32 as i32;
+                        as i32;
                     //end if
                     if pass != 0 && !ptr.is_null() {
                         syn = ptr as *mut bot_synonymlist_t; //end if
@@ -1209,7 +1209,7 @@ pub unsafe extern "C" fn BotLoadSynonyms(
                         size = (size as libc::c_ulong).wrapping_add(
                             (::std::mem::size_of::<bot_synonym_t>() as libc::c_ulong)
                                 .wrapping_add(len),
-                        ) as i32 as i32;
+                        ) as i32;
                         if pass != 0 && !ptr.is_null() {
                             synonym = ptr as *mut bot_synonym_t;
                             ptr = ptr
@@ -1757,7 +1757,7 @@ pub unsafe extern "C" fn BotLoadRandomStrings(
                     .wrapping_sub(1 as i32 as libc::c_ulong);
             size = (size as libc::c_ulong).wrapping_add(
                 (::std::mem::size_of::<bot_randomlist_t>() as libc::c_ulong).wrapping_add(len),
-            ) as i32 as i32;
+            ) as i32;
             if pass != 0 && !ptr.is_null() {
                 random = ptr as *mut bot_randomlist_t;
                 ptr =
@@ -1810,7 +1810,7 @@ pub unsafe extern "C" fn BotLoadRandomStrings(
                 size = (size as libc::c_ulong).wrapping_add(
                     (::std::mem::size_of::<bot_randomstring_t>() as libc::c_ulong)
                         .wrapping_add(len),
-                ) as i32 as i32;
+                ) as i32;
                 if pass != 0 && !ptr.is_null() {
                     randomstring = ptr as *mut bot_randomstring_t;
                     ptr = ptr.offset(
@@ -3636,7 +3636,7 @@ pub unsafe extern "C" fn BotLoadInitialChat(
                         }
                         size = (size as libc::c_ulong)
                             .wrapping_add(::std::mem::size_of::<bot_chattype_t>() as libc::c_ulong)
-                            as i32 as i32;
+                            as i32;
                         //read the chat messages
                         while crate::src::botlib::l_precomp::PC_CheckTokenString(
                             source as *mut crate::src::botlib::l_precomp::source_s,
@@ -3681,7 +3681,7 @@ pub unsafe extern "C" fn BotLoadInitialChat(
                             size = (size as libc::c_ulong).wrapping_add(
                                 (::std::mem::size_of::<bot_chatmessage_t>() as libc::c_ulong)
                                     .wrapping_add(len),
-                            ) as i32 as i32
+                            ) as i32
                         }
                     }
                 } else {
@@ -3982,7 +3982,7 @@ pub unsafe extern "C" fn BotExpandChatMessage(
                         ::libc::strcpy(&mut *outputbuf.offset(len as isize), temp.as_mut_ptr());
                         len = (len as libc::c_ulong)
                             .wrapping_add(crate::stdlib::strlen(temp.as_mut_ptr()))
-                            as i32 as i32
+                            as i32
                     }
                 }
                 114 => {
@@ -4029,8 +4029,7 @@ pub unsafe extern "C" fn BotExpandChatMessage(
                         return crate::src::qcommon::q_shared::qfalse as i32;
                     }
                     ::libc::strcpy(&mut *outputbuf.offset(len as isize), ptr);
-                    len = (len as libc::c_ulong).wrapping_add(crate::stdlib::strlen(ptr)) as i32
-                        as i32;
+                    len = (len as libc::c_ulong).wrapping_add(crate::stdlib::strlen(ptr)) as i32;
                     expansion = crate::src::qcommon::q_shared::qtrue as i32
                 }
                 _ => {
@@ -4319,43 +4318,43 @@ pub unsafe extern "C" fn BotInitialChat(
         ::libc::strcat(match_0.string.as_mut_ptr(), var0);
         match_0.variables[0 as i32 as usize].offset = index as libc::c_char;
         match_0.variables[0 as i32 as usize].length = crate::stdlib::strlen(var0) as i32;
-        index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var0)) as i32 as i32
+        index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var0)) as i32
     }
     if !var1.is_null() {
         ::libc::strcat(match_0.string.as_mut_ptr(), var1);
         match_0.variables[1 as i32 as usize].offset = index as libc::c_char;
         match_0.variables[1 as i32 as usize].length = crate::stdlib::strlen(var1) as i32;
-        index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var1)) as i32 as i32
+        index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var1)) as i32
     }
     if !var2.is_null() {
         ::libc::strcat(match_0.string.as_mut_ptr(), var2);
         match_0.variables[2 as i32 as usize].offset = index as libc::c_char;
         match_0.variables[2 as i32 as usize].length = crate::stdlib::strlen(var2) as i32;
-        index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var2)) as i32 as i32
+        index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var2)) as i32
     }
     if !var3.is_null() {
         ::libc::strcat(match_0.string.as_mut_ptr(), var3);
         match_0.variables[3 as i32 as usize].offset = index as libc::c_char;
         match_0.variables[3 as i32 as usize].length = crate::stdlib::strlen(var3) as i32;
-        index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var3)) as i32 as i32
+        index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var3)) as i32
     }
     if !var4.is_null() {
         ::libc::strcat(match_0.string.as_mut_ptr(), var4);
         match_0.variables[4 as i32 as usize].offset = index as libc::c_char;
         match_0.variables[4 as i32 as usize].length = crate::stdlib::strlen(var4) as i32;
-        index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var4)) as i32 as i32
+        index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var4)) as i32
     }
     if !var5.is_null() {
         ::libc::strcat(match_0.string.as_mut_ptr(), var5);
         match_0.variables[5 as i32 as usize].offset = index as libc::c_char;
         match_0.variables[5 as i32 as usize].length = crate::stdlib::strlen(var5) as i32;
-        index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var5)) as i32 as i32
+        index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var5)) as i32
     }
     if !var6.is_null() {
         ::libc::strcat(match_0.string.as_mut_ptr(), var6);
         match_0.variables[6 as i32 as usize].offset = index as libc::c_char;
         match_0.variables[6 as i32 as usize].length = crate::stdlib::strlen(var6) as i32;
-        index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var6)) as i32 as i32
+        index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var6)) as i32
     }
     if !var7.is_null() {
         ::libc::strcat(match_0.string.as_mut_ptr(), var7);
@@ -4685,43 +4684,43 @@ pub unsafe extern "C" fn BotReplyChat(
             ::libc::strcat(bestmatch.string.as_mut_ptr(), var0);
             bestmatch.variables[0 as i32 as usize].offset = index as libc::c_char;
             bestmatch.variables[0 as i32 as usize].length = crate::stdlib::strlen(var0) as i32;
-            index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var0)) as i32 as i32
+            index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var0)) as i32
         }
         if !var1.is_null() {
             ::libc::strcat(bestmatch.string.as_mut_ptr(), var1);
             bestmatch.variables[1 as i32 as usize].offset = index as libc::c_char;
             bestmatch.variables[1 as i32 as usize].length = crate::stdlib::strlen(var1) as i32;
-            index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var1)) as i32 as i32
+            index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var1)) as i32
         }
         if !var2.is_null() {
             ::libc::strcat(bestmatch.string.as_mut_ptr(), var2);
             bestmatch.variables[2 as i32 as usize].offset = index as libc::c_char;
             bestmatch.variables[2 as i32 as usize].length = crate::stdlib::strlen(var2) as i32;
-            index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var2)) as i32 as i32
+            index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var2)) as i32
         }
         if !var3.is_null() {
             ::libc::strcat(bestmatch.string.as_mut_ptr(), var3);
             bestmatch.variables[3 as i32 as usize].offset = index as libc::c_char;
             bestmatch.variables[3 as i32 as usize].length = crate::stdlib::strlen(var3) as i32;
-            index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var3)) as i32 as i32
+            index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var3)) as i32
         }
         if !var4.is_null() {
             ::libc::strcat(bestmatch.string.as_mut_ptr(), var4);
             bestmatch.variables[4 as i32 as usize].offset = index as libc::c_char;
             bestmatch.variables[4 as i32 as usize].length = crate::stdlib::strlen(var4) as i32;
-            index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var4)) as i32 as i32
+            index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var4)) as i32
         }
         if !var5.is_null() {
             ::libc::strcat(bestmatch.string.as_mut_ptr(), var5);
             bestmatch.variables[5 as i32 as usize].offset = index as libc::c_char;
             bestmatch.variables[5 as i32 as usize].length = crate::stdlib::strlen(var5) as i32;
-            index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var5)) as i32 as i32
+            index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var5)) as i32
         }
         if !var6.is_null() {
             ::libc::strcat(bestmatch.string.as_mut_ptr(), var6);
             bestmatch.variables[6 as i32 as usize].offset = index as libc::c_char;
             bestmatch.variables[6 as i32 as usize].length = crate::stdlib::strlen(var6) as i32;
-            index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var6)) as i32 as i32
+            index = (index as libc::c_ulong).wrapping_add(crate::stdlib::strlen(var6)) as i32
         }
         if !var7.is_null() {
             ::libc::strcat(bestmatch.string.as_mut_ptr(), var7);

--- a/quake3-rs/ioquake3/src/client/cl_avi.rs
+++ b/quake3-rs/ioquake3/src/client/cl_avi.rs
@@ -204,7 +204,7 @@ unsafe extern "C" fn WRITE_STRING(mut s: *const libc::c_char) {
         s as *const libc::c_void,
         crate::stdlib::strlen(s),
     );
-    bufIndex = (bufIndex as libc::c_ulong).wrapping_add(crate::stdlib::strlen(s)) as i32 as i32;
+    bufIndex = (bufIndex as libc::c_ulong).wrapping_add(crate::stdlib::strlen(s)) as i32;
 }
 /*
 ===============

--- a/quake3-rs/ioquake3/src/client/cl_input.rs
+++ b/quake3-rs/ioquake3/src/client/cl_input.rs
@@ -494,7 +494,7 @@ pub unsafe extern "C" fn CL_KeyState(mut key: *mut crate::client_h::kbutton_t) -
         } else {
             msec = (msec as u32).wrapping_add(
                 (crate::src::qcommon::common::com_frameTime as u32).wrapping_sub((*key).downtime),
-            ) as i32 as i32
+            ) as i32
         }
         (*key).downtime = crate::src::qcommon::common::com_frameTime as u32
     }

--- a/quake3-rs/ioquake3/src/client/snd_mem.rs
+++ b/quake3-rs/ioquake3/src/client/snd_mem.rs
@@ -58,7 +58,7 @@ pub unsafe extern "C" fn SND_free(mut v: *mut crate::snd_local_h::sndBuffer) {
     freelist = v;
     inUse = (inUse as libc::c_ulong)
         .wrapping_add(::std::mem::size_of::<crate::snd_local_h::sndBuffer>() as libc::c_ulong)
-        as i32 as i32;
+        as i32;
 }
 #[no_mangle]
 
@@ -69,10 +69,10 @@ pub unsafe extern "C" fn SND_malloc() -> *mut crate::snd_local_h::sndBuffer {
     }
     inUse = (inUse as libc::c_ulong)
         .wrapping_sub(::std::mem::size_of::<crate::snd_local_h::sndBuffer>() as libc::c_ulong)
-        as i32 as i32;
+        as i32;
     totalInUse = (totalInUse as libc::c_ulong)
         .wrapping_add(::std::mem::size_of::<crate::snd_local_h::sndBuffer>() as libc::c_ulong)
-        as i32 as i32;
+        as i32;
     v = freelist;
     freelist = *(freelist as *mut *mut crate::snd_local_h::sndBuffer);
     (*v).next = 0 as *mut crate::snd_local_h::sndBuffer_s;

--- a/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/res0.rs
+++ b/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/res0.rs
@@ -120,7 +120,7 @@ pub unsafe extern "C" fn res0_free_look(mut i: *mut libc::c_void) {
 unsafe extern "C" fn icount(mut v: u32) -> i32 {
     let mut ret: i32 = 0 as i32;
     while v != 0 {
-        ret = (ret as u32).wrapping_add(v & 1 as i32 as u32) as i32 as i32;
+        ret = (ret as u32).wrapping_add(v & 1 as i32 as u32) as i32;
         v >>= 1 as i32
     }
     return ret;

--- a/quake3-rs/ioquake3/src/opus_1_2_1/celt/bands.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/celt/bands.rs
@@ -833,7 +833,7 @@ pub unsafe extern "C" fn spreading_decision(
                         (32 as i32 * (tcount[1 as i32 as usize] + tcount[0 as i32 as usize]))
                             as crate::opus_types_h::opus_uint32,
                         N as crate::opus_types_h::opus_uint32,
-                    )) as i32 as i32
+                    )) as i32
                 }
                 tmp = (2 as i32 * tcount[2 as i32 as usize] >= N) as i32
                     + (2 as i32 * tcount[1 as i32 as usize] >= N) as i32

--- a/quake3-rs/ioquake3/src/opus_1_2_1/celt/cwrs.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/celt/cwrs.rs
@@ -1462,7 +1462,7 @@ unsafe extern "C" fn icwrs(mut _n: i32, mut _y: *const i32) -> crate::opus_types
             (i as u32).wrapping_add(
                 *CELT_PVQ_U_ROW[if _n - j < k { (_n) - j } else { k } as usize]
                     .offset(if _n - j > k { (_n) - j } else { k } as isize),
-            ) as crate::opus_types_h::opus_uint32 as crate::opus_types_h::opus_uint32;
+            ) as crate::opus_types_h::opus_uint32;
         k += ::libc::abs(*_y.offset(j as isize));
         if *_y.offset(j as isize) < 0 as i32 {
             i = (i as u32).wrapping_add(
@@ -1477,7 +1477,6 @@ unsafe extern "C" fn icwrs(mut _n: i32, mut _y: *const i32) -> crate::opus_types
                         (k) + 1 as i32
                     } as isize),
             ) as crate::opus_types_h::opus_uint32
-                as crate::opus_types_h::opus_uint32
         }
         if !(j > 0 as i32) {
             break;
@@ -1536,8 +1535,7 @@ unsafe extern "C" fn cwrsi(
             /*Are the pulses in this dimension negative?*/
             p = *row.offset((_k + 1 as i32) as isize);
             s = -((_i >= p) as i32);
-            _i = (_i as u32).wrapping_sub(p & s as u32) as crate::opus_types_h::opus_uint32
-                as crate::opus_types_h::opus_uint32;
+            _i = (_i as u32).wrapping_sub(p & s as u32) as crate::opus_types_h::opus_uint32;
             /*Count how many pulses were placed in this dimension.*/
             k0 = _k;
             q = *row.offset(_n as isize);
@@ -1557,8 +1555,7 @@ unsafe extern "C" fn cwrsi(
                     p = *row.offset(_k as isize)
                 }
             }
-            _i = (_i as u32).wrapping_sub(p) as crate::opus_types_h::opus_uint32
-                as crate::opus_types_h::opus_uint32;
+            _i = (_i as u32).wrapping_sub(p) as crate::opus_types_h::opus_uint32;
             val = (k0 - _k + s ^ s) as crate::opus_types_h::opus_int16;
             let fresh0 = _y;
             _y = _y.offset(1);
@@ -1570,16 +1567,14 @@ unsafe extern "C" fn cwrsi(
             p = *CELT_PVQ_U_ROW[_k as usize].offset(_n as isize);
             q = *CELT_PVQ_U_ROW[(_k + 1 as i32) as usize].offset(_n as isize);
             if p <= _i && _i < q {
-                _i = (_i as u32).wrapping_sub(p) as crate::opus_types_h::opus_uint32
-                    as crate::opus_types_h::opus_uint32;
+                _i = (_i as u32).wrapping_sub(p) as crate::opus_types_h::opus_uint32;
                 let fresh1 = _y;
                 _y = _y.offset(1);
                 *fresh1 = 0 as i32
             } else {
                 /*Are the pulses in this dimension negative?*/
                 s = -((_i >= q) as i32);
-                _i = (_i as u32).wrapping_sub(q & s as u32) as crate::opus_types_h::opus_uint32
-                    as crate::opus_types_h::opus_uint32;
+                _i = (_i as u32).wrapping_sub(q & s as u32) as crate::opus_types_h::opus_uint32;
                 /*Count how many pulses were placed in this dimension.*/
                 k0 = _k;
                 loop {
@@ -1589,8 +1584,7 @@ unsafe extern "C" fn cwrsi(
                         break;
                     }
                 }
-                _i = (_i as u32).wrapping_sub(p) as crate::opus_types_h::opus_uint32
-                    as crate::opus_types_h::opus_uint32;
+                _i = (_i as u32).wrapping_sub(p) as crate::opus_types_h::opus_uint32;
                 val = (k0 - _k + s ^ s) as crate::opus_types_h::opus_int16;
                 let fresh2 = _y;
                 _y = _y.offset(1);
@@ -1603,13 +1597,12 @@ unsafe extern "C" fn cwrsi(
     /*_n==2*/
     p = (2 as i32 * _k + 1 as i32) as crate::opus_types_h::opus_uint32;
     s = -((_i >= p) as i32);
-    _i = (_i as u32).wrapping_sub(p & s as u32) as crate::opus_types_h::opus_uint32
-        as crate::opus_types_h::opus_uint32;
+    _i = (_i as u32).wrapping_sub(p & s as u32) as crate::opus_types_h::opus_uint32;
     k0 = _k;
     _k = (_i.wrapping_add(1 as i32 as u32) >> 1 as i32) as i32;
     if _k != 0 {
         _i = (_i as u32).wrapping_sub((2 as i32 * _k - 1 as i32) as u32)
-            as crate::opus_types_h::opus_uint32 as crate::opus_types_h::opus_uint32
+            as crate::opus_types_h::opus_uint32
     }
     val = (k0 - _k + s ^ s) as crate::opus_types_h::opus_int16;
     let fresh3 = _y;

--- a/quake3-rs/ioquake3/src/opus_1_2_1/celt/entdec.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/celt/entdec.rs
@@ -220,8 +220,7 @@ pub unsafe extern "C" fn ec_dec_update(
 ) {
     let mut s: crate::opus_types_h::opus_uint32 = 0;
     s = (*_this).ext.wrapping_mul(_ft.wrapping_sub(_fh));
-    (*_this).val = ((*_this).val as u32).wrapping_sub(s) as crate::opus_types_h::opus_uint32
-        as crate::opus_types_h::opus_uint32;
+    (*_this).val = ((*_this).val as u32).wrapping_sub(s) as crate::opus_types_h::opus_uint32;
     (*_this).rng = if _fl > 0 as i32 as u32 {
         (*_this).ext.wrapping_mul(_fh.wrapping_sub(_fl))
     } else {
@@ -418,9 +417,9 @@ pub unsafe extern "C" fn ec_dec_bits(
     }
     ret = window & ((1 as i32 as crate::opus_types_h::opus_uint32) << _bits).wrapping_sub(1 as u32);
     window >>= _bits;
-    available = (available as u32).wrapping_sub(_bits) as i32 as i32;
+    available = (available as u32).wrapping_sub(_bits) as i32;
     (*_this).end_window = window;
     (*_this).nend_bits = available;
-    (*_this).nbits_total = ((*_this).nbits_total as u32).wrapping_add(_bits) as i32 as i32;
+    (*_this).nbits_total = ((*_this).nbits_total as u32).wrapping_add(_bits) as i32;
     return ret;
 }

--- a/quake3-rs/ioquake3/src/opus_1_2_1/celt/entenc.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/celt/entenc.rs
@@ -194,12 +194,10 @@ pub unsafe extern "C" fn ec_encode(
             (*_this)
                 .rng
                 .wrapping_sub(r.wrapping_mul(_ft.wrapping_sub(_fl))),
-        ) as crate::opus_types_h::opus_uint32
-            as crate::opus_types_h::opus_uint32;
+        ) as crate::opus_types_h::opus_uint32;
         (*_this).rng = r.wrapping_mul(_fh.wrapping_sub(_fl))
     } else {
         (*_this).rng = ((*_this).rng as u32).wrapping_sub(r.wrapping_mul(_ft.wrapping_sub(_fh)))
-            as crate::opus_types_h::opus_uint32
             as crate::opus_types_h::opus_uint32
     }
     ec_enc_normalize(_this);
@@ -219,13 +217,11 @@ pub unsafe extern "C" fn ec_encode_bin(
             (*_this)
                 .rng
                 .wrapping_sub(r.wrapping_mul(((1 as u32) << _bits).wrapping_sub(_fl))),
-        ) as crate::opus_types_h::opus_uint32
-            as crate::opus_types_h::opus_uint32;
+        ) as crate::opus_types_h::opus_uint32;
         (*_this).rng = r.wrapping_mul(_fh.wrapping_sub(_fl))
     } else {
         (*_this).rng = ((*_this).rng as u32)
             .wrapping_sub(r.wrapping_mul(((1 as u32) << _bits).wrapping_sub(_fh)))
-            as crate::opus_types_h::opus_uint32
             as crate::opus_types_h::opus_uint32
     }
     ec_enc_normalize(_this);
@@ -244,8 +240,7 @@ pub unsafe extern "C" fn ec_enc_bit_logp(
     r = (*_this).rng;
     l = (*_this).val;
     s = r >> _logp;
-    r = (r as u32).wrapping_sub(s) as crate::opus_types_h::opus_uint32
-        as crate::opus_types_h::opus_uint32;
+    r = (r as u32).wrapping_sub(s) as crate::opus_types_h::opus_uint32;
     if _val != 0 {
         (*_this).val = l.wrapping_add(r)
     }
@@ -267,8 +262,7 @@ pub unsafe extern "C" fn ec_enc_icdf(
             (*_this)
                 .rng
                 .wrapping_sub(r.wrapping_mul(*_icdf.offset((_s - 1 as i32) as isize) as u32)),
-        ) as crate::opus_types_h::opus_uint32
-            as crate::opus_types_h::opus_uint32;
+        ) as crate::opus_types_h::opus_uint32;
         (*_this).rng = r.wrapping_mul(
             (*_icdf.offset((_s - 1 as i32) as isize) as i32 - *_icdf.offset(_s as isize) as i32)
                 as u32,
@@ -276,7 +270,7 @@ pub unsafe extern "C" fn ec_enc_icdf(
     } else {
         (*_this).rng =
             ((*_this).rng as u32).wrapping_sub(r.wrapping_mul(*_icdf.offset(_s as isize) as u32))
-                as crate::opus_types_h::opus_uint32 as crate::opus_types_h::opus_uint32
+                as crate::opus_types_h::opus_uint32
     }
     ec_enc_normalize(_this);
 }
@@ -342,10 +336,10 @@ pub unsafe extern "C" fn ec_enc_bits(
         }
     }
     window |= _fl << used;
-    used = (used as u32).wrapping_add(_bits) as i32 as i32;
+    used = (used as u32).wrapping_add(_bits) as i32;
     (*_this).end_window = window;
     (*_this).nend_bits = used;
-    (*_this).nbits_total = ((*_this).nbits_total as u32).wrapping_add(_bits) as i32 as i32;
+    (*_this).nbits_total = ((*_this).nbits_total as u32).wrapping_add(_bits) as i32;
 }
 #[no_mangle]
 

--- a/quake3-rs/ioquake3/src/opus_1_2_1/src/opus_multistream_encoder.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/src/opus_multistream_encoder.rs
@@ -93,7 +93,6 @@ pub mod mathops_h {
         in_0.f = x;
         integer = (in_0.i >> 23 as i32).wrapping_sub(127 as i32 as u32) as i32;
         in_0.i = (in_0.i as u32).wrapping_sub((integer << 23 as i32) as u32)
-            as crate::opus_types_h::opus_uint32
             as crate::opus_types_h::opus_uint32;
         frac = in_0.f - 1.5f32;
         frac = -0.41445418f32
@@ -947,7 +946,7 @@ pub unsafe extern "C" fn opus_multistream_surround_encoder_get_size(
                         ::std::mem::size_of::<crate::arch_h::opus_val32>() as libc::c_ulong
                     ),
             ),
-        ) as crate::opus_types_h::opus_int32 as crate::opus_types_h::opus_int32
+        ) as crate::opus_types_h::opus_int32
     }
     return size;
 }

--- a/quake3-rs/ioquake3/src/opusfile_0_9/src/info.rs
+++ b/quake3-rs/ioquake3/src/opusfile_0_9/src/info.rs
@@ -309,12 +309,10 @@ unsafe extern "C" fn opus_tags_parse_impl(
         return -(133 as i32);
     }
     _data = _data.offset(8 as i32 as isize);
-    len = (len as libc::c_ulong).wrapping_sub(8 as i32 as libc::c_ulong) as crate::stddef_h::size_t
-        as crate::stddef_h::size_t;
+    len = (len as libc::c_ulong).wrapping_sub(8 as i32 as libc::c_ulong) as crate::stddef_h::size_t;
     count = op_parse_uint32le(_data);
     _data = _data.offset(4 as i32 as isize);
-    len = (len as libc::c_ulong).wrapping_sub(4 as i32 as libc::c_ulong) as crate::stddef_h::size_t
-        as crate::stddef_h::size_t;
+    len = (len as libc::c_ulong).wrapping_sub(4 as i32 as libc::c_ulong) as crate::stddef_h::size_t;
     if count as libc::c_ulong > len {
         return -(133 as i32);
     }
@@ -326,15 +324,13 @@ unsafe extern "C" fn opus_tags_parse_impl(
         }
     }
     _data = _data.offset(count as isize);
-    len = (len as libc::c_ulong).wrapping_sub(count as libc::c_ulong) as crate::stddef_h::size_t
-        as crate::stddef_h::size_t;
+    len = (len as libc::c_ulong).wrapping_sub(count as libc::c_ulong) as crate::stddef_h::size_t;
     if len < 4 as i32 as libc::c_ulong {
         return -(133 as i32);
     }
     count = op_parse_uint32le(_data);
     _data = _data.offset(4 as i32 as isize);
-    len = (len as libc::c_ulong).wrapping_sub(4 as i32 as libc::c_ulong) as crate::stddef_h::size_t
-        as crate::stddef_h::size_t;
+    len = (len as libc::c_ulong).wrapping_sub(4 as i32 as libc::c_ulong) as crate::stddef_h::size_t;
     /*Check to make sure there's minimally sufficient data left in the packet.*/
     if count as libc::c_ulong > len >> 2 as i32 {
         return -(133 as i32);
@@ -361,7 +357,7 @@ unsafe extern "C" fn opus_tags_parse_impl(
         count = op_parse_uint32le(_data);
         _data = _data.offset(4 as i32 as isize);
         len = (len as libc::c_ulong).wrapping_sub(4 as i32 as libc::c_ulong)
-            as crate::stddef_h::size_t as crate::stddef_h::size_t;
+            as crate::stddef_h::size_t;
         if count as libc::c_ulong > len {
             return -(133 as i32);
         }
@@ -384,8 +380,7 @@ unsafe extern "C" fn opus_tags_parse_impl(
             *fresh4 = 0 as *mut libc::c_char
         }
         _data = _data.offset(count as isize);
-        len = (len as libc::c_ulong).wrapping_sub(count as libc::c_ulong) as crate::stddef_h::size_t
-            as crate::stddef_h::size_t;
+        len = (len as libc::c_ulong).wrapping_sub(count as libc::c_ulong) as crate::stddef_h::size_t;
         ci += 1
     }
     if len > 0 as i32 as libc::c_ulong && *_data.offset(0 as i32 as isize) as i32 & 1 as i32 != 0 {
@@ -925,7 +920,6 @@ unsafe extern "C" fn op_extract_jpeg_params(
             } else {
                 /*Other markers: skip the whole marker segment.*/
                 offs = (offs as libc::c_ulong).wrapping_add(segment_len) as crate::stddef_h::size_t
-                    as crate::stddef_h::size_t
             }
         }
     };
@@ -1007,7 +1001,7 @@ unsafe extern "C" fn op_extract_png_params(
             }
             offs = (offs as libc::c_ulong)
                 .wrapping_add((12 as i32 as u32).wrapping_add(chunk_len) as libc::c_ulong)
-                as crate::stddef_h::size_t as crate::stddef_h::size_t
+                as crate::stddef_h::size_t
         }
     };
 }
@@ -1152,12 +1146,10 @@ unsafe extern "C" fn opus_picture_tag_parse_impl(
     }
     i = 0 as i32 as crate::stddef_h::size_t;
     picture_type = op_parse_uint32be(_buf.offset(i as isize)) as crate::opus_types_h::opus_int32;
-    i = (i as libc::c_ulong).wrapping_add(4 as i32 as libc::c_ulong) as crate::stddef_h::size_t
-        as crate::stddef_h::size_t;
+    i = (i as libc::c_ulong).wrapping_add(4 as i32 as libc::c_ulong) as crate::stddef_h::size_t;
     /*Extract the MIME type.*/
     mime_type_length = op_parse_uint32be(_buf.offset(i as isize));
-    i = (i as libc::c_ulong).wrapping_add(4 as i32 as libc::c_ulong) as crate::stddef_h::size_t
-        as crate::stddef_h::size_t;
+    i = (i as libc::c_ulong).wrapping_add(4 as i32 as libc::c_ulong) as crate::stddef_h::size_t;
     if mime_type_length as libc::c_ulong > _buf_sz.wrapping_sub(32 as i32 as libc::c_ulong) {
         return -(132 as i32);
     }
@@ -1177,11 +1169,10 @@ unsafe extern "C" fn opus_picture_tag_parse_impl(
     *mime_type.offset(mime_type_length as isize) = '\u{0}' as i32 as libc::c_char;
     (*_pic).mime_type = mime_type;
     i = (i as libc::c_ulong).wrapping_add(mime_type_length as libc::c_ulong)
-        as crate::stddef_h::size_t as crate::stddef_h::size_t;
+        as crate::stddef_h::size_t;
     /*Extract the description string.*/
     description_length = op_parse_uint32be(_buf.offset(i as isize));
-    i = (i as libc::c_ulong).wrapping_add(4 as i32 as libc::c_ulong) as crate::stddef_h::size_t
-        as crate::stddef_h::size_t;
+    i = (i as libc::c_ulong).wrapping_add(4 as i32 as libc::c_ulong) as crate::stddef_h::size_t;
     if description_length as libc::c_ulong
         > _buf_sz
             .wrapping_sub(mime_type_length as libc::c_ulong)
@@ -1205,20 +1196,16 @@ unsafe extern "C" fn opus_picture_tag_parse_impl(
     *description.offset(description_length as isize) = '\u{0}' as i32 as libc::c_char;
     (*_pic).description = description;
     i = (i as libc::c_ulong).wrapping_add(description_length as libc::c_ulong)
-        as crate::stddef_h::size_t as crate::stddef_h::size_t;
+        as crate::stddef_h::size_t;
     /*Extract the remaining fields.*/
     width = op_parse_uint32be(_buf.offset(i as isize));
-    i = (i as libc::c_ulong).wrapping_add(4 as i32 as libc::c_ulong) as crate::stddef_h::size_t
-        as crate::stddef_h::size_t;
+    i = (i as libc::c_ulong).wrapping_add(4 as i32 as libc::c_ulong) as crate::stddef_h::size_t;
     height = op_parse_uint32be(_buf.offset(i as isize));
-    i = (i as libc::c_ulong).wrapping_add(4 as i32 as libc::c_ulong) as crate::stddef_h::size_t
-        as crate::stddef_h::size_t;
+    i = (i as libc::c_ulong).wrapping_add(4 as i32 as libc::c_ulong) as crate::stddef_h::size_t;
     depth = op_parse_uint32be(_buf.offset(i as isize));
-    i = (i as libc::c_ulong).wrapping_add(4 as i32 as libc::c_ulong) as crate::stddef_h::size_t
-        as crate::stddef_h::size_t;
+    i = (i as libc::c_ulong).wrapping_add(4 as i32 as libc::c_ulong) as crate::stddef_h::size_t;
     colors = op_parse_uint32be(_buf.offset(i as isize));
-    i = (i as libc::c_ulong).wrapping_add(4 as i32 as libc::c_ulong) as crate::stddef_h::size_t
-        as crate::stddef_h::size_t;
+    i = (i as libc::c_ulong).wrapping_add(4 as i32 as libc::c_ulong) as crate::stddef_h::size_t;
     /*If one of these is set, they all must be, but colors==0 is a valid value.*/
     colors_set = (width != 0 as i32 as u32
         || height != 0 as i32 as u32
@@ -1230,8 +1217,7 @@ unsafe extern "C" fn opus_picture_tag_parse_impl(
         return -(132 as i32);
     }
     data_length = op_parse_uint32be(_buf.offset(i as isize));
-    i = (i as libc::c_ulong).wrapping_add(4 as i32 as libc::c_ulong) as crate::stddef_h::size_t
-        as crate::stddef_h::size_t;
+    i = (i as libc::c_ulong).wrapping_add(4 as i32 as libc::c_ulong) as crate::stddef_h::size_t;
     if data_length as libc::c_ulong > _buf_sz.wrapping_sub(i) {
         return -(132 as i32);
     }
@@ -1383,8 +1369,7 @@ unsafe extern "C" fn opus_picture_tag_parse_impl(
     }
     /*Adjust _buf_sz instead of using data_length to capture the terminating NUL
     for URLs.*/
-    _buf_sz = (_buf_sz as libc::c_ulong).wrapping_sub(i) as crate::stddef_h::size_t
-        as crate::stddef_h::size_t;
+    _buf_sz = (_buf_sz as libc::c_ulong).wrapping_sub(i) as crate::stddef_h::size_t;
     crate::stdlib::memmove(
         _buf as *mut libc::c_void,
         _buf.offset(i as isize) as *const libc::c_void,

--- a/quake3-rs/ioquake3/src/qcommon/files.rs
+++ b/quake3-rs/ioquake3/src/qcommon/files.rs
@@ -2618,7 +2618,7 @@ unsafe extern "C" fn FS_LoadZipFile(
         len = (len as libc::c_ulong).wrapping_add(
             crate::stdlib::strlen(filename_inzip.as_mut_ptr())
                 .wrapping_add(1 as i32 as libc::c_ulong),
-        ) as i32 as i32;
+        ) as i32;
         crate::src::qcommon::unzip::unzGoToNextFile(uf);
         i += 1
     }
@@ -3139,8 +3139,8 @@ unsafe extern "C" fn Sys_ConcatenateFileLists(
     let mut cat: *mut *mut libc::c_char = 0 as *mut *mut libc::c_char;
     let mut dst: *mut *mut libc::c_char = 0 as *mut *mut libc::c_char;
     let mut src: *mut *mut libc::c_char = 0 as *mut *mut libc::c_char;
-    totalLength = (totalLength as u32).wrapping_add(Sys_CountFileList(list0)) as i32 as i32;
-    totalLength = (totalLength as u32).wrapping_add(Sys_CountFileList(list1)) as i32 as i32;
+    totalLength = (totalLength as u32).wrapping_add(Sys_CountFileList(list0)) as i32;
+    totalLength = (totalLength as u32).wrapping_add(Sys_CountFileList(list1)) as i32;
     /* Create new list. */
     cat = crate::src::qcommon::common::Z_Malloc(
         ((totalLength + 1 as i32) as libc::c_ulong)

--- a/quake3-rs/ioquake3/src/qcommon/md4.rs
+++ b/quake3-rs/ioquake3/src/qcommon/md4.rs
@@ -474,10 +474,10 @@ unsafe extern "C" fn mdfour64(mut M: *mut crate::stdlib::uint32_t) {
             .wrapping_add(X[15 as i32 as usize])
             .wrapping_add(0x6ed9eba1 as i32 as u32)
             >> 32 as i32 - 15 as i32;
-    A = (A as u32).wrapping_add(AA) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
-    B = (B as u32).wrapping_add(BB) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
-    C = (C as u32).wrapping_add(CC) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
-    D = (D as u32).wrapping_add(DD) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    A = (A as u32).wrapping_add(AA) as crate::stdlib::uint32_t;
+    B = (B as u32).wrapping_add(BB) as crate::stdlib::uint32_t;
+    C = (C as u32).wrapping_add(CC) as crate::stdlib::uint32_t;
+    D = (D as u32).wrapping_add(DD) as crate::stdlib::uint32_t;
     j = 0 as i32;
     while j < 16 as i32 {
         X[j as usize] = 0 as i32 as crate::stdlib::uint32_t;
@@ -536,8 +536,7 @@ unsafe extern "C" fn mdfour_tail(mut in_0: *mut crate::src::qcommon::q_shared::b
     let mut buf: [crate::src::qcommon::q_shared::byte; 128] = [0; 128];
     let mut M: [crate::stdlib::uint32_t; 16] = [0; 16];
     let mut b: crate::stdlib::uint32_t = 0;
-    (*m).totalN = ((*m).totalN as u32).wrapping_add(n as u32) as crate::stdlib::uint32_t
-        as crate::stdlib::uint32_t;
+    (*m).totalN = ((*m).totalN as u32).wrapping_add(n as u32) as crate::stdlib::uint32_t;
     b = (*m).totalN.wrapping_mul(8 as i32 as u32);
     crate::stdlib::memset(
         buf.as_mut_ptr() as *mut libc::c_void,
@@ -581,7 +580,6 @@ unsafe extern "C" fn mdfour_update(
         in_0 = in_0.offset(64 as i32 as isize);
         n -= 64 as i32;
         (*m).totalN = ((*m).totalN as u32).wrapping_add(64 as i32 as u32) as crate::stdlib::uint32_t
-            as crate::stdlib::uint32_t
     }
     mdfour_tail(in_0, n);
 }

--- a/quake3-rs/ioquake3/src/qcommon/md5.rs
+++ b/quake3-rs/ioquake3/src/qcommon/md5.rs
@@ -75,462 +75,462 @@ unsafe extern "C" fn MD5Transform(
         (d ^ b & (c ^ d))
             .wrapping_add(*in_0.offset(0 as i32 as isize))
             .wrapping_add(0xd76aa478 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     a = a << 7 as i32 | a >> 32 as i32 - 7 as i32;
-    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t;
     d = (d as u32).wrapping_add(
         (c ^ a & (b ^ c))
             .wrapping_add(*in_0.offset(1 as i32 as isize))
             .wrapping_add(0xe8c7b756 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     d = d << 12 as i32 | d >> 32 as i32 - 12 as i32;
-    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t;
     c = (c as u32).wrapping_add(
         (b ^ d & (a ^ b))
             .wrapping_add(*in_0.offset(2 as i32 as isize))
             .wrapping_add(0x242070db as i32 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     c = c << 17 as i32 | c >> 32 as i32 - 17 as i32;
-    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t;
     b = (b as u32).wrapping_add(
         (a ^ c & (d ^ a))
             .wrapping_add(*in_0.offset(3 as i32 as isize))
             .wrapping_add(0xc1bdceee as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     b = b << 22 as i32 | b >> 32 as i32 - 22 as i32;
-    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t;
     a = (a as u32).wrapping_add(
         (d ^ b & (c ^ d))
             .wrapping_add(*in_0.offset(4 as i32 as isize))
             .wrapping_add(0xf57c0faf as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     a = a << 7 as i32 | a >> 32 as i32 - 7 as i32;
-    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t;
     d = (d as u32).wrapping_add(
         (c ^ a & (b ^ c))
             .wrapping_add(*in_0.offset(5 as i32 as isize))
             .wrapping_add(0x4787c62a as i32 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     d = d << 12 as i32 | d >> 32 as i32 - 12 as i32;
-    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t;
     c = (c as u32).wrapping_add(
         (b ^ d & (a ^ b))
             .wrapping_add(*in_0.offset(6 as i32 as isize))
             .wrapping_add(0xa8304613 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     c = c << 17 as i32 | c >> 32 as i32 - 17 as i32;
-    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t;
     b = (b as u32).wrapping_add(
         (a ^ c & (d ^ a))
             .wrapping_add(*in_0.offset(7 as i32 as isize))
             .wrapping_add(0xfd469501 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     b = b << 22 as i32 | b >> 32 as i32 - 22 as i32;
-    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t;
     a = (a as u32).wrapping_add(
         (d ^ b & (c ^ d))
             .wrapping_add(*in_0.offset(8 as i32 as isize))
             .wrapping_add(0x698098d8 as i32 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     a = a << 7 as i32 | a >> 32 as i32 - 7 as i32;
-    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t;
     d = (d as u32).wrapping_add(
         (c ^ a & (b ^ c))
             .wrapping_add(*in_0.offset(9 as i32 as isize))
             .wrapping_add(0x8b44f7af as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     d = d << 12 as i32 | d >> 32 as i32 - 12 as i32;
-    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t;
     c = (c as u32).wrapping_add(
         (b ^ d & (a ^ b))
             .wrapping_add(*in_0.offset(10 as i32 as isize))
             .wrapping_add(0xffff5bb1 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     c = c << 17 as i32 | c >> 32 as i32 - 17 as i32;
-    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t;
     b = (b as u32).wrapping_add(
         (a ^ c & (d ^ a))
             .wrapping_add(*in_0.offset(11 as i32 as isize))
             .wrapping_add(0x895cd7be as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     b = b << 22 as i32 | b >> 32 as i32 - 22 as i32;
-    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t;
     a = (a as u32).wrapping_add(
         (d ^ b & (c ^ d))
             .wrapping_add(*in_0.offset(12 as i32 as isize))
             .wrapping_add(0x6b901122 as i32 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     a = a << 7 as i32 | a >> 32 as i32 - 7 as i32;
-    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t;
     d = (d as u32).wrapping_add(
         (c ^ a & (b ^ c))
             .wrapping_add(*in_0.offset(13 as i32 as isize))
             .wrapping_add(0xfd987193 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     d = d << 12 as i32 | d >> 32 as i32 - 12 as i32;
-    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t;
     c = (c as u32).wrapping_add(
         (b ^ d & (a ^ b))
             .wrapping_add(*in_0.offset(14 as i32 as isize))
             .wrapping_add(0xa679438e as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     c = c << 17 as i32 | c >> 32 as i32 - 17 as i32;
-    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t;
     b = (b as u32).wrapping_add(
         (a ^ c & (d ^ a))
             .wrapping_add(*in_0.offset(15 as i32 as isize))
             .wrapping_add(0x49b40821 as i32 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     b = b << 22 as i32 | b >> 32 as i32 - 22 as i32;
-    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t;
     a = (a as u32).wrapping_add(
         (c ^ d & (b ^ c))
             .wrapping_add(*in_0.offset(1 as i32 as isize))
             .wrapping_add(0xf61e2562 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     a = a << 5 as i32 | a >> 32 as i32 - 5 as i32;
-    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t;
     d = (d as u32).wrapping_add(
         (b ^ c & (a ^ b))
             .wrapping_add(*in_0.offset(6 as i32 as isize))
             .wrapping_add(0xc040b340 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     d = d << 9 as i32 | d >> 32 as i32 - 9 as i32;
-    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t;
     c = (c as u32).wrapping_add(
         (a ^ b & (d ^ a))
             .wrapping_add(*in_0.offset(11 as i32 as isize))
             .wrapping_add(0x265e5a51 as i32 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     c = c << 14 as i32 | c >> 32 as i32 - 14 as i32;
-    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t;
     b = (b as u32).wrapping_add(
         (d ^ a & (c ^ d))
             .wrapping_add(*in_0.offset(0 as i32 as isize))
             .wrapping_add(0xe9b6c7aa as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     b = b << 20 as i32 | b >> 32 as i32 - 20 as i32;
-    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t;
     a = (a as u32).wrapping_add(
         (c ^ d & (b ^ c))
             .wrapping_add(*in_0.offset(5 as i32 as isize))
             .wrapping_add(0xd62f105d as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     a = a << 5 as i32 | a >> 32 as i32 - 5 as i32;
-    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t;
     d = (d as u32).wrapping_add(
         (b ^ c & (a ^ b))
             .wrapping_add(*in_0.offset(10 as i32 as isize))
             .wrapping_add(0x2441453 as i32 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     d = d << 9 as i32 | d >> 32 as i32 - 9 as i32;
-    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t;
     c = (c as u32).wrapping_add(
         (a ^ b & (d ^ a))
             .wrapping_add(*in_0.offset(15 as i32 as isize))
             .wrapping_add(0xd8a1e681 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     c = c << 14 as i32 | c >> 32 as i32 - 14 as i32;
-    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t;
     b = (b as u32).wrapping_add(
         (d ^ a & (c ^ d))
             .wrapping_add(*in_0.offset(4 as i32 as isize))
             .wrapping_add(0xe7d3fbc8 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     b = b << 20 as i32 | b >> 32 as i32 - 20 as i32;
-    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t;
     a = (a as u32).wrapping_add(
         (c ^ d & (b ^ c))
             .wrapping_add(*in_0.offset(9 as i32 as isize))
             .wrapping_add(0x21e1cde6 as i32 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     a = a << 5 as i32 | a >> 32 as i32 - 5 as i32;
-    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t;
     d = (d as u32).wrapping_add(
         (b ^ c & (a ^ b))
             .wrapping_add(*in_0.offset(14 as i32 as isize))
             .wrapping_add(0xc33707d6 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     d = d << 9 as i32 | d >> 32 as i32 - 9 as i32;
-    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t;
     c = (c as u32).wrapping_add(
         (a ^ b & (d ^ a))
             .wrapping_add(*in_0.offset(3 as i32 as isize))
             .wrapping_add(0xf4d50d87 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     c = c << 14 as i32 | c >> 32 as i32 - 14 as i32;
-    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t;
     b = (b as u32).wrapping_add(
         (d ^ a & (c ^ d))
             .wrapping_add(*in_0.offset(8 as i32 as isize))
             .wrapping_add(0x455a14ed as i32 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     b = b << 20 as i32 | b >> 32 as i32 - 20 as i32;
-    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t;
     a = (a as u32).wrapping_add(
         (c ^ d & (b ^ c))
             .wrapping_add(*in_0.offset(13 as i32 as isize))
             .wrapping_add(0xa9e3e905 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     a = a << 5 as i32 | a >> 32 as i32 - 5 as i32;
-    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t;
     d = (d as u32).wrapping_add(
         (b ^ c & (a ^ b))
             .wrapping_add(*in_0.offset(2 as i32 as isize))
             .wrapping_add(0xfcefa3f8 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     d = d << 9 as i32 | d >> 32 as i32 - 9 as i32;
-    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t;
     c = (c as u32).wrapping_add(
         (a ^ b & (d ^ a))
             .wrapping_add(*in_0.offset(7 as i32 as isize))
             .wrapping_add(0x676f02d9 as i32 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     c = c << 14 as i32 | c >> 32 as i32 - 14 as i32;
-    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t;
     b = (b as u32).wrapping_add(
         (d ^ a & (c ^ d))
             .wrapping_add(*in_0.offset(12 as i32 as isize))
             .wrapping_add(0x8d2a4c8a as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     b = b << 20 as i32 | b >> 32 as i32 - 20 as i32;
-    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t;
     a = (a as u32).wrapping_add(
         (b ^ c ^ d)
             .wrapping_add(*in_0.offset(5 as i32 as isize))
             .wrapping_add(0xfffa3942 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     a = a << 4 as i32 | a >> 32 as i32 - 4 as i32;
-    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t;
     d = (d as u32).wrapping_add(
         (a ^ b ^ c)
             .wrapping_add(*in_0.offset(8 as i32 as isize))
             .wrapping_add(0x8771f681 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     d = d << 11 as i32 | d >> 32 as i32 - 11 as i32;
-    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t;
     c = (c as u32).wrapping_add(
         (d ^ a ^ b)
             .wrapping_add(*in_0.offset(11 as i32 as isize))
             .wrapping_add(0x6d9d6122 as i32 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     c = c << 16 as i32 | c >> 32 as i32 - 16 as i32;
-    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t;
     b = (b as u32).wrapping_add(
         (c ^ d ^ a)
             .wrapping_add(*in_0.offset(14 as i32 as isize))
             .wrapping_add(0xfde5380c as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     b = b << 23 as i32 | b >> 32 as i32 - 23 as i32;
-    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t;
     a = (a as u32).wrapping_add(
         (b ^ c ^ d)
             .wrapping_add(*in_0.offset(1 as i32 as isize))
             .wrapping_add(0xa4beea44 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     a = a << 4 as i32 | a >> 32 as i32 - 4 as i32;
-    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t;
     d = (d as u32).wrapping_add(
         (a ^ b ^ c)
             .wrapping_add(*in_0.offset(4 as i32 as isize))
             .wrapping_add(0x4bdecfa9 as i32 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     d = d << 11 as i32 | d >> 32 as i32 - 11 as i32;
-    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t;
     c = (c as u32).wrapping_add(
         (d ^ a ^ b)
             .wrapping_add(*in_0.offset(7 as i32 as isize))
             .wrapping_add(0xf6bb4b60 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     c = c << 16 as i32 | c >> 32 as i32 - 16 as i32;
-    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t;
     b = (b as u32).wrapping_add(
         (c ^ d ^ a)
             .wrapping_add(*in_0.offset(10 as i32 as isize))
             .wrapping_add(0xbebfbc70 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     b = b << 23 as i32 | b >> 32 as i32 - 23 as i32;
-    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t;
     a = (a as u32).wrapping_add(
         (b ^ c ^ d)
             .wrapping_add(*in_0.offset(13 as i32 as isize))
             .wrapping_add(0x289b7ec6 as i32 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     a = a << 4 as i32 | a >> 32 as i32 - 4 as i32;
-    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t;
     d = (d as u32).wrapping_add(
         (a ^ b ^ c)
             .wrapping_add(*in_0.offset(0 as i32 as isize))
             .wrapping_add(0xeaa127fa as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     d = d << 11 as i32 | d >> 32 as i32 - 11 as i32;
-    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t;
     c = (c as u32).wrapping_add(
         (d ^ a ^ b)
             .wrapping_add(*in_0.offset(3 as i32 as isize))
             .wrapping_add(0xd4ef3085 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     c = c << 16 as i32 | c >> 32 as i32 - 16 as i32;
-    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t;
     b = (b as u32).wrapping_add(
         (c ^ d ^ a)
             .wrapping_add(*in_0.offset(6 as i32 as isize))
             .wrapping_add(0x4881d05 as i32 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     b = b << 23 as i32 | b >> 32 as i32 - 23 as i32;
-    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t;
     a = (a as u32).wrapping_add(
         (b ^ c ^ d)
             .wrapping_add(*in_0.offset(9 as i32 as isize))
             .wrapping_add(0xd9d4d039 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     a = a << 4 as i32 | a >> 32 as i32 - 4 as i32;
-    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t;
     d = (d as u32).wrapping_add(
         (a ^ b ^ c)
             .wrapping_add(*in_0.offset(12 as i32 as isize))
             .wrapping_add(0xe6db99e5 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     d = d << 11 as i32 | d >> 32 as i32 - 11 as i32;
-    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t;
     c = (c as u32).wrapping_add(
         (d ^ a ^ b)
             .wrapping_add(*in_0.offset(15 as i32 as isize))
             .wrapping_add(0x1fa27cf8 as i32 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     c = c << 16 as i32 | c >> 32 as i32 - 16 as i32;
-    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t;
     b = (b as u32).wrapping_add(
         (c ^ d ^ a)
             .wrapping_add(*in_0.offset(2 as i32 as isize))
             .wrapping_add(0xc4ac5665 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     b = b << 23 as i32 | b >> 32 as i32 - 23 as i32;
-    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t;
     a = (a as u32).wrapping_add(
         (c ^ (b | !d))
             .wrapping_add(*in_0.offset(0 as i32 as isize))
             .wrapping_add(0xf4292244 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     a = a << 6 as i32 | a >> 32 as i32 - 6 as i32;
-    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t;
     d = (d as u32).wrapping_add(
         (b ^ (a | !c))
             .wrapping_add(*in_0.offset(7 as i32 as isize))
             .wrapping_add(0x432aff97 as i32 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     d = d << 10 as i32 | d >> 32 as i32 - 10 as i32;
-    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t;
     c = (c as u32).wrapping_add(
         (a ^ (d | !b))
             .wrapping_add(*in_0.offset(14 as i32 as isize))
             .wrapping_add(0xab9423a7 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     c = c << 15 as i32 | c >> 32 as i32 - 15 as i32;
-    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t;
     b = (b as u32).wrapping_add(
         (d ^ (c | !a))
             .wrapping_add(*in_0.offset(5 as i32 as isize))
             .wrapping_add(0xfc93a039 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     b = b << 21 as i32 | b >> 32 as i32 - 21 as i32;
-    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t;
     a = (a as u32).wrapping_add(
         (c ^ (b | !d))
             .wrapping_add(*in_0.offset(12 as i32 as isize))
             .wrapping_add(0x655b59c3 as i32 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     a = a << 6 as i32 | a >> 32 as i32 - 6 as i32;
-    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t;
     d = (d as u32).wrapping_add(
         (b ^ (a | !c))
             .wrapping_add(*in_0.offset(3 as i32 as isize))
             .wrapping_add(0x8f0ccc92 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     d = d << 10 as i32 | d >> 32 as i32 - 10 as i32;
-    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t;
     c = (c as u32).wrapping_add(
         (a ^ (d | !b))
             .wrapping_add(*in_0.offset(10 as i32 as isize))
             .wrapping_add(0xffeff47d as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     c = c << 15 as i32 | c >> 32 as i32 - 15 as i32;
-    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t;
     b = (b as u32).wrapping_add(
         (d ^ (c | !a))
             .wrapping_add(*in_0.offset(1 as i32 as isize))
             .wrapping_add(0x85845dd1 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     b = b << 21 as i32 | b >> 32 as i32 - 21 as i32;
-    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t;
     a = (a as u32).wrapping_add(
         (c ^ (b | !d))
             .wrapping_add(*in_0.offset(8 as i32 as isize))
             .wrapping_add(0x6fa87e4f as i32 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     a = a << 6 as i32 | a >> 32 as i32 - 6 as i32;
-    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t;
     d = (d as u32).wrapping_add(
         (b ^ (a | !c))
             .wrapping_add(*in_0.offset(15 as i32 as isize))
             .wrapping_add(0xfe2ce6e0 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     d = d << 10 as i32 | d >> 32 as i32 - 10 as i32;
-    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t;
     c = (c as u32).wrapping_add(
         (a ^ (d | !b))
             .wrapping_add(*in_0.offset(6 as i32 as isize))
             .wrapping_add(0xa3014314 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     c = c << 15 as i32 | c >> 32 as i32 - 15 as i32;
-    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t;
     b = (b as u32).wrapping_add(
         (d ^ (c | !a))
             .wrapping_add(*in_0.offset(13 as i32 as isize))
             .wrapping_add(0x4e0811a1 as i32 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     b = b << 21 as i32 | b >> 32 as i32 - 21 as i32;
-    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t;
     a = (a as u32).wrapping_add(
         (c ^ (b | !d))
             .wrapping_add(*in_0.offset(4 as i32 as isize))
             .wrapping_add(0xf7537e82 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     a = a << 6 as i32 | a >> 32 as i32 - 6 as i32;
-    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    a = (a as u32).wrapping_add(b) as crate::stdlib::uint32_t;
     d = (d as u32).wrapping_add(
         (b ^ (a | !c))
             .wrapping_add(*in_0.offset(11 as i32 as isize))
             .wrapping_add(0xbd3af235 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     d = d << 10 as i32 | d >> 32 as i32 - 10 as i32;
-    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    d = (d as u32).wrapping_add(a) as crate::stdlib::uint32_t;
     c = (c as u32).wrapping_add(
         (a ^ (d | !b))
             .wrapping_add(*in_0.offset(2 as i32 as isize))
             .wrapping_add(0x2ad7d2bb as i32 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     c = c << 15 as i32 | c >> 32 as i32 - 15 as i32;
-    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    c = (c as u32).wrapping_add(d) as crate::stdlib::uint32_t;
     b = (b as u32).wrapping_add(
         (d ^ (c | !a))
             .wrapping_add(*in_0.offset(9 as i32 as isize))
             .wrapping_add(0xeb86d391 as u32),
-    ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    ) as crate::stdlib::uint32_t;
     b = b << 21 as i32 | b >> 32 as i32 - 21 as i32;
-    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+    b = (b as u32).wrapping_add(c) as crate::stdlib::uint32_t;
     let ref mut fresh0 = *buf.offset(0 as i32 as isize);
     *fresh0 =
-        (*fresh0 as u32).wrapping_add(a) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+        (*fresh0 as u32).wrapping_add(a) as crate::stdlib::uint32_t;
     let ref mut fresh1 = *buf.offset(1 as i32 as isize);
     *fresh1 =
-        (*fresh1 as u32).wrapping_add(b) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+        (*fresh1 as u32).wrapping_add(b) as crate::stdlib::uint32_t;
     let ref mut fresh2 = *buf.offset(2 as i32 as isize);
     *fresh2 =
-        (*fresh2 as u32).wrapping_add(c) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+        (*fresh2 as u32).wrapping_add(c) as crate::stdlib::uint32_t;
     let ref mut fresh3 = *buf.offset(3 as i32 as isize);
     *fresh3 =
-        (*fresh3 as u32).wrapping_add(d) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+        (*fresh3 as u32).wrapping_add(d) as crate::stdlib::uint32_t;
 }
 /*
  * Update context to reflect the concatenation of another buffer full
@@ -547,7 +547,7 @@ unsafe extern "C" fn MD5Update(mut ctx: *mut MD5Context, mut buf: *const u8, mut
     }
     (*ctx).bits[1 as i32 as usize] = ((*ctx).bits[1 as i32 as usize] as u32)
         .wrapping_add(len >> 29 as i32)
-        as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+        as crate::stdlib::uint32_t;
     t = t >> 3 as i32 & 0x3f as i32 as u32;
     /* Handle any leading odd-sized chunks */
     if t != 0 {

--- a/quake3-rs/ioquake3/src/qcommon/net_ip.rs
+++ b/quake3-rs/ioquake3/src/qcommon/net_ip.rs
@@ -2085,14 +2085,14 @@ unsafe extern "C" fn NET_GetCvars() -> crate::src::qcommon::q_shared::qboolean {
         b"0.0.0.0\x00" as *const u8 as *const libc::c_char,
         0x20 as i32,
     ) as *mut crate::src::qcommon::q_shared::cvar_s;
-    modified = (modified as u32).wrapping_add((*net_ip).modified as u32) as i32 as i32;
+    modified = (modified as u32).wrapping_add((*net_ip).modified as u32) as i32;
     (*net_ip).modified = crate::src::qcommon::q_shared::qfalse;
     net_ip6 = crate::src::qcommon::cvar::Cvar_Get(
         b"net_ip6\x00" as *const u8 as *const libc::c_char,
         b"::\x00" as *const u8 as *const libc::c_char,
         0x20 as i32,
     ) as *mut crate::src::qcommon::q_shared::cvar_s;
-    modified = (modified as u32).wrapping_add((*net_ip6).modified as u32) as i32 as i32;
+    modified = (modified as u32).wrapping_add((*net_ip6).modified as u32) as i32;
     (*net_ip6).modified = crate::src::qcommon::q_shared::qfalse;
     net_port = crate::src::qcommon::cvar::Cvar_Get(
         b"net_port\x00" as *const u8 as *const libc::c_char,
@@ -2102,7 +2102,7 @@ unsafe extern "C" fn NET_GetCvars() -> crate::src::qcommon::q_shared::qboolean {
         ),
         0x20 as i32,
     ) as *mut crate::src::qcommon::q_shared::cvar_s;
-    modified = (modified as u32).wrapping_add((*net_port).modified as u32) as i32 as i32;
+    modified = (modified as u32).wrapping_add((*net_port).modified as u32) as i32;
     (*net_port).modified = crate::src::qcommon::q_shared::qfalse;
     net_port6 = crate::src::qcommon::cvar::Cvar_Get(
         b"net_port6\x00" as *const u8 as *const libc::c_char,
@@ -2112,7 +2112,7 @@ unsafe extern "C" fn NET_GetCvars() -> crate::src::qcommon::q_shared::qboolean {
         ),
         0x20 as i32,
     ) as *mut crate::src::qcommon::q_shared::cvar_s;
-    modified = (modified as u32).wrapping_add((*net_port6).modified as u32) as i32 as i32;
+    modified = (modified as u32).wrapping_add((*net_port6).modified as u32) as i32;
     (*net_port6).modified = crate::src::qcommon::q_shared::qfalse;
     // Some cvars for configuring multicast options which facilitates scanning for servers on local subnets.
     net_mcast6addr = crate::src::qcommon::cvar::Cvar_Get(
@@ -2120,49 +2120,49 @@ unsafe extern "C" fn NET_GetCvars() -> crate::src::qcommon::q_shared::qboolean {
         b"ff04::696f:7175:616b:6533\x00" as *const u8 as *const libc::c_char,
         0x20 as i32 | 0x1 as i32,
     ) as *mut crate::src::qcommon::q_shared::cvar_s;
-    modified = (modified as u32).wrapping_add((*net_mcast6addr).modified as u32) as i32 as i32;
+    modified = (modified as u32).wrapping_add((*net_mcast6addr).modified as u32) as i32;
     (*net_mcast6addr).modified = crate::src::qcommon::q_shared::qfalse;
     net_mcast6iface = crate::src::qcommon::cvar::Cvar_Get(
         b"net_mcast6iface\x00" as *const u8 as *const libc::c_char,
         b"\x00" as *const u8 as *const libc::c_char,
         0x20 as i32 | 0x1 as i32,
     ) as *mut crate::src::qcommon::q_shared::cvar_s;
-    modified = (modified as u32).wrapping_add((*net_mcast6iface).modified as u32) as i32 as i32;
+    modified = (modified as u32).wrapping_add((*net_mcast6iface).modified as u32) as i32;
     (*net_mcast6iface).modified = crate::src::qcommon::q_shared::qfalse;
     net_socksEnabled = crate::src::qcommon::cvar::Cvar_Get(
         b"net_socksEnabled\x00" as *const u8 as *const libc::c_char,
         b"0\x00" as *const u8 as *const libc::c_char,
         0x20 as i32 | 0x1 as i32,
     ) as *mut crate::src::qcommon::q_shared::cvar_s;
-    modified = (modified as u32).wrapping_add((*net_socksEnabled).modified as u32) as i32 as i32;
+    modified = (modified as u32).wrapping_add((*net_socksEnabled).modified as u32) as i32;
     (*net_socksEnabled).modified = crate::src::qcommon::q_shared::qfalse;
     net_socksServer = crate::src::qcommon::cvar::Cvar_Get(
         b"net_socksServer\x00" as *const u8 as *const libc::c_char,
         b"\x00" as *const u8 as *const libc::c_char,
         0x20 as i32 | 0x1 as i32,
     ) as *mut crate::src::qcommon::q_shared::cvar_s;
-    modified = (modified as u32).wrapping_add((*net_socksServer).modified as u32) as i32 as i32;
+    modified = (modified as u32).wrapping_add((*net_socksServer).modified as u32) as i32;
     (*net_socksServer).modified = crate::src::qcommon::q_shared::qfalse;
     net_socksPort = crate::src::qcommon::cvar::Cvar_Get(
         b"net_socksPort\x00" as *const u8 as *const libc::c_char,
         b"1080\x00" as *const u8 as *const libc::c_char,
         0x20 as i32 | 0x1 as i32,
     ) as *mut crate::src::qcommon::q_shared::cvar_s;
-    modified = (modified as u32).wrapping_add((*net_socksPort).modified as u32) as i32 as i32;
+    modified = (modified as u32).wrapping_add((*net_socksPort).modified as u32) as i32;
     (*net_socksPort).modified = crate::src::qcommon::q_shared::qfalse;
     net_socksUsername = crate::src::qcommon::cvar::Cvar_Get(
         b"net_socksUsername\x00" as *const u8 as *const libc::c_char,
         b"\x00" as *const u8 as *const libc::c_char,
         0x20 as i32 | 0x1 as i32,
     ) as *mut crate::src::qcommon::q_shared::cvar_s;
-    modified = (modified as u32).wrapping_add((*net_socksUsername).modified as u32) as i32 as i32;
+    modified = (modified as u32).wrapping_add((*net_socksUsername).modified as u32) as i32;
     (*net_socksUsername).modified = crate::src::qcommon::q_shared::qfalse;
     net_socksPassword = crate::src::qcommon::cvar::Cvar_Get(
         b"net_socksPassword\x00" as *const u8 as *const libc::c_char,
         b"\x00" as *const u8 as *const libc::c_char,
         0x20 as i32 | 0x1 as i32,
     ) as *mut crate::src::qcommon::q_shared::cvar_s;
-    modified = (modified as u32).wrapping_add((*net_socksPassword).modified as u32) as i32 as i32;
+    modified = (modified as u32).wrapping_add((*net_socksPassword).modified as u32) as i32;
     (*net_socksPassword).modified = crate::src::qcommon::q_shared::qfalse;
     net_dropsim = crate::src::qcommon::cvar::Cvar_Get(
         b"net_dropsim\x00" as *const u8 as *const libc::c_char,

--- a/quake3-rs/ioquake3/src/qcommon/unzip.rs
+++ b/quake3-rs/ioquake3/src/qcommon/unzip.rs
@@ -200,7 +200,7 @@ unsafe extern "C" fn unzlocal_getShort(
         err = unzlocal_getByte(pzlib_filefunc_def, filestream, &mut i)
     }
     x = (x as libc::c_ulong).wrapping_add((i as crate::zconf_h::uLong) << 8 as i32)
-        as crate::zconf_h::uLong as crate::zconf_h::uLong;
+        as crate::zconf_h::uLong;
     if err == 0 as i32 {
         *pX = x
     } else {
@@ -223,17 +223,17 @@ unsafe extern "C" fn unzlocal_getLong(
         err = unzlocal_getByte(pzlib_filefunc_def, filestream, &mut i)
     }
     x = (x as libc::c_ulong).wrapping_add((i as crate::zconf_h::uLong) << 8 as i32)
-        as crate::zconf_h::uLong as crate::zconf_h::uLong;
+        as crate::zconf_h::uLong;
     if err == 0 as i32 {
         err = unzlocal_getByte(pzlib_filefunc_def, filestream, &mut i)
     }
     x = (x as libc::c_ulong).wrapping_add((i as crate::zconf_h::uLong) << 16 as i32)
-        as crate::zconf_h::uLong as crate::zconf_h::uLong;
+        as crate::zconf_h::uLong;
     if err == 0 as i32 {
         err = unzlocal_getByte(pzlib_filefunc_def, filestream, &mut i)
     }
     x = (x as libc::c_ulong).wrapping_add((i as crate::zconf_h::uLong) << 24 as i32)
-        as crate::zconf_h::uLong as crate::zconf_h::uLong;
+        as crate::zconf_h::uLong;
     if err == 0 as i32 {
         *pX = x
     } else {
@@ -353,7 +353,7 @@ unsafe extern "C" fn unzlocal_SearchCentralDir(
             uBackRead = uMaxBack
         } else {
             uBackRead = (uBackRead as libc::c_ulong).wrapping_add(0x400 as i32 as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong
+                as crate::zconf_h::uLong
         }
         uReadPos = uSizeFile.wrapping_sub(uBackRead);
         uReadSize =
@@ -855,8 +855,7 @@ unsafe extern "C" fn unzlocal_GetCurrentFileInfoInternal(
     {
         err = -(1 as i32)
     }
-    lSeek = (lSeek as libc::c_ulong).wrapping_add(file_info.size_filename) as libc::c_long
-        as libc::c_long;
+    lSeek = (lSeek as libc::c_ulong).wrapping_add(file_info.size_filename) as libc::c_long;
     if err == 0 as i32 && !szFileName.is_null() {
         let mut uSizeRead: crate::zconf_h::uLong = 0;
         if file_info.size_filename < fileNameBufferSize {
@@ -883,7 +882,7 @@ unsafe extern "C" fn unzlocal_GetCurrentFileInfoInternal(
                 err = -(1 as i32)
             }
         }
-        lSeek = (lSeek as libc::c_ulong).wrapping_sub(uSizeRead) as libc::c_long as libc::c_long
+        lSeek = (lSeek as libc::c_ulong).wrapping_sub(uSizeRead) as libc::c_long
     }
     if err == 0 as i32 && !extraField.is_null() {
         let mut uSizeRead_0: crate::zconf_h::uLong = 0;
@@ -930,10 +929,9 @@ unsafe extern "C" fn unzlocal_GetCurrentFileInfoInternal(
         }
         lSeek = (lSeek as libc::c_ulong)
             .wrapping_add(file_info.size_file_extra.wrapping_sub(uSizeRead_0))
-            as libc::c_long as libc::c_long
+            as libc::c_long
     } else {
         lSeek = (lSeek as libc::c_ulong).wrapping_add(file_info.size_file_extra) as libc::c_long
-            as libc::c_long
     }
     if err == 0 as i32 && !szComment.is_null() {
         let mut uSizeRead_1: crate::zconf_h::uLong = 0;
@@ -1073,7 +1071,7 @@ pub unsafe extern "C" fn unzGoToNextFile(mut file: crate::src::qcommon::unzip::u
             .wrapping_add((*s).cur_file_info.size_filename)
             .wrapping_add((*s).cur_file_info.size_file_extra)
             .wrapping_add((*s).cur_file_info.size_file_comment),
-    ) as crate::zconf_h::uLong as crate::zconf_h::uLong;
+    ) as crate::zconf_h::uLong;
     (*s).num_file = (*s).num_file.wrapping_add(1);
     err = unzlocal_GetCurrentFileInfoInternal(
         file,
@@ -1361,7 +1359,7 @@ unsafe extern "C" fn unzlocal_CheckCurrentFileCoherencyHeader(
         err = -(103 as i32)
     }
     *piSizeVar = (*piSizeVar as u32).wrapping_add(size_filename as crate::zconf_h::uInt)
-        as crate::zconf_h::uInt as crate::zconf_h::uInt;
+        as crate::zconf_h::uInt;
     if unzlocal_getShort(&mut (*s).z_filefunc, (*s).filestream, &mut size_extra_field) != 0 as i32 {
         err = -(1 as i32)
     }
@@ -1372,7 +1370,7 @@ unsafe extern "C" fn unzlocal_CheckCurrentFileCoherencyHeader(
         .wrapping_add(size_filename);
     *psize_local_extrafield = size_extra_field as crate::zconf_h::uInt;
     *piSizeVar = (*piSizeVar as u32).wrapping_add(size_extra_field as crate::zconf_h::uInt)
-        as crate::zconf_h::uInt as crate::zconf_h::uInt;
+        as crate::zconf_h::uInt;
     return err;
 }
 /*
@@ -1628,11 +1626,11 @@ pub unsafe extern "C" fn unzReadCurrentFile(
             (*pfile_in_zip_read_info).pos_in_zipfile =
                 ((*pfile_in_zip_read_info).pos_in_zipfile as libc::c_ulong)
                     .wrapping_add(uReadThis as libc::c_ulong)
-                    as crate::zconf_h::uLong as crate::zconf_h::uLong;
+                    as crate::zconf_h::uLong;
             (*pfile_in_zip_read_info).rest_read_compressed =
                 ((*pfile_in_zip_read_info).rest_read_compressed as libc::c_ulong)
                     .wrapping_sub(uReadThis as libc::c_ulong)
-                    as crate::zconf_h::uLong as crate::zconf_h::uLong;
+                    as crate::zconf_h::uLong;
             (*pfile_in_zip_read_info).stream.next_in =
                 (*pfile_in_zip_read_info).read_buffer as *mut crate::zconf_h::Bytef;
             (*pfile_in_zip_read_info).stream.avail_in = uReadThis
@@ -1671,14 +1669,13 @@ pub unsafe extern "C" fn unzReadCurrentFile(
             );
             (*pfile_in_zip_read_info).rest_read_uncompressed =
                 ((*pfile_in_zip_read_info).rest_read_uncompressed as libc::c_ulong)
-                    .wrapping_sub(uDoCopy as libc::c_ulong) as crate::zconf_h::uLong
-                    as crate::zconf_h::uLong;
+                    .wrapping_sub(uDoCopy as libc::c_ulong) as crate::zconf_h::uLong;
             (*pfile_in_zip_read_info).stream.avail_in =
                 ((*pfile_in_zip_read_info).stream.avail_in as u32).wrapping_sub(uDoCopy)
-                    as crate::zconf_h::uInt as crate::zconf_h::uInt;
+                    as crate::zconf_h::uInt;
             (*pfile_in_zip_read_info).stream.avail_out =
                 ((*pfile_in_zip_read_info).stream.avail_out as u32).wrapping_sub(uDoCopy)
-                    as crate::zconf_h::uInt as crate::zconf_h::uInt;
+                    as crate::zconf_h::uInt;
             (*pfile_in_zip_read_info).stream.next_out = (*pfile_in_zip_read_info)
                 .stream
                 .next_out
@@ -1689,10 +1686,9 @@ pub unsafe extern "C" fn unzReadCurrentFile(
                 .offset(uDoCopy as isize);
             (*pfile_in_zip_read_info).stream.total_out =
                 ((*pfile_in_zip_read_info).stream.total_out as libc::c_ulong)
-                    .wrapping_add(uDoCopy as libc::c_ulong) as crate::zconf_h::uLong
-                    as crate::zconf_h::uLong;
+                    .wrapping_add(uDoCopy as libc::c_ulong) as crate::zconf_h::uLong;
             iRead =
-                (iRead as u32).wrapping_add(uDoCopy) as crate::zconf_h::uInt as crate::zconf_h::uInt
+                (iRead as u32).wrapping_add(uDoCopy) as crate::zconf_h::uInt
         } else {
             let mut uTotalOutBefore: crate::zconf_h::uLong = 0;
             let mut uTotalOutAfter: crate::zconf_h::uLong = 0;
@@ -1723,11 +1719,10 @@ pub unsafe extern "C" fn unzReadCurrentFile(
             );
             (*pfile_in_zip_read_info).rest_read_uncompressed =
                 ((*pfile_in_zip_read_info).rest_read_uncompressed as libc::c_ulong)
-                    .wrapping_sub(uOutThis) as crate::zconf_h::uLong
-                    as crate::zconf_h::uLong;
+                    .wrapping_sub(uOutThis) as crate::zconf_h::uLong;
             iRead = (iRead as u32)
                 .wrapping_add(uTotalOutAfter.wrapping_sub(uTotalOutBefore) as crate::zconf_h::uInt)
-                as crate::zconf_h::uInt as crate::zconf_h::uInt;
+                as crate::zconf_h::uInt;
             if err == 1 as i32 {
                 return if iRead == 0 as i32 as u32 {
                     0 as i32 as u32

--- a/quake3-rs/ioquake3/src/sdl/sdl_snd.rs
+++ b/quake3-rs/ioquake3/src/sdl/sdl_snd.rs
@@ -168,7 +168,7 @@ unsafe extern "C" fn SNDDMA_AudioCallback(
         {
             let mut ptr: *mut f32 = stream as *mut f32;
             len = (len as libc::c_ulong).wrapping_div(::std::mem::size_of::<f32>() as libc::c_ulong)
-                as i32 as i32;
+                as i32;
             i = 0 as i32;
             while i < len {
                 *ptr *= sdlMasterGain;
@@ -179,7 +179,7 @@ unsafe extern "C" fn SNDDMA_AudioCallback(
             let mut ptr_0: *mut crate::stdlib::Sint16 = stream as *mut crate::stdlib::Sint16;
             len = (len as libc::c_ulong)
                 .wrapping_div(::std::mem::size_of::<crate::stdlib::Sint16>() as libc::c_ulong)
-                as i32 as i32;
+                as i32;
             i = 0 as i32;
             while i < len {
                 *ptr_0 = (*ptr_0 as f32 * sdlMasterGain) as crate::stdlib::Sint16;
@@ -190,7 +190,7 @@ unsafe extern "C" fn SNDDMA_AudioCallback(
             let mut ptr_1: *mut crate::stdlib::Uint8 = stream;
             len = (len as libc::c_ulong)
                 .wrapping_div(::std::mem::size_of::<crate::stdlib::Uint8>() as libc::c_ulong)
-                as i32 as i32;
+                as i32;
             i = 0 as i32;
             while i < len {
                 *ptr_1 = (*ptr_1 as f32 * sdlMasterGain) as crate::stdlib::Uint8;

--- a/quake3-rs/ioquake3/src/server/sv_client.rs
+++ b/quake3-rs/ioquake3/src/server/sv_client.rs
@@ -1258,7 +1258,7 @@ pub unsafe extern "C" fn SV_FreeClient(mut client: *mut crate::server_h::client_
                     ::std::mem::size_of::<*mut crate::server_h::voipServerPacket_t>()
                         as libc::c_ulong,
                 ),
-        ) as i32 as i32;
+        ) as i32;
         crate::src::qcommon::common::Z_Free(
             (*client).voipPacket[index as usize] as *mut libc::c_void,
         );

--- a/quake3-rs/ioquake3/src/server/sv_snapshot.rs
+++ b/quake3-rs/ioquake3/src/server/sv_snapshot.rs
@@ -1039,7 +1039,7 @@ unsafe extern "C" fn SV_WriteVoipToClient(
                     ::std::mem::size_of::<*mut crate::server_h::voipServerPacket_t>()
                         as libc::c_ulong,
                 ),
-        ) as i32 as i32
+        ) as i32
     };
 }
 /*

--- a/quake3-rs/ioquake3/src/zlib/adler32.rs
+++ b/quake3-rs/ioquake3/src/zlib/adler32.rs
@@ -25,10 +25,10 @@ pub unsafe extern "C" fn adler32(
     if len == 1 as i32 as u32 {
         adler = (adler as libc::c_ulong)
             .wrapping_add(*buf.offset(0 as i32 as isize) as libc::c_ulong)
-            as crate::zconf_h::uLong as crate::zconf_h::uLong;
+            as crate::zconf_h::uLong;
         if adler >= 65521 as libc::c_ulong {
             adler = (adler as libc::c_ulong).wrapping_sub(65521 as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong
+                as crate::zconf_h::uLong
         }
         sum2 = sum2.wrapping_add(adler);
         if sum2 >= 65521 as libc::c_ulong {
@@ -51,85 +51,84 @@ pub unsafe extern "C" fn adler32(
             let fresh1 = buf;
             buf = buf.offset(1);
             adler = (adler as libc::c_ulong).wrapping_add(*fresh1 as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong;
+                as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler)
         }
         if adler >= 65521 as libc::c_ulong {
             adler = (adler as libc::c_ulong).wrapping_sub(65521 as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong
+                as crate::zconf_h::uLong
         }
         sum2 = sum2.wrapping_rem(65521 as libc::c_ulong);
         return adler | sum2 << 16 as i32;
     }
     /* do length NMAX blocks -- requires just one modulo operation */
     while len >= 5552 as i32 as u32 {
-        len = (len as u32).wrapping_sub(5552 as i32 as u32) as crate::zconf_h::uInt
-            as crate::zconf_h::uInt; /* NMAX is divisible by 16 */
+        len = (len as u32).wrapping_sub(5552 as i32 as u32) as crate::zconf_h::uInt; /* NMAX is divisible by 16 */
         n = (5552 as i32 / 16 as i32) as u32;
         loop {
             adler = (adler as libc::c_ulong)
                 .wrapping_add(*buf.offset(0 as i32 as isize) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong;
+                as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong)
                 .wrapping_add(*buf.offset((0 as i32 + 1 as i32) as isize) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong;
+                as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong)
                 .wrapping_add(*buf.offset((0 as i32 + 2 as i32) as isize) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong;
+                as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong).wrapping_add(
                 *buf.offset((0 as i32 + 2 as i32 + 1 as i32) as isize) as libc::c_ulong,
-            ) as crate::zconf_h::uLong as crate::zconf_h::uLong;
+            ) as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong)
                 .wrapping_add(*buf.offset((0 as i32 + 4 as i32) as isize) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong;
+                as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong).wrapping_add(
                 *buf.offset((0 as i32 + 4 as i32 + 1 as i32) as isize) as libc::c_ulong,
-            ) as crate::zconf_h::uLong as crate::zconf_h::uLong;
+            ) as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong).wrapping_add(
                 *buf.offset((0 as i32 + 4 as i32 + 2 as i32) as isize) as libc::c_ulong,
-            ) as crate::zconf_h::uLong as crate::zconf_h::uLong;
+            ) as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong).wrapping_add(
                 *buf.offset((0 as i32 + 4 as i32 + 2 as i32 + 1 as i32) as isize) as libc::c_ulong,
-            ) as crate::zconf_h::uLong as crate::zconf_h::uLong;
+            ) as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong)
                 .wrapping_add(*buf.offset(8 as i32 as isize) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong;
+                as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong)
                 .wrapping_add(*buf.offset((8 as i32 + 1 as i32) as isize) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong;
+                as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong)
                 .wrapping_add(*buf.offset((8 as i32 + 2 as i32) as isize) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong;
+                as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong).wrapping_add(
                 *buf.offset((8 as i32 + 2 as i32 + 1 as i32) as isize) as libc::c_ulong,
-            ) as crate::zconf_h::uLong as crate::zconf_h::uLong;
+            ) as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong)
                 .wrapping_add(*buf.offset((8 as i32 + 4 as i32) as isize) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong;
+                as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong).wrapping_add(
                 *buf.offset((8 as i32 + 4 as i32 + 1 as i32) as isize) as libc::c_ulong,
-            ) as crate::zconf_h::uLong as crate::zconf_h::uLong;
+            ) as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong).wrapping_add(
                 *buf.offset((8 as i32 + 4 as i32 + 2 as i32) as isize) as libc::c_ulong,
-            ) as crate::zconf_h::uLong as crate::zconf_h::uLong;
+            ) as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong).wrapping_add(
                 *buf.offset((8 as i32 + 4 as i32 + 2 as i32 + 1 as i32) as isize) as libc::c_ulong,
-            ) as crate::zconf_h::uLong as crate::zconf_h::uLong;
+            ) as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             /* 16 sums unrolled */
             buf = buf.offset(16 as i32 as isize);
@@ -139,78 +138,77 @@ pub unsafe extern "C" fn adler32(
             }
         }
         adler = (adler as libc::c_ulong).wrapping_rem(65521 as libc::c_ulong)
-            as crate::zconf_h::uLong as crate::zconf_h::uLong;
+            as crate::zconf_h::uLong;
         sum2 = sum2.wrapping_rem(65521 as libc::c_ulong)
     }
     /* do remaining bytes (less than NMAX, still just one modulo) */
     if len != 0 {
         /* avoid modulos if none remaining */
         while len >= 16 as i32 as u32 {
-            len = (len as u32).wrapping_sub(16 as i32 as u32) as crate::zconf_h::uInt
-                as crate::zconf_h::uInt;
+            len = (len as u32).wrapping_sub(16 as i32 as u32) as crate::zconf_h::uInt;
             adler = (adler as libc::c_ulong)
                 .wrapping_add(*buf.offset(0 as i32 as isize) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong;
+                as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong)
                 .wrapping_add(*buf.offset((0 as i32 + 1 as i32) as isize) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong;
+                as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong)
                 .wrapping_add(*buf.offset((0 as i32 + 2 as i32) as isize) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong;
+                as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong).wrapping_add(
                 *buf.offset((0 as i32 + 2 as i32 + 1 as i32) as isize) as libc::c_ulong,
-            ) as crate::zconf_h::uLong as crate::zconf_h::uLong;
+            ) as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong)
                 .wrapping_add(*buf.offset((0 as i32 + 4 as i32) as isize) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong;
+                as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong).wrapping_add(
                 *buf.offset((0 as i32 + 4 as i32 + 1 as i32) as isize) as libc::c_ulong,
-            ) as crate::zconf_h::uLong as crate::zconf_h::uLong;
+            ) as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong).wrapping_add(
                 *buf.offset((0 as i32 + 4 as i32 + 2 as i32) as isize) as libc::c_ulong,
-            ) as crate::zconf_h::uLong as crate::zconf_h::uLong;
+            ) as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong).wrapping_add(
                 *buf.offset((0 as i32 + 4 as i32 + 2 as i32 + 1 as i32) as isize) as libc::c_ulong,
-            ) as crate::zconf_h::uLong as crate::zconf_h::uLong;
+            ) as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong)
                 .wrapping_add(*buf.offset(8 as i32 as isize) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong;
+                as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong)
                 .wrapping_add(*buf.offset((8 as i32 + 1 as i32) as isize) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong;
+                as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong)
                 .wrapping_add(*buf.offset((8 as i32 + 2 as i32) as isize) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong;
+                as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong).wrapping_add(
                 *buf.offset((8 as i32 + 2 as i32 + 1 as i32) as isize) as libc::c_ulong,
-            ) as crate::zconf_h::uLong as crate::zconf_h::uLong;
+            ) as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong)
                 .wrapping_add(*buf.offset((8 as i32 + 4 as i32) as isize) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong;
+                as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong).wrapping_add(
                 *buf.offset((8 as i32 + 4 as i32 + 1 as i32) as isize) as libc::c_ulong,
-            ) as crate::zconf_h::uLong as crate::zconf_h::uLong;
+            ) as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong).wrapping_add(
                 *buf.offset((8 as i32 + 4 as i32 + 2 as i32) as isize) as libc::c_ulong,
-            ) as crate::zconf_h::uLong as crate::zconf_h::uLong;
+            ) as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             adler = (adler as libc::c_ulong).wrapping_add(
                 *buf.offset((8 as i32 + 4 as i32 + 2 as i32 + 1 as i32) as isize) as libc::c_ulong,
-            ) as crate::zconf_h::uLong as crate::zconf_h::uLong;
+            ) as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler);
             buf = buf.offset(16 as i32 as isize)
         }
@@ -223,11 +221,11 @@ pub unsafe extern "C" fn adler32(
             let fresh3 = buf;
             buf = buf.offset(1);
             adler = (adler as libc::c_ulong).wrapping_add(*fresh3 as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong;
+                as crate::zconf_h::uLong;
             sum2 = sum2.wrapping_add(adler)
         }
         adler = (adler as libc::c_ulong).wrapping_rem(65521 as libc::c_ulong)
-            as crate::zconf_h::uLong as crate::zconf_h::uLong;
+            as crate::zconf_h::uLong;
         sum2 = sum2.wrapping_rem(65521 as libc::c_ulong)
     }
     /* return recombined sums */

--- a/quake3-rs/ioquake3/src/zlib/inflate.rs
+++ b/quake3-rs/ioquake3/src/zlib/inflate.rs
@@ -5175,7 +5175,6 @@ pub unsafe extern "C" fn inflate(mut strm: crate::zlib_h::z_streamp, mut flush: 
                     out = out.wrapping_sub(left);
                     (*strm).total_out = ((*strm).total_out as libc::c_ulong)
                         .wrapping_add(out as libc::c_ulong)
-                        as crate::zconf_h::uLong
                         as crate::zconf_h::uLong;
                     (*state).total = (*state).total.wrapping_add(out as libc::c_ulong);
                     if out != 0 {
@@ -5829,9 +5828,9 @@ pub unsafe extern "C" fn inflate(mut strm: crate::zlib_h::z_streamp, mut flush: 
     in_0 = in_0.wrapping_sub((*strm).avail_in);
     out = out.wrapping_sub((*strm).avail_out);
     (*strm).total_in = ((*strm).total_in as libc::c_ulong).wrapping_add(in_0 as libc::c_ulong)
-        as crate::zconf_h::uLong as crate::zconf_h::uLong;
+        as crate::zconf_h::uLong;
     (*strm).total_out = ((*strm).total_out as libc::c_ulong).wrapping_add(out as libc::c_ulong)
-        as crate::zconf_h::uLong as crate::zconf_h::uLong;
+        as crate::zconf_h::uLong;
     (*state).total = (*state).total.wrapping_add(out as libc::c_ulong);
     if (*state).wrap != 0 && out != 0 {
         (*state).check = crate::src::zlib::adler32::adler32(
@@ -6037,10 +6036,10 @@ pub unsafe extern "C" fn inflateSync(mut strm: crate::zlib_h::z_streamp) -> i32 
     /* search available input */
     len = syncsearch(&mut (*state).have, (*strm).next_in, (*strm).avail_in);
     (*strm).avail_in =
-        ((*strm).avail_in as u32).wrapping_sub(len) as crate::zconf_h::uInt as crate::zconf_h::uInt;
+        ((*strm).avail_in as u32).wrapping_sub(len) as crate::zconf_h::uInt;
     (*strm).next_in = (*strm).next_in.offset(len as isize);
     (*strm).total_in = ((*strm).total_in as libc::c_ulong).wrapping_add(len as libc::c_ulong)
-        as crate::zconf_h::uLong as crate::zconf_h::uLong;
+        as crate::zconf_h::uLong;
     /* return no joy or set up to restart inflate() on a new block */
     if (*state).have != 4 as i32 as u32 {
         return -(3 as i32);

--- a/quake3-rs/ioquake3/src/zlib/zutil.rs
+++ b/quake3-rs/ioquake3/src/zlib/zutil.rs
@@ -47,65 +47,65 @@ pub unsafe extern "C" fn zlibCompileFlags() -> crate::zconf_h::uLong {
         2 => {}
         4 => {
             flags = (flags as libc::c_ulong).wrapping_add(1 as i32 as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong
+                as crate::zconf_h::uLong
         }
         8 => {
             flags = (flags as libc::c_ulong).wrapping_add(2 as i32 as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong
+                as crate::zconf_h::uLong
         }
         _ => {
             flags = (flags as libc::c_ulong).wrapping_add(3 as i32 as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong
+                as crate::zconf_h::uLong
         }
     }
     match ::std::mem::size_of::<crate::zconf_h::uLong>() as libc::c_ulong {
         2 => {}
         4 => {
             flags = (flags as libc::c_ulong).wrapping_add(((1 as i32) << 2 as i32) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong
+                as crate::zconf_h::uLong
         }
         8 => {
             flags = (flags as libc::c_ulong).wrapping_add(((2 as i32) << 2 as i32) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong
+                as crate::zconf_h::uLong
         }
         _ => {
             flags = (flags as libc::c_ulong).wrapping_add(((3 as i32) << 2 as i32) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong
+                as crate::zconf_h::uLong
         }
     }
     match ::std::mem::size_of::<crate::zconf_h::voidpf>() as libc::c_ulong {
         2 => {}
         4 => {
             flags = (flags as libc::c_ulong).wrapping_add(((1 as i32) << 4 as i32) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong
+                as crate::zconf_h::uLong
         }
         8 => {
             flags = (flags as libc::c_ulong).wrapping_add(((2 as i32) << 4 as i32) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong
+                as crate::zconf_h::uLong
         }
         _ => {
             flags = (flags as libc::c_ulong).wrapping_add(((3 as i32) << 4 as i32) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong
+                as crate::zconf_h::uLong
         }
     }
     match ::std::mem::size_of::<crate::stdlib::off_t>() as libc::c_ulong {
         2 => {}
         4 => {
             flags = (flags as libc::c_ulong).wrapping_add(((1 as i32) << 6 as i32) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong
+                as crate::zconf_h::uLong
         }
         8 => {
             flags = (flags as libc::c_ulong).wrapping_add(((2 as i32) << 6 as i32) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong
+                as crate::zconf_h::uLong
         }
         _ => {
             flags = (flags as libc::c_ulong).wrapping_add(((3 as i32) << 6 as i32) as libc::c_ulong)
-                as crate::zconf_h::uLong as crate::zconf_h::uLong
+                as crate::zconf_h::uLong
         }
     }
     flags = (flags as libc::c_ulong)
         .wrapping_add(((1 as libc::c_long) << 17 as i32) as libc::c_ulong)
-        as crate::zconf_h::uLong as crate::zconf_h::uLong;
+        as crate::zconf_h::uLong;
     return flags;
 }
 /*

--- a/quake3-rs/qagamex86_64/src/game/g_arenas.rs
+++ b/quake3-rs/qagamex86_64/src/game/g_arenas.rs
@@ -404,7 +404,7 @@ pub unsafe extern "C" fn UpdateTournamentInfo() {
                 .persistant[crate::bg_public_h::PERS_SCORE as i32 as usize],
         );
         msglen = (msglen as libc::c_ulong).wrapping_add(crate::stdlib::strlen(buf.as_mut_ptr()))
-            as i32 as i32;
+            as i32;
         if msglen as libc::c_ulong >= ::std::mem::size_of::<[libc::c_char; 1024]>() as libc::c_ulong
         {
             break;

--- a/quake3-rs/qagamex86_64/src/game/g_main.rs
+++ b/quake3-rs/qagamex86_64/src/game/g_main.rs
@@ -2381,7 +2381,7 @@ pub unsafe extern "C" fn AddTournamentPlayer() {
     crate::src::game::g_cmds::SetTeam(
         &mut *g_entities
             .as_mut_ptr()
-            .offset(nextInLine.offset_from(level.clients) as isize as isize)
+            .offset(nextInLine.offset_from(level.clients) as isize)
             as *mut _ as *mut crate::g_local_h::gentity_s,
         b"f\x00" as *const u8 as *const libc::c_char,
     );

--- a/quake3-rs/qagamex86_64/src/game/g_svcmds.rs
+++ b/quake3-rs/qagamex86_64/src/game/g_svcmds.rs
@@ -1013,7 +1013,7 @@ pub unsafe extern "C" fn Svcmd_ForceTeam_f() {
     );
     crate::src::game::g_cmds::SetTeam(
         &mut *crate::src::game::g_main::g_entities.as_mut_ptr().offset(
-            cl.offset_from(crate::src::game::g_main::level.clients) as isize as isize,
+            cl.offset_from(crate::src::game::g_main::level.clients) as isize,
         ) as *mut _ as *mut crate::g_local_h::gentity_s,
         str.as_mut_ptr(),
     );

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jcdctmgr.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jcdctmgr.rs
@@ -337,7 +337,7 @@ unsafe extern "C" fn forward_DCT(
         }
         bi = bi.wrapping_add(1);
         start_col = (start_col as u32).wrapping_add((*compptr).DCT_h_scaled_size as u32)
-            as crate::jmorecfg_h::JDIMENSION as crate::jmorecfg_h::JDIMENSION
+            as crate::jmorecfg_h::JDIMENSION
     }
 }
 
@@ -389,7 +389,7 @@ unsafe extern "C" fn forward_DCT_float(
         }
         bi = bi.wrapping_add(1);
         start_col = (start_col as u32).wrapping_add((*compptr).DCT_h_scaled_size as u32)
-            as crate::jmorecfg_h::JDIMENSION as crate::jmorecfg_h::JDIMENSION
+            as crate::jmorecfg_h::JDIMENSION
     }
 }
 /* DCT_FLOAT_SUPPORTED */

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jcprepct.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jcprepct.rs
@@ -301,10 +301,9 @@ unsafe extern "C" fn pre_process_data(
             numrows,
         );
         *in_row_ctr = (*in_row_ctr as u32).wrapping_add(numrows as u32)
-            as crate::jmorecfg_h::JDIMENSION as crate::jmorecfg_h::JDIMENSION;
+            as crate::jmorecfg_h::JDIMENSION;
         (*prep).next_buf_row += numrows;
         (*prep).rows_to_go = ((*prep).rows_to_go as u32).wrapping_sub(numrows as u32)
-            as crate::jmorecfg_h::JDIMENSION
             as crate::jmorecfg_h::JDIMENSION;
         /* If at bottom of image, pad to fill the conversion buffer. */
         if (*prep).rows_to_go == 0 as i32 as u32
@@ -427,11 +426,9 @@ unsafe extern "C" fn pre_process_context(
                 }
             }
             *in_row_ctr = (*in_row_ctr as u32).wrapping_add(numrows as u32)
-                as crate::jmorecfg_h::JDIMENSION
                 as crate::jmorecfg_h::JDIMENSION;
             (*prep).next_buf_row += numrows;
             (*prep).rows_to_go = ((*prep).rows_to_go as u32).wrapping_sub(numrows as u32)
-                as crate::jmorecfg_h::JDIMENSION
                 as crate::jmorecfg_h::JDIMENSION
         } else {
             /* Return for more data, unless we are at the bottom of the image. */

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdatasrc.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdatasrc.rs
@@ -360,7 +360,7 @@ unsafe extern "C" fn skip_input_data(
             .offset(num_bytes as crate::stddef_h::size_t as isize);
         (*src).bytes_in_buffer = ((*src).bytes_in_buffer as libc::c_ulong)
             .wrapping_sub(num_bytes as crate::stddef_h::size_t)
-            as crate::stddef_h::size_t as crate::stddef_h::size_t
+            as crate::stddef_h::size_t
     };
 }
 /*

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdpostct.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdpostct.rs
@@ -379,8 +379,7 @@ unsafe extern "C" fn post_process_1pass(
         output_buf.offset(*out_row_ctr as isize),
         num_rows as i32,
     );
-    *out_row_ctr = (*out_row_ctr as u32).wrapping_add(num_rows) as crate::jmorecfg_h::JDIMENSION
-        as crate::jmorecfg_h::JDIMENSION;
+    *out_row_ctr = (*out_row_ctr as u32).wrapping_add(num_rows) as crate::jmorecfg_h::JDIMENSION;
 }
 /*
  * Process some data in the first pass of 2-pass quantization.
@@ -445,12 +444,10 @@ unsafe extern "C" fn post_process_prepass(
             num_rows as i32,
         );
         *out_row_ctr = (*out_row_ctr as u32).wrapping_add(num_rows) as crate::jmorecfg_h::JDIMENSION
-            as crate::jmorecfg_h::JDIMENSION
     }
     /* Advance if we filled the strip. */
     if (*post).next_row >= (*post).strip_height {
         (*post).starting_row = ((*post).starting_row as u32).wrapping_add((*post).strip_height)
-            as crate::jmorecfg_h::JDIMENSION
             as crate::jmorecfg_h::JDIMENSION;
         (*post).next_row = 0 as i32 as crate::jmorecfg_h::JDIMENSION
     };
@@ -509,14 +506,12 @@ unsafe extern "C" fn post_process_2pass(
         output_buf.offset(*out_row_ctr as isize),
         num_rows as i32,
     );
-    *out_row_ctr = (*out_row_ctr as u32).wrapping_add(num_rows) as crate::jmorecfg_h::JDIMENSION
-        as crate::jmorecfg_h::JDIMENSION;
+    *out_row_ctr = (*out_row_ctr as u32).wrapping_add(num_rows) as crate::jmorecfg_h::JDIMENSION;
     /* Advance if we filled the strip. */
     (*post).next_row = ((*post).next_row as u32).wrapping_add(num_rows)
-        as crate::jmorecfg_h::JDIMENSION as crate::jmorecfg_h::JDIMENSION;
+        as crate::jmorecfg_h::JDIMENSION;
     if (*post).next_row >= (*post).strip_height {
         (*post).starting_row = ((*post).starting_row as u32).wrapping_add((*post).strip_height)
-            as crate::jmorecfg_h::JDIMENSION
             as crate::jmorecfg_h::JDIMENSION;
         (*post).next_row = 0 as i32 as crate::jmorecfg_h::JDIMENSION
     };

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdsample.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdsample.rs
@@ -315,7 +315,7 @@ unsafe extern "C" fn sep_upsample(
     }
     /* And not more than what the client can accept: */
     out_rows_avail = (out_rows_avail as u32).wrapping_sub(*out_row_ctr)
-        as crate::jmorecfg_h::JDIMENSION as crate::jmorecfg_h::JDIMENSION;
+        as crate::jmorecfg_h::JDIMENSION;
     if num_rows > out_rows_avail {
         num_rows = out_rows_avail
     }
@@ -332,13 +332,11 @@ unsafe extern "C" fn sep_upsample(
         num_rows as i32,
     );
     /* Adjust counts */
-    *out_row_ctr = (*out_row_ctr as u32).wrapping_add(num_rows) as crate::jmorecfg_h::JDIMENSION
-        as crate::jmorecfg_h::JDIMENSION;
+    *out_row_ctr = (*out_row_ctr as u32).wrapping_add(num_rows) as crate::jmorecfg_h::JDIMENSION;
     (*upsample).rows_to_go = ((*upsample).rows_to_go as u32).wrapping_sub(num_rows)
-        as crate::jmorecfg_h::JDIMENSION
         as crate::jmorecfg_h::JDIMENSION;
     (*upsample).next_row_out =
-        ((*upsample).next_row_out as u32).wrapping_add(num_rows) as i32 as i32;
+        ((*upsample).next_row_out as u32).wrapping_add(num_rows) as i32;
     /* When the buffer is emptied, declare this input row group consumed */
     if (*upsample).next_row_out >= (*cinfo).max_v_samp_factor {
         *in_row_group_ctr = (*in_row_group_ctr).wrapping_add(1)

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jmemmgr.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jmemmgr.rs
@@ -406,7 +406,7 @@ unsafe extern "C" fn alloc_small(
     if odd_bytes > 0 as i32 as libc::c_ulong {
         sizeofobject = (sizeofobject as libc::c_ulong)
             .wrapping_add((::std::mem::size_of::<f64>() as libc::c_ulong).wrapping_sub(odd_bytes))
-            as crate::stddef_h::size_t as crate::stddef_h::size_t
+            as crate::stddef_h::size_t
     }
     /* See if space is available in any existing pool */
     if pool_id < 0 as i32 || pool_id >= 2 as i32 {
@@ -454,7 +454,7 @@ unsafe extern "C" fn alloc_small(
                 break;
             }
             slop = (slop as libc::c_ulong).wrapping_div(2 as i32 as libc::c_ulong)
-                as crate::stddef_h::size_t as crate::stddef_h::size_t;
+                as crate::stddef_h::size_t;
             if slop < 50 as i32 as libc::c_ulong {
                 /* give up when it gets real small */
                 out_of_memory(cinfo, 2 as i32);
@@ -462,7 +462,7 @@ unsafe extern "C" fn alloc_small(
         }
         (*mem).total_space_allocated = ((*mem).total_space_allocated as libc::c_ulong)
             .wrapping_add(min_request.wrapping_add(slop))
-            as libc::c_long as libc::c_long;
+            as libc::c_long;
         /* Success, initialize the new pool header and add to end of list */
         (*hdr_ptr).hdr.next = 0 as small_pool_ptr;
         (*hdr_ptr).hdr.bytes_used = 0 as i32 as crate::stddef_h::size_t;
@@ -478,11 +478,9 @@ unsafe extern "C" fn alloc_small(
     data_ptr = hdr_ptr.offset(1 as i32 as isize) as *mut libc::c_char; /* point to first data byte in pool */
     data_ptr = data_ptr.offset((*hdr_ptr).hdr.bytes_used as isize); /* point to place for object */
     (*hdr_ptr).hdr.bytes_used = ((*hdr_ptr).hdr.bytes_used as libc::c_ulong)
-        .wrapping_add(sizeofobject) as crate::stddef_h::size_t
-        as crate::stddef_h::size_t;
+        .wrapping_add(sizeofobject) as crate::stddef_h::size_t;
     (*hdr_ptr).hdr.bytes_left = ((*hdr_ptr).hdr.bytes_left as libc::c_ulong)
-        .wrapping_sub(sizeofobject) as crate::stddef_h::size_t
-        as crate::stddef_h::size_t;
+        .wrapping_sub(sizeofobject) as crate::stddef_h::size_t;
     return data_ptr as *mut libc::c_void;
 }
 /*
@@ -520,7 +518,7 @@ unsafe extern "C" fn alloc_large(
     if odd_bytes > 0 as i32 as libc::c_ulong {
         sizeofobject = (sizeofobject as libc::c_ulong)
             .wrapping_add((::std::mem::size_of::<f64>() as libc::c_ulong).wrapping_sub(odd_bytes))
-            as crate::stddef_h::size_t as crate::stddef_h::size_t
+            as crate::stddef_h::size_t
     }
     /* Always make a new pool */
     if pool_id < 0 as i32 || pool_id >= 2 as i32 {
@@ -542,7 +540,7 @@ unsafe extern "C" fn alloc_large(
     }
     (*mem).total_space_allocated = ((*mem).total_space_allocated as libc::c_ulong).wrapping_add(
         sizeofobject.wrapping_add(::std::mem::size_of::<large_pool_hdr>() as libc::c_ulong),
-    ) as libc::c_long as libc::c_long;
+    ) as libc::c_long;
     /* Success, initialize the new pool header and add to list */
     (*hdr_ptr).hdr.next = (*mem).large_list[pool_id as usize];
     /* We maintain space counts in each pool header for statistical purposes,
@@ -853,14 +851,14 @@ unsafe extern "C" fn realize_virt_arrays(mut cinfo: crate::jpeglib_h::j_common_p
                     .wrapping_mul(
                         ::std::mem::size_of::<crate::jmorecfg_h::JSAMPLE>() as libc::c_ulong
                     ),
-            ) as libc::c_long as libc::c_long;
+            ) as libc::c_long;
             maximum_space = (maximum_space as libc::c_ulong).wrapping_add(
                 (((*sptr).rows_in_array as libc::c_long * (*sptr).samplesperrow as libc::c_long)
                     as libc::c_ulong)
                     .wrapping_mul(
                         ::std::mem::size_of::<crate::jmorecfg_h::JSAMPLE>() as libc::c_ulong
                     ),
-            ) as libc::c_long as libc::c_long
+            ) as libc::c_long
         }
         sptr = (*sptr).next
     }
@@ -874,14 +872,14 @@ unsafe extern "C" fn realize_virt_arrays(mut cinfo: crate::jpeglib_h::j_common_p
                     .wrapping_mul(
                         ::std::mem::size_of::<crate::jpeglib_h::JBLOCK>() as libc::c_ulong
                     ),
-            ) as libc::c_long as libc::c_long; /* no unrealized arrays, no work */
+            ) as libc::c_long; /* no unrealized arrays, no work */
             maximum_space = (maximum_space as libc::c_ulong).wrapping_add(
                 (((*bptr).rows_in_array as libc::c_long * (*bptr).blocksperrow as libc::c_long)
                     as libc::c_ulong)
                     .wrapping_mul(
                         ::std::mem::size_of::<crate::jpeglib_h::JBLOCK>() as libc::c_ulong
                     ),
-            ) as libc::c_long as libc::c_long
+            ) as libc::c_long
         }
         bptr = (*bptr).next
     }
@@ -1228,10 +1226,8 @@ unsafe extern "C" fn access_virt_sarray(
                 as crate::stddef_h::size_t)
                 .wrapping_mul(::std::mem::size_of::<crate::jmorecfg_h::JSAMPLE>() as libc::c_ulong);
             undef_row = (undef_row as u32).wrapping_sub((*ptr).cur_start_row)
-                as crate::jmorecfg_h::JDIMENSION
                 as crate::jmorecfg_h::JDIMENSION;
             end_row = (end_row as u32).wrapping_sub((*ptr).cur_start_row)
-                as crate::jmorecfg_h::JDIMENSION
                 as crate::jmorecfg_h::JDIMENSION;
             while undef_row < end_row {
                 crate::src::jpeg_8c::jutils::jzero_far(
@@ -1356,10 +1352,8 @@ unsafe extern "C" fn access_virt_barray(
                 as crate::stddef_h::size_t)
                 .wrapping_mul(::std::mem::size_of::<crate::jpeglib_h::JBLOCK>() as libc::c_ulong);
             undef_row = (undef_row as u32).wrapping_sub((*ptr).cur_start_row)
-                as crate::jmorecfg_h::JDIMENSION
                 as crate::jmorecfg_h::JDIMENSION;
             end_row = (end_row as u32).wrapping_sub((*ptr).cur_start_row)
-                as crate::jmorecfg_h::JDIMENSION
                 as crate::jmorecfg_h::JDIMENSION;
             while undef_row < end_row {
                 crate::src::jpeg_8c::jutils::jzero_far(
@@ -1460,8 +1454,7 @@ unsafe extern "C" fn free_pool(mut cinfo: crate::jpeglib_h::j_common_ptr, mut po
             space_freed,
         );
         (*mem).total_space_allocated = ((*mem).total_space_allocated as libc::c_ulong)
-            .wrapping_sub(space_freed) as libc::c_long
-            as libc::c_long;
+            .wrapping_sub(space_freed) as libc::c_long;
         lhdr_ptr = next_lhdr_ptr
     }
     /* Release small objects */
@@ -1480,8 +1473,7 @@ unsafe extern "C" fn free_pool(mut cinfo: crate::jpeglib_h::j_common_ptr, mut po
             space_freed,
         );
         (*mem).total_space_allocated = ((*mem).total_space_allocated as libc::c_ulong)
-            .wrapping_sub(space_freed) as libc::c_long
-            as libc::c_long;
+            .wrapping_sub(space_freed) as libc::c_long;
         shdr_ptr = next_shdr_ptr
     }
 }

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderercommon/tr_font.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderercommon/tr_font.rs
@@ -181,7 +181,7 @@ pub unsafe extern "C" fn RE_RegisterFont(
             );
             fdOffset = (fdOffset as libc::c_ulong)
                 .wrapping_add(::std::mem::size_of::<[libc::c_char; 32]>() as libc::c_ulong)
-                as i32 as i32;
+                as i32;
             i += 1
         }
         (*font).glyphScale = readFloat();

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderercommon/tr_image_png.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderercommon/tr_image_png.rs
@@ -191,7 +191,7 @@ unsafe extern "C" fn BufferedFileRead(
      *  Raise the pointer and counter.
      */
     (*BF).Ptr = (*BF).Ptr.offset(Length as isize);
-    (*BF).BytesLeft = ((*BF).BytesLeft as u32).wrapping_sub(Length) as i32 as i32;
+    (*BF).BytesLeft = ((*BF).BytesLeft as u32).wrapping_sub(Length) as i32;
     return RetVal;
 }
 /*
@@ -231,7 +231,7 @@ unsafe extern "C" fn BufferedFileRewind(
      *  lower the pointer and counter.
      */
     (*BF).Ptr = (*BF).Ptr.offset(-(Offset as isize));
-    (*BF).BytesLeft = ((*BF).BytesLeft as u32).wrapping_add(Offset) as i32 as i32;
+    (*BF).BytesLeft = ((*BF).BytesLeft as u32).wrapping_add(Offset) as i32;
     return crate::src::qcommon::q_shared::qtrue;
 }
 /*
@@ -258,7 +258,7 @@ unsafe extern "C" fn BufferedFileSkip(
      *  lower the pointer and counter.
      */
     (*BF).Ptr = (*BF).Ptr.offset(Offset as isize);
-    (*BF).BytesLeft = ((*BF).BytesLeft as u32).wrapping_sub(Offset) as i32 as i32;
+    (*BF).BytesLeft = ((*BF).BytesLeft as u32).wrapping_sub(Offset) as i32;
     return crate::src::qcommon::q_shared::qtrue;
 }
 /*
@@ -416,9 +416,8 @@ unsafe extern "C" fn DecompressIDATs(
                 }
                 BytesToRewind = (BytesToRewind as u32)
                     .wrapping_add(Length.wrapping_add(4 as i32 as u32))
-                    as i32 as i32;
+                    as i32;
                 CompressedDataLength = (CompressedDataLength as u32).wrapping_add(Length)
-                    as crate::stdlib::uint32_t
                     as crate::stdlib::uint32_t
             }
         }
@@ -1354,7 +1353,7 @@ unsafe extern "C" fn DecodeImageInterlaced(
                     }) as u32,
                 )
                 .wrapping_mul(PassHeight[a as usize]),
-        ) as crate::stdlib::uint32_t as crate::stdlib::uint32_t;
+        ) as crate::stdlib::uint32_t;
         a = a.wrapping_add(1)
     }
     /*

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_bsp.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_bsp.rs
@@ -951,7 +951,7 @@ unsafe extern "C" fn ParseFace(
     ofsIndexes = sfaceSize;
     sfaceSize = (sfaceSize as libc::c_ulong).wrapping_add(
         (::std::mem::size_of::<i32>() as libc::c_ulong).wrapping_mul(numIndexes as libc::c_ulong),
-    ) as i32 as i32;
+    ) as i32;
     cv = crate::src::renderergl1::tr_main::ri
         .Hunk_Alloc
         .expect("non-null function pointer")(

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_model.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_model.rs
@@ -1053,7 +1053,7 @@ unsafe extern "C" fn R_LoadMDR(
         size = (size as libc::c_ulong).wrapping_add(
             ((*pinmodel).numFrames as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<[libc::c_char; 16]>() as libc::c_ulong),
-        ) as i32 as i32;
+        ) as i32;
         // now add enough space for the uncompressed bones.
         size = (size as libc::c_ulong).wrapping_add(
             (((*pinmodel).numFrames * (*pinmodel).numBones) as libc::c_ulong).wrapping_mul(
@@ -1062,7 +1062,7 @@ unsafe extern "C" fn R_LoadMDR(
                         ::std::mem::size_of::<crate::qfiles_h::mdrCompBone_t>() as libc::c_ulong
                     ),
             ),
-        ) as i32 as i32
+        ) as i32
     }
     // simple bounds check
     if (*pinmodel).numBones < 0 as i32

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_model_iqm.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_model_iqm.rs
@@ -1323,7 +1323,7 @@ pub unsafe extern "C" fn R_LoadIQM(
                         .offset((*joint).name as isize),
                 )
                 .wrapping_add(1 as i32 as libc::c_ulong),
-            ) as crate::stddef_h::size_t as crate::stddef_h::size_t;
+            ) as crate::stddef_h::size_t;
             i += 1;
             joint = joint.offset(1)
         }
@@ -1404,28 +1404,28 @@ pub unsafe extern "C" fn R_LoadIQM(
             ((*header).num_meshes as libc::c_ulong).wrapping_mul(::std::mem::size_of::<
                 crate::tr_local_h::srfIQModel_t,
             >() as libc::c_ulong),
-        ) as crate::stddef_h::size_t as crate::stddef_h::size_t; // triangles
+        ) as crate::stddef_h::size_t; // triangles
         size = (size as libc::c_ulong).wrapping_add(
             ((*header).num_triangles.wrapping_mul(3 as i32 as u32) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<i32>() as libc::c_ulong),
-        ) as crate::stddef_h::size_t as crate::stddef_h::size_t; // positions
+        ) as crate::stddef_h::size_t; // positions
         size = (size as libc::c_ulong).wrapping_add(
             ((*header).num_vertexes.wrapping_mul(3 as i32 as u32) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<f32>() as libc::c_ulong),
-        ) as crate::stddef_h::size_t as crate::stddef_h::size_t; // texcoords
+        ) as crate::stddef_h::size_t; // texcoords
         size = (size as libc::c_ulong).wrapping_add(
             ((*header).num_vertexes.wrapping_mul(2 as i32 as u32) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<f32>() as libc::c_ulong),
-        ) as crate::stddef_h::size_t as crate::stddef_h::size_t; // normals
+        ) as crate::stddef_h::size_t; // normals
         size = (size as libc::c_ulong).wrapping_add(
             ((*header).num_vertexes.wrapping_mul(3 as i32 as u32) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<f32>() as libc::c_ulong),
-        ) as crate::stddef_h::size_t as crate::stddef_h::size_t;
+        ) as crate::stddef_h::size_t;
         if vertexArrayFormat[crate::iqm_h::IQM_TANGENT as i32 as usize] != -(1 as i32) {
             size = (size as libc::c_ulong).wrapping_add(
                 ((*header).num_vertexes.wrapping_mul(4 as i32 as u32) as libc::c_ulong)
                     .wrapping_mul(::std::mem::size_of::<f32>() as libc::c_ulong),
-            ) as crate::stddef_h::size_t as crate::stddef_h::size_t
+            ) as crate::stddef_h::size_t
             // tangents
         }
         if vertexArrayFormat[crate::iqm_h::IQM_COLOR as i32 as usize] != -(1 as i32) {
@@ -1433,19 +1433,19 @@ pub unsafe extern "C" fn R_LoadIQM(
                 ((*header).num_vertexes.wrapping_mul(4 as i32 as u32) as libc::c_ulong)
                     .wrapping_mul(::std::mem::size_of::<crate::src::qcommon::q_shared::byte>()
                         as libc::c_ulong),
-            ) as crate::stddef_h::size_t as crate::stddef_h::size_t
+            ) as crate::stddef_h::size_t
             // colors
         } // influences
         if allocateInfluences != 0 {
             size = (size as libc::c_ulong).wrapping_add(
                 ((*header).num_vertexes as libc::c_ulong)
                     .wrapping_mul(::std::mem::size_of::<i32>() as libc::c_ulong),
-            ) as crate::stddef_h::size_t as crate::stddef_h::size_t; // influenceBlendIndexes
+            ) as crate::stddef_h::size_t; // influenceBlendIndexes
             size = (size as libc::c_ulong).wrapping_add(
                 ((allocateInfluences * 4 as i32) as libc::c_ulong)
                     .wrapping_mul(::std::mem::size_of::<crate::src::qcommon::q_shared::byte>()
                         as libc::c_ulong),
-            ) as crate::stddef_h::size_t as crate::stddef_h::size_t;
+            ) as crate::stddef_h::size_t;
             if vertexArrayFormat[crate::iqm_h::IQM_BLENDWEIGHTS as i32 as usize]
                 == crate::iqm_h::IQM_UBYTE as i32
             {
@@ -1453,7 +1453,7 @@ pub unsafe extern "C" fn R_LoadIQM(
                     ((allocateInfluences * 4 as i32) as libc::c_ulong)
                         .wrapping_mul(::std::mem::size_of::<crate::src::qcommon::q_shared::byte>()
                             as libc::c_ulong),
-                ) as crate::stddef_h::size_t as crate::stddef_h::size_t
+                ) as crate::stddef_h::size_t
             // influenceBlendWeights
             } else if vertexArrayFormat[crate::iqm_h::IQM_BLENDWEIGHTS as i32 as usize]
                 == crate::iqm_h::IQM_FLOAT as i32
@@ -1461,23 +1461,22 @@ pub unsafe extern "C" fn R_LoadIQM(
                 size = (size as libc::c_ulong).wrapping_add(
                     ((allocateInfluences * 4 as i32) as libc::c_ulong)
                         .wrapping_mul(::std::mem::size_of::<f32>() as libc::c_ulong),
-                ) as crate::stddef_h::size_t as crate::stddef_h::size_t
+                ) as crate::stddef_h::size_t
                 // influenceBlendWeights
             }
         }
     } // joint names
     if (*header).num_joints != 0 {
-        size = (size as libc::c_ulong).wrapping_add(joint_names) as crate::stddef_h::size_t
-            as crate::stddef_h::size_t;
+        size = (size as libc::c_ulong).wrapping_add(joint_names) as crate::stddef_h::size_t;
         // joint mats
         size = (size as libc::c_ulong).wrapping_add(
             ((*header).num_joints as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<i32>() as libc::c_ulong),
-        ) as crate::stddef_h::size_t as crate::stddef_h::size_t; // joint parents
+        ) as crate::stddef_h::size_t; // joint parents
         size = (size as libc::c_ulong).wrapping_add(
             ((*header).num_joints.wrapping_mul(12 as i32 as u32) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<f32>() as libc::c_ulong),
-        ) as crate::stddef_h::size_t as crate::stddef_h::size_t
+        ) as crate::stddef_h::size_t
     }
     if (*header).num_poses != 0 {
         size = (size as libc::c_ulong).wrapping_add(
@@ -1486,19 +1485,19 @@ pub unsafe extern "C" fn R_LoadIQM(
                 .wrapping_mul((*header).num_frames)
                 .wrapping_mul(12 as i32 as u32) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<f32>() as libc::c_ulong),
-        ) as crate::stddef_h::size_t as crate::stddef_h::size_t
+        ) as crate::stddef_h::size_t
         // pose mats
     }
     if (*header).ofs_bounds != 0 {
         size = (size as libc::c_ulong).wrapping_add(
             ((*header).num_frames.wrapping_mul(6 as i32 as u32) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<f32>() as libc::c_ulong),
-        ) as crate::stddef_h::size_t as crate::stddef_h::size_t
+        ) as crate::stddef_h::size_t
     // model bounds
     } else if (*header).num_meshes != 0 && (*header).num_frames == 0 as i32 as u32 {
         size = (size as libc::c_ulong).wrapping_add(
             (6 as i32 as libc::c_ulong).wrapping_mul(::std::mem::size_of::<f32>() as libc::c_ulong),
-        ) as crate::stddef_h::size_t as crate::stddef_h::size_t
+        ) as crate::stddef_h::size_t
         // model bounds
     }
     (*mod_0).type_0 = crate::tr_local_h::MOD_IQM;


### PR DESCRIPTION
## Summary
- simplify repeated `as T` casts in Rust files

## Testing
- `cargo +nightly-2019-12-05 build --release`

------
https://chatgpt.com/codex/tasks/task_e_68539badb5d8832982b0178ed81e6884