### PR TITLE
Fix build errors for isize conversion

### DIFF
--- a/quake3-rs/cgamex86_64/src/cgame/cg_draw.rs
+++ b/quake3-rs/cgamex86_64/src/cgame/cg_draw.rs
@@ -641,7 +641,7 @@ pub unsafe extern "C" fn CG_DrawFlagModel(
                 w,
                 h,
                 cg_items[item.offset_from(crate::src::game::bg_misc::bg_itemlist.as_mut_ptr())
-                    as libc::c_long as usize]
+                    as isize as usize]
                     .icon,
             );
         }

--- a/quake3-rs/cgamex86_64/src/cgame/cg_main.rs
+++ b/quake3-rs/cgamex86_64/src/cgame/cg_main.rs
@@ -3482,7 +3482,7 @@ unsafe extern "C" fn CG_RegisterItemSounds(mut itemNum: i32) {
         while *s as i32 != 0 && *s as i32 != ' ' as i32 {
             s = s.offset(1)
         }
-        len = s.offset_from(start) as libc::c_long as i32;
+        len = s.offset_from(start) as isize as i32;
         if len >= 64 as i32 || len < 5 as i32 {
             CG_Error(
                 b"PrecacheItem: %s has bad precache string\x00" as *const u8 as *const libc::c_char,

--- a/quake3-rs/cgamex86_64/src/cgame/cg_servercmds.rs
+++ b/quake3-rs/cgamex86_64/src/cgame/cg_servercmds.rs
@@ -467,9 +467,9 @@ pub unsafe extern "C" fn CG_ShaderStateChanged() {
         crate::stdlib::strncpy(
             originalShader.as_mut_ptr(),
             o,
-            n.offset_from(o) as libc::c_long as libc::c_ulong,
+            n.offset_from(o) as isize as libc::c_ulong,
         );
-        originalShader[n.offset_from(o) as libc::c_long as usize] = 0 as i32 as libc::c_char;
+        originalShader[n.offset_from(o) as isize as usize] = 0 as i32 as libc::c_char;
         n = n.offset(1);
         t = ::libc::strstr(n, b":\x00" as *const u8 as *const libc::c_char);
         if !(!t.is_null() && *t as i32 != 0) {
@@ -478,18 +478,18 @@ pub unsafe extern "C" fn CG_ShaderStateChanged() {
         crate::stdlib::strncpy(
             newShader.as_mut_ptr(),
             n,
-            t.offset_from(n) as libc::c_long as libc::c_ulong,
+            t.offset_from(n) as isize as libc::c_ulong,
         );
-        newShader[t.offset_from(n) as libc::c_long as usize] = 0 as i32 as libc::c_char;
+        newShader[t.offset_from(n) as isize as usize] = 0 as i32 as libc::c_char;
         t = t.offset(1);
         o = ::libc::strstr(t, b"@\x00" as *const u8 as *const libc::c_char);
         if !o.is_null() {
             crate::stdlib::strncpy(
                 timeOffset.as_mut_ptr(),
                 t,
-                o.offset_from(t) as libc::c_long as libc::c_ulong,
+                o.offset_from(t) as isize as libc::c_ulong,
             );
-            timeOffset[o.offset_from(t) as libc::c_long as usize] = 0 as i32 as libc::c_char;
+            timeOffset[o.offset_from(t) as isize as usize] = 0 as i32 as libc::c_char;
             o = o.offset(1);
             crate::src::cgame::cg_syscalls::trap_R_RemapShader(
                 originalShader.as_mut_ptr(),
@@ -636,9 +636,9 @@ unsafe extern "C" fn CG_AddToTeamChat(mut str: *const libc::c_char) {
     while *str != 0 {
         if len > 80 as i32 - 1 as i32 {
             if !ls.is_null() {
-                str = str.offset(-(p.offset_from(ls) as libc::c_long as isize));
+                str = str.offset(-(p.offset_from(ls) as isize as isize));
                 str = str.offset(1);
-                p = p.offset(-(p.offset_from(ls) as libc::c_long as isize))
+                p = p.offset(-(p.offset_from(ls) as isize as isize))
             }
             *p = 0 as i32 as libc::c_char;
             crate::src::cgame::cg_main::cgs.teamChatMsgTimes

--- a/quake3-rs/cgamex86_64/src/cgame/cg_syscalls.rs
+++ b/quake3-rs/cgamex86_64/src/cgame/cg_syscalls.rs
@@ -394,7 +394,7 @@ pub unsafe extern "C" fn trap_FS_FCloseFile(mut f: crate::src::qcommon::q_shared
 
 pub unsafe extern "C" fn trap_FS_Seek(
     mut f: crate::src::qcommon::q_shared::fileHandle_t,
-    mut offset: libc::c_long,
+    mut offset: isize,
     mut origin: i32,
 ) -> i32 {
     return syscall.expect("non-null function pointer")(

--- a/quake3-rs/cgamex86_64/src/cgame/cg_weapons.rs
+++ b/quake3-rs/cgamex86_64/src/cgame/cg_weapons.rs
@@ -1218,7 +1218,7 @@ pub unsafe extern "C" fn CG_RegisterWeapon(mut weaponNum: i32) {
         );
     }
     CG_RegisterItemVisuals(
-        item.offset_from(crate::src::game::bg_misc::bg_itemlist.as_mut_ptr()) as libc::c_long
+        item.offset_from(crate::src::game::bg_misc::bg_itemlist.as_mut_ptr()) as isize
             as i32,
     );
     // load cmodel before model so filecache works
@@ -2305,8 +2305,8 @@ pub unsafe extern "C" fn CG_AddPlayerWeapon(
     // then this is a fake player (like on the single player podiums), so
     // go ahead and use the cent
     if nonPredictedCent.offset_from(crate::src::cgame::cg_main::cg_entities.as_mut_ptr())
-        as libc::c_long
-        != (*cent).currentState.clientNum as libc::c_long
+        as isize
+        != (*cent).currentState.clientNum as isize
     {
         nonPredictedCent = cent
     }

--- a/quake3-rs/cgamex86_64/src/qcommon/q_shared.rs
+++ b/quake3-rs/cgamex86_64/src/qcommon/q_shared.rs
@@ -986,12 +986,12 @@ pub unsafe extern "C" fn COM_StripExtension(
         slash = ::libc::strrchr(in_0, '/' as i32);
         (slash.is_null()) || slash < dot
     } {
-        destsize = if (destsize as libc::c_long)
-            < dot.offset_from(in_0) as libc::c_long + 1 as i32 as libc::c_long
+        destsize = if (destsize as isize)
+            < dot.offset_from(in_0) as isize + 1 as i32 as isize
         {
-            destsize as libc::c_long
+            destsize as isize
         } else {
-            (dot.offset_from(in_0) as libc::c_long) + 1 as i32 as libc::c_long
+            (dot.offset_from(in_0) as isize) + 1 as i32 as isize
         } as i32
     }
     if in_0 == out as *const libc::c_char && destsize > 1 as i32 {
@@ -1298,7 +1298,7 @@ pub unsafe extern "C" fn COM_Compress(mut data_p: *mut libc::c_char) -> i32 {
         }
         *out = 0 as i32 as libc::c_char
     }
-    return out.offset_from(data_p) as libc::c_long as i32;
+    return out.offset_from(data_p) as isize as i32;
 }
 #[no_mangle]
 pub unsafe extern "C" fn COM_ParseExt(

--- a/quake3-rs/cgamex86_64/src/stdlib.rs
+++ b/quake3-rs/cgamex86_64/src/stdlib.rs
@@ -79,7 +79,7 @@ pub const _ISpunct: crate::src::qcommon::q_shared::C2RustUnnamed_0 = 4;
 pub const _ISalnum: crate::src::qcommon::q_shared::C2RustUnnamed_0 = 8;
 // ================ END ctype_h ================
 // =============== BEGIN stdint_h ================
-pub type intptr_t = libc::c_long;
+pub type intptr_t = isize;
 // ================ END stdint_h ================
 // =============== BEGIN types_h ================
 pub type __int32_t = i32;

--- a/quake3-rs/ioquake3/lib.rs
+++ b/quake3-rs/ioquake3/lib.rs
@@ -736,11 +736,11 @@ pub mod highlevel_h {
         pub impulse_noisetune: f64,
         pub req: f32,
         pub managed: i32,
-        pub bitrate_min: libc::c_long,
-        pub bitrate_av: libc::c_long,
+        pub bitrate_min: isize,
+        pub bitrate_av: isize,
         pub bitrate_av_damp: f64,
-        pub bitrate_max: libc::c_long,
-        pub bitrate_reservoir: libc::c_long,
+        pub bitrate_max: isize,
+        pub bitrate_reservoir: isize,
         pub bitrate_reservoir_bias: f64,
         pub impulse_block_p: i32,
         pub noise_normalize_p: i32,
@@ -808,7 +808,7 @@ pub mod codec_internal_h {
     #[repr(C)]
     #[derive(Copy, Clone)]
     pub struct codec_setup_info {
-        pub blocksizes: [libc::c_long; 2],
+        pub blocksizes: [isize; 2],
         pub modes: i32,
         pub maps: i32,
         pub floors: i32,
@@ -843,9 +843,9 @@ pub mod codec_internal_h {
         pub n: i32,
         pub quant_q: i32,
         pub vi: *mut crate::backends_h::vorbis_info_floor1,
-        pub phrasebits: libc::c_long,
-        pub postbits: libc::c_long,
-        pub frames: libc::c_long,
+        pub phrasebits: isize,
+        pub postbits: isize,
+        pub frames: isize,
     }
 }
 pub mod backends_h {
@@ -889,8 +889,8 @@ pub mod backends_h {
     #[derive(Copy, Clone)]
     pub struct vorbis_info_floor0 {
         pub order: i32,
-        pub rate: libc::c_long,
-        pub barkmap: libc::c_long,
+        pub rate: isize,
+        pub barkmap: isize,
         pub ampbits: i32,
         pub ampdB: i32,
         pub numbooks: i32,
@@ -945,7 +945,7 @@ pub mod backends_h {
                 _: *mut *mut i32,
                 _: *mut i32,
                 _: i32,
-            ) -> *mut *mut libc::c_long,
+            ) -> *mut *mut isize,
         >,
         pub forward: Option<
             unsafe extern "C" fn(
@@ -955,7 +955,7 @@ pub mod backends_h {
                 _: *mut *mut i32,
                 _: *mut i32,
                 _: i32,
-                _: *mut *mut libc::c_long,
+                _: *mut *mut isize,
                 _: i32,
             ) -> i32,
         >,
@@ -973,8 +973,8 @@ pub mod backends_h {
     #[repr(C)]
     #[derive(Copy, Clone)]
     pub struct vorbis_info_residue0 {
-        pub begin: libc::c_long,
-        pub end: libc::c_long,
+        pub begin: isize,
+        pub end: isize,
         pub grouping: i32,
         pub partitions: i32,
         pub partvals: i32,
@@ -1089,11 +1089,11 @@ pub mod codec_h {
     pub struct vorbis_info {
         pub version: i32,
         pub channels: i32,
-        pub rate: libc::c_long,
-        pub bitrate_upper: libc::c_long,
-        pub bitrate_nominal: libc::c_long,
-        pub bitrate_lower: libc::c_long,
-        pub bitrate_window: libc::c_long,
+        pub rate: isize,
+        pub bitrate_upper: isize,
+        pub bitrate_nominal: isize,
+        pub bitrate_lower: isize,
+        pub bitrate_window: isize,
         pub codec_setup: *mut libc::c_void,
     }
 
@@ -1109,10 +1109,10 @@ pub mod codec_h {
         pub pcm_returned: i32,
         pub preextrapolate: i32,
         pub eofflag: i32,
-        pub lW: libc::c_long,
-        pub W: libc::c_long,
-        pub nW: libc::c_long,
-        pub centerW: libc::c_long,
+        pub lW: isize,
+        pub W: isize,
+        pub nW: isize,
+        pub centerW: isize,
         pub granulepos: crate::config_types_h::ogg_int64_t,
         pub sequence: crate::config_types_h::ogg_int64_t,
         pub glue_bits: crate::config_types_h::ogg_int64_t,
@@ -1127,9 +1127,9 @@ pub mod codec_h {
     pub struct vorbis_block {
         pub pcm: *mut *mut f32,
         pub opb: crate::ogg_h::oggpack_buffer,
-        pub lW: libc::c_long,
-        pub W: libc::c_long,
-        pub nW: libc::c_long,
+        pub lW: isize,
+        pub W: isize,
+        pub nW: isize,
         pub pcmend: i32,
         pub mode: i32,
         pub eofflag: i32,
@@ -1137,14 +1137,14 @@ pub mod codec_h {
         pub sequence: crate::config_types_h::ogg_int64_t,
         pub vd: *mut crate::codec_h::vorbis_dsp_state,
         pub localstore: *mut libc::c_void,
-        pub localtop: libc::c_long,
-        pub localalloc: libc::c_long,
-        pub totaluse: libc::c_long,
+        pub localtop: isize,
+        pub localalloc: isize,
+        pub totaluse: isize,
         pub reap: *mut crate::codec_h::alloc_chain,
-        pub glue_bits: libc::c_long,
-        pub time_bits: libc::c_long,
-        pub floor_bits: libc::c_long,
-        pub res_bits: libc::c_long,
+        pub glue_bits: isize,
+        pub time_bits: isize,
+        pub floor_bits: isize,
+        pub res_bits: isize,
         pub internal: *mut libc::c_void,
     }
 
@@ -1175,41 +1175,41 @@ pub mod ogg_h {
     #[repr(C)]
     #[derive(Copy, Clone)]
     pub struct oggpack_buffer {
-        pub endbyte: libc::c_long,
+        pub endbyte: isize,
         pub endbit: i32,
         pub buffer: *mut u8,
         pub ptr: *mut u8,
-        pub storage: libc::c_long,
+        pub storage: isize,
     }
 
     #[repr(C)]
     #[derive(Copy, Clone)]
     pub struct ogg_page {
         pub header: *mut u8,
-        pub header_len: libc::c_long,
+        pub header_len: isize,
         pub body: *mut u8,
-        pub body_len: libc::c_long,
+        pub body_len: isize,
     }
 
     #[repr(C)]
     #[derive(Copy, Clone)]
     pub struct ogg_stream_state {
         pub body_data: *mut u8,
-        pub body_storage: libc::c_long,
-        pub body_fill: libc::c_long,
-        pub body_returned: libc::c_long,
+        pub body_storage: isize,
+        pub body_fill: isize,
+        pub body_returned: isize,
         pub lacing_vals: *mut i32,
         pub granule_vals: *mut crate::config_types_h::ogg_int64_t,
-        pub lacing_storage: libc::c_long,
-        pub lacing_fill: libc::c_long,
-        pub lacing_packet: libc::c_long,
-        pub lacing_returned: libc::c_long,
+        pub lacing_storage: isize,
+        pub lacing_fill: isize,
+        pub lacing_packet: isize,
+        pub lacing_returned: isize,
         pub header: [u8; 282],
         pub header_fill: i32,
         pub e_o_s: i32,
         pub b_o_s: i32,
-        pub serialno: libc::c_long,
-        pub pageno: libc::c_long,
+        pub serialno: isize,
+        pub pageno: isize,
         pub packetno: crate::config_types_h::ogg_int64_t,
         pub granulepos: crate::config_types_h::ogg_int64_t,
     }
@@ -1218,9 +1218,9 @@ pub mod ogg_h {
     #[derive(Copy, Clone)]
     pub struct ogg_packet {
         pub packet: *mut u8,
-        pub bytes: libc::c_long,
-        pub b_o_s: libc::c_long,
-        pub e_o_s: libc::c_long,
+        pub bytes: isize,
+        pub b_o_s: isize,
+        pub e_o_s: isize,
         pub granulepos: crate::config_types_h::ogg_int64_t,
         pub packetno: crate::config_types_h::ogg_int64_t,
     }
@@ -1632,7 +1632,7 @@ pub mod keys_h {
     }
 }
 pub mod curlbuild_h {
-    pub type curl_off_t = libc::c_long;
+    pub type curl_off_t = isize;
 }
 pub mod opus_types_h {
     pub type opus_int16 = crate::stdlib::int16_t;
@@ -2082,7 +2082,7 @@ pub mod tr_public_h {
         pub FS_FileIsInPAK:
             Option<unsafe extern "C" fn(_: *const libc::c_char, _: *mut i32) -> i32>,
         pub FS_ReadFile: Option<
-            unsafe extern "C" fn(_: *const libc::c_char, _: *mut *mut libc::c_void) -> libc::c_long,
+            unsafe extern "C" fn(_: *const libc::c_char, _: *mut *mut libc::c_void) -> isize,
         >,
         pub FS_FreeFile: Option<unsafe extern "C" fn(_: *mut libc::c_void) -> ()>,
         pub FS_ListFiles: Option<
@@ -2118,7 +2118,7 @@ pub mod tr_public_h {
         pub IN_Init: Option<unsafe extern "C" fn(_: *mut libc::c_void) -> ()>,
         pub IN_Shutdown: Option<unsafe extern "C" fn() -> ()>,
         pub IN_Restart: Option<unsafe extern "C" fn() -> ()>,
-        pub ftol: Option<unsafe extern "C" fn(_: f32) -> libc::c_long>,
+        pub ftol: Option<unsafe extern "C" fn(_: f32) -> isize>,
         pub Sys_SetEnv:
             Option<unsafe extern "C" fn(_: *const libc::c_char, _: *const libc::c_char) -> ()>,
         pub Sys_GLimpSafeInit: Option<unsafe extern "C" fn() -> ()>,
@@ -2135,7 +2135,7 @@ pub mod tr_public_h {
     >;
 }
 pub mod stddef_h {
-    pub type ptrdiff_t = libc::c_long;
+    pub type ptrdiff_t = isize;
 
     pub type size_t = libc::c_ulong;
 
@@ -2774,7 +2774,7 @@ pub mod botlib_h {
         pub FS_Seek: Option<
             unsafe extern "C" fn(
                 _: crate::src::qcommon::q_shared::fileHandle_t,
-                _: libc::c_long,
+                _: isize,
                 _: i32,
             ) -> i32,
         >,
@@ -3433,7 +3433,7 @@ pub mod server_h {
         pub ipv: crate::server_h::C2RustUnnamed_164,
         pub lastTime: i32,
         pub burst: i8,
-        pub hash: libc::c_long,
+        pub hash: isize,
         pub prev: *mut crate::server_h::leakyBucket_t,
         pub next: *mut crate::server_h::leakyBucket_t,
     }
@@ -7240,11 +7240,11 @@ pub mod stdlib {
         ) -> libc::c_ulong;
 
         #[no_mangle]
-        pub fn fseek(__stream: *mut crate::stdlib::FILE, __off: libc::c_long, __whence: i32)
+        pub fn fseek(__stream: *mut crate::stdlib::FILE, __off: isize, __whence: i32)
             -> i32;
 
         #[no_mangle]
-        pub fn ftell(__stream: *mut crate::stdlib::FILE) -> libc::c_long;
+        pub fn ftell(__stream: *mut crate::stdlib::FILE) -> isize;
 
         #[no_mangle]
         pub fn fseeko(
@@ -9232,14 +9232,14 @@ pub mod stdlib {
     pub type jmp_buf = [crate::stdlib::__jmp_buf_tag; 1];
     pub type mbstate_t = crate::stdlib::__mbstate_t;
     pub type mode_t = crate::stdlib::__mode_t;
-    pub type __fd_mask = libc::c_long;
+    pub type __fd_mask = isize;
 
     #[repr(C)]
     #[derive(Copy, Clone)]
     pub struct fd_set {
         pub __fds_bits: [crate::stdlib::__fd_mask; 16],
     }
-    pub type __jmp_buf = [libc::c_long; 8];
+    pub type __jmp_buf = [isize; 8];
     pub type __sighandler_t = Option<unsafe extern "C" fn(_: i32) -> ()>;
     pub type sa_family_t = u16;
     pub type socklen_t = crate::stdlib::__socklen_t;
@@ -9289,7 +9289,7 @@ pub mod stdlib {
         pub st_ctim: ::libc::timespec,
         pub __glibc_reserved: [crate::stdlib::__syscall_slong_t; 3],
     }
-    pub type intptr_t = libc::c_long;
+    pub type intptr_t = isize;
     pub type int16_t = crate::stdlib::__int16_t;
 
     pub type int32_t = crate::stdlib::__int32_t;
@@ -9365,7 +9365,7 @@ pub mod stdlib {
 
     pub type __uint32_t = u32;
 
-    pub type __int64_t = libc::c_long;
+    pub type __int64_t = isize;
 
     pub type __dev_t = libc::c_ulong;
 
@@ -9379,27 +9379,27 @@ pub mod stdlib {
 
     pub type __nlink_t = libc::c_ulong;
 
-    pub type __off_t = libc::c_long;
+    pub type __off_t = isize;
 
-    pub type __off64_t = libc::c_long;
+    pub type __off64_t = isize;
 
     pub type __pid_t = i32;
 
-    pub type __clock_t = libc::c_long;
+    pub type __clock_t = isize;
 
-    pub type __time_t = libc::c_long;
+    pub type __time_t = isize;
 
     pub type __useconds_t = u32;
 
-    pub type __suseconds_t = libc::c_long;
+    pub type __suseconds_t = isize;
 
-    pub type __blksize_t = libc::c_long;
+    pub type __blksize_t = isize;
 
-    pub type __blkcnt_t = libc::c_long;
+    pub type __blkcnt_t = isize;
 
-    pub type __ssize_t = libc::c_long;
+    pub type __ssize_t = isize;
 
-    pub type __syscall_slong_t = libc::c_long;
+    pub type __syscall_slong_t = isize;
 
     pub type __socklen_t = u32;
 }

--- a/quake3-rs/ioquake3/src/asm/ftola.rs
+++ b/quake3-rs/ioquake3/src/asm/ftola.rs
@@ -27,8 +27,8 @@ static mut fpucw: u16 = 0xc7f as i32 as u16;
  */
 #[no_mangle]
 
-pub unsafe extern "C" fn qftolsse(mut f: f32) -> libc::c_long {
-    let mut retval: libc::c_long = 0;
+pub unsafe extern "C" fn qftolsse(mut f: f32) -> isize {
+    let mut retval: isize = 0;
     asm!("cvttss2si $1, $0\n" : "=r" (retval) : "x" (f) : : "volatile");
     return retval;
 }
@@ -42,8 +42,8 @@ pub unsafe extern "C" fn qvmftolsse() -> i32 {
 }
 #[no_mangle]
 
-pub unsafe extern "C" fn qftolx87(mut f: f32) -> libc::c_long {
-    let mut retval: libc::c_long = 0;
+pub unsafe extern "C" fn qftolx87(mut f: f32) -> isize {
+    let mut retval: isize = 0;
     let mut oldcw: u16 = 0 as i32 as u16;
     asm!("fnstcw $2\nfldcw $3\nflds $1\nfistpl $1\nfldcw $2\nmov $1, $0\n" : "=r"
      (retval) : "*m" (&f), "*m" (&oldcw), "*m" (&fpucw) : : "volatile");

--- a/quake3-rs/ioquake3/src/botlib/be_aas_file.rs
+++ b/quake3-rs/ioquake3/src/botlib/be_aas_file.rs
@@ -786,7 +786,7 @@ pub unsafe extern "C" fn AAS_LoadAASLump(
             .FS_Seek
             .expect("non-null function pointer")(
             fp,
-            offset as libc::c_long,
+            offset as isize,
             crate::src::qcommon::q_shared::FS_SEEK_SET as i32,
         ) != 0
         {
@@ -1511,7 +1511,7 @@ pub unsafe extern "C" fn AAS_WriteAASFile(
         .FS_Seek
         .expect("non-null function pointer")(
         fp,
-        0 as i32 as libc::c_long,
+        0 as i32 as isize,
         crate::src::qcommon::q_shared::FS_SEEK_SET as i32,
     );
     AAS_DData(

--- a/quake3-rs/ioquake3/src/botlib/be_aas_route.rs
+++ b/quake3-rs/ioquake3/src/botlib/be_aas_route.rs
@@ -845,9 +845,9 @@ pub unsafe extern "C" fn AAS_CalculateAreaTravelTimes() {
             ((*settings).numreachableareas as libc::c_ulong)
                 .wrapping_mul(
                     ((*revreach).numlinks as libc::c_ulong)
-                        .wrapping_add(::std::mem::size_of::<libc::c_long>() as libc::c_ulong)
+                        .wrapping_add(::std::mem::size_of::<isize>() as libc::c_ulong)
                         .wrapping_sub(1 as i32 as libc::c_ulong)
-                        & !(::std::mem::size_of::<libc::c_long>() as libc::c_ulong)
+                        & !(::std::mem::size_of::<isize>() as libc::c_ulong)
                             .wrapping_sub(1 as i32 as libc::c_ulong),
                 )
                 .wrapping_mul(::std::mem::size_of::<u16>() as libc::c_ulong),
@@ -892,9 +892,9 @@ pub unsafe extern "C" fn AAS_CalculateAreaTravelTimes() {
             *fresh5 = ptr as *mut u16;
             ptr = ptr.offset(
                 (((*revreach).numlinks as libc::c_ulong)
-                    .wrapping_add(::std::mem::size_of::<libc::c_long>() as libc::c_ulong)
+                    .wrapping_add(::std::mem::size_of::<isize>() as libc::c_ulong)
                     .wrapping_sub(1 as i32 as libc::c_ulong)
-                    & !(::std::mem::size_of::<libc::c_long>() as libc::c_ulong)
+                    & !(::std::mem::size_of::<isize>() as libc::c_ulong)
                         .wrapping_sub(1 as i32 as libc::c_ulong))
                 .wrapping_mul(::std::mem::size_of::<u16>() as libc::c_ulong)
                     as isize,

--- a/quake3-rs/ioquake3/src/botlib/be_ai_chat.rs
+++ b/quake3-rs/ioquake3/src/botlib/be_ai_chat.rs
@@ -1202,9 +1202,9 @@ pub unsafe extern "C" fn BotLoadSynonyms(
                         len = crate::stdlib::strlen(token.string.as_mut_ptr())
                             .wrapping_add(1 as i32 as libc::c_ulong);
                         len = len
-                            .wrapping_add(::std::mem::size_of::<libc::c_long>() as libc::c_ulong)
+                            .wrapping_add(::std::mem::size_of::<isize>() as libc::c_ulong)
                             .wrapping_sub(1 as i32 as libc::c_ulong)
-                            & !(::std::mem::size_of::<libc::c_long>() as libc::c_ulong)
+                            & !(::std::mem::size_of::<isize>() as libc::c_ulong)
                                 .wrapping_sub(1 as i32 as libc::c_ulong);
                         size = (size as libc::c_ulong).wrapping_add(
                             (::std::mem::size_of::<bot_synonym_t>() as libc::c_ulong)
@@ -1751,9 +1751,9 @@ pub unsafe extern "C" fn BotLoadRandomStrings(
             len = crate::stdlib::strlen(token.string.as_mut_ptr())
                 .wrapping_add(1 as i32 as libc::c_ulong);
             len = len
-                .wrapping_add(::std::mem::size_of::<libc::c_long>() as libc::c_ulong)
+                .wrapping_add(::std::mem::size_of::<isize>() as libc::c_ulong)
                 .wrapping_sub(1 as i32 as libc::c_ulong)
-                & !(::std::mem::size_of::<libc::c_long>() as libc::c_ulong)
+                & !(::std::mem::size_of::<isize>() as libc::c_ulong)
                     .wrapping_sub(1 as i32 as libc::c_ulong);
             size = (size as libc::c_ulong).wrapping_add(
                 (::std::mem::size_of::<bot_randomlist_t>() as libc::c_ulong).wrapping_add(len),
@@ -1803,9 +1803,9 @@ pub unsafe extern "C" fn BotLoadRandomStrings(
                 len = crate::stdlib::strlen(chatmessagestring.as_mut_ptr())
                     .wrapping_add(1 as i32 as libc::c_ulong);
                 len = len
-                    .wrapping_add(::std::mem::size_of::<libc::c_long>() as libc::c_ulong)
+                    .wrapping_add(::std::mem::size_of::<isize>() as libc::c_ulong)
                     .wrapping_sub(1 as i32 as libc::c_ulong)
-                    & !(::std::mem::size_of::<libc::c_long>() as libc::c_ulong)
+                    & !(::std::mem::size_of::<isize>() as libc::c_ulong)
                         .wrapping_sub(1 as i32 as libc::c_ulong);
                 size = (size as libc::c_ulong).wrapping_add(
                     (::std::mem::size_of::<bot_randomstring_t>() as libc::c_ulong)
@@ -2421,9 +2421,9 @@ pub unsafe extern "C" fn StringsMatch(
                         if lastvariable >= 0 as i32 {
                             (*match_0).variables[lastvariable as usize].length =
                                 (newstrptr.offset_from((*match_0).string.as_mut_ptr())
-                                    as libc::c_long
+                                    as isize
                                     - (*match_0).variables[lastvariable as usize].offset
-                                        as libc::c_long) as i32;
+                                        as isize) as i32;
                             //newstrptr - match->variables[lastvariable].ptr;
                             lastvariable = -(1 as i32);
                             break;
@@ -2446,7 +2446,7 @@ pub unsafe extern "C" fn StringsMatch(
             //if it is a variable piece of string
             //Log_Write("MT_VARIABLE");
             (*match_0).variables[(*mp).variable as usize].offset =
-                strptr.offset_from((*match_0).string.as_mut_ptr()) as libc::c_long as libc::c_char;
+                strptr.offset_from((*match_0).string.as_mut_ptr()) as isize as libc::c_char;
             lastvariable = (*mp).variable
         }
         mp = (*mp).next
@@ -3654,10 +3654,10 @@ pub unsafe extern "C" fn BotLoadInitialChat(
                                 .wrapping_add(1 as i32 as libc::c_ulong);
                             len =
                                 len.wrapping_add(
-                                    ::std::mem::size_of::<libc::c_long>() as libc::c_ulong
+                                    ::std::mem::size_of::<isize>() as libc::c_ulong
                                 )
                                 .wrapping_sub(1 as i32 as libc::c_ulong)
-                                    & !(::std::mem::size_of::<libc::c_long>() as libc::c_ulong)
+                                    & !(::std::mem::size_of::<isize>() as libc::c_ulong)
                                         .wrapping_sub(1 as i32 as libc::c_ulong);
                             if pass != 0 && !ptr.is_null() {
                                 chatmessage = ptr as *mut bot_chatmessage_t;

--- a/quake3-rs/ioquake3/src/botlib/be_interface.rs
+++ b/quake3-rs/ioquake3/src/botlib/be_interface.rs
@@ -385,7 +385,7 @@ pub static mut botlibsetup: i32 = crate::src::qcommon::q_shared::qfalse as i32;
 #[no_mangle]
 
 pub unsafe extern "C" fn Sys_MilliSeconds() -> i32 {
-    return (crate::stdlib::clock() * 1000 as i32 as libc::c_long
+    return (crate::stdlib::clock() * 1000 as i32 as isize
         / 1000000 as i32 as crate::stdlib::__clock_t) as i32;
 }
 //end of the function Sys_MilliSeconds

--- a/quake3-rs/ioquake3/src/botlib/l_memory.rs
+++ b/quake3-rs/ioquake3/src/botlib/l_memory.rs
@@ -84,7 +84,7 @@ pub unsafe extern "C" fn GetMemory(mut size: libc::c_ulong) -> *mut libc::c_void
         return 0 as *mut libc::c_void;
     }
     memid = ptr as *mut libc::c_ulong;
-    *memid = 0x12345678 as libc::c_long as libc::c_ulong;
+    *memid = 0x12345678 as isize as libc::c_ulong;
     return (ptr as *mut libc::c_char)
         .offset(::std::mem::size_of::<libc::c_ulong>() as libc::c_ulong as isize)
         as *mut libc::c_ulong as *mut libc::c_void;
@@ -133,7 +133,7 @@ pub unsafe extern "C" fn GetHunkMemory(mut size: libc::c_ulong) -> *mut libc::c_
         return 0 as *mut libc::c_void;
     }
     memid = ptr as *mut libc::c_ulong;
-    *memid = 0x87654321 as libc::c_long as libc::c_ulong;
+    *memid = 0x87654321 as isize as libc::c_ulong;
     return (ptr as *mut libc::c_char)
         .offset(::std::mem::size_of::<libc::c_ulong>() as libc::c_ulong as isize)
         as *mut libc::c_ulong as *mut libc::c_void;
@@ -172,7 +172,7 @@ pub unsafe extern "C" fn FreeMemory(mut ptr: *mut libc::c_void) {
     memid = (ptr as *mut libc::c_char)
         .offset(-(::std::mem::size_of::<libc::c_ulong>() as libc::c_ulong as isize))
         as *mut libc::c_ulong;
-    if *memid == 0x12345678 as libc::c_long as libc::c_ulong {
+    if *memid == 0x12345678 as isize as libc::c_ulong {
         crate::src::botlib::be_interface::botimport
             .FreeMemory
             .expect("non-null function pointer")(memid as *mut libc::c_void);

--- a/quake3-rs/ioquake3/src/botlib/l_precomp.rs
+++ b/quake3-rs/ioquake3/src/botlib/l_precomp.rs
@@ -109,7 +109,7 @@ pub struct operator_s {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct value_s {
-    pub intvalue: libc::c_long,
+    pub intvalue: isize,
     pub floatvalue: f32,
     pub parentheses: i32,
     pub prev: *mut value_s,
@@ -1081,7 +1081,7 @@ pub unsafe extern "C" fn PC_ExpandBuiltinDefine(
             *lasttoken = token
         }
         3 => {
-            t = ::libc::time(0 as *mut crate::stdlib::time_t);
+            t = ::libc::time(0 as *mut libc::c_long) as crate::stdlib::time_t;
             curtime = crate::stdlib::ctime(&mut t);
             ::libc::strcpy(
                 (*token).string.as_mut_ptr(),
@@ -1108,7 +1108,7 @@ pub unsafe extern "C" fn PC_ExpandBuiltinDefine(
             *lasttoken = token
         }
         4 => {
-            t = ::libc::time(0 as *mut crate::stdlib::time_t);
+            t = ::libc::time(0 as *mut libc::c_long) as crate::stdlib::time_t;
             curtime = crate::stdlib::ctime(&mut t);
             ::libc::strcpy(
                 (*token).string.as_mut_ptr(),
@@ -1707,8 +1707,8 @@ pub unsafe extern "C" fn PC_ReadLine(
 pub unsafe extern "C" fn PC_WhiteSpaceBeforeToken(
     mut token: *mut crate::src::botlib::l_script::token_t,
 ) -> i32 {
-    return ((*token).endwhitespace_p.offset_from((*token).whitespace_p) as libc::c_long
-        > 0 as i32 as libc::c_long) as i32;
+    return ((*token).endwhitespace_p.offset_from((*token).whitespace_p) as isize
+        > 0 as i32 as isize) as i32;
 }
 //end of the function PC_WhiteSpaceBeforeToken
 //============================================================================
@@ -2501,7 +2501,7 @@ pub unsafe extern "C" fn PC_OperatorPriority(mut op: i32) -> i32 {
 pub unsafe extern "C" fn PC_EvaluateTokens(
     mut source: *mut crate::src::botlib::l_precomp::source_t,
     mut tokens: *mut crate::src::botlib::l_script::token_t,
-    mut intvalue: *mut libc::c_long,
+    mut intvalue: *mut isize,
     mut floatvalue: *mut f32,
     mut integer: i32,
 ) -> i32 {
@@ -2545,7 +2545,7 @@ pub unsafe extern "C" fn PC_EvaluateTokens(
     lastvalue = 0 as *mut value_t;
     firstvalue = lastvalue;
     if !intvalue.is_null() {
-        *intvalue = 0 as i32 as libc::c_long
+        *intvalue = 0 as i32 as isize
     }
     if !floatvalue.is_null() {
         *floatvalue = 0 as i32 as f32
@@ -2609,10 +2609,10 @@ pub unsafe extern "C" fn PC_EvaluateTokens(
                         {
                             //end else
                             //DEFINEHASHING
-                            (*v).intvalue = 1 as i32 as libc::c_long; //end if
+                            (*v).intvalue = 1 as i32 as isize; //end if
                             (*v).floatvalue = 1 as i32 as f32
                         } else {
-                            (*v).intvalue = 0 as i32 as libc::c_long; //end if
+                            (*v).intvalue = 0 as i32 as isize; //end if
                             (*v).floatvalue = 0 as i32 as f32
                         }
                         (*v).parentheses = parentheses;
@@ -2680,10 +2680,10 @@ pub unsafe extern "C" fn PC_EvaluateTokens(
                     //v = (value_t *) GetClearedMemory(sizeof(value_t));
                     if negativevalue != 0 {
                         //end else
-                        (*v).intvalue = -((*t).intvalue as i32) as libc::c_long; //end if
+                        (*v).intvalue = -((*t).intvalue as i32) as isize; //end if
                         (*v).floatvalue = -(*t).floatvalue
                     } else {
-                        (*v).intvalue = (*t).intvalue as libc::c_long;
+                        (*v).intvalue = (*t).intvalue as isize;
                         (*v).floatvalue = (*t).floatvalue
                     }
                     (*v).parentheses = parentheses;
@@ -2933,7 +2933,7 @@ pub unsafe extern "C" fn PC_EvaluateTokens(
         //DEBUG_EVAL
         match (*o).operator {
             36 => {
-                (*v1).intvalue = ((*v1).intvalue == 0) as i32 as libc::c_long;
+                (*v1).intvalue = ((*v1).intvalue == 0) as i32 as isize;
                 (*v1).floatvalue = ((*v1).floatvalue == 0.) as i32 as f32
                 //end switch
                 //end if
@@ -2978,36 +2978,36 @@ pub unsafe extern "C" fn PC_EvaluateTokens(
             }
             5 => {
                 (*v1).intvalue =
-                    ((*v1).intvalue != 0 && (*v2).intvalue != 0) as i32 as libc::c_long;
+                    ((*v1).intvalue != 0 && (*v2).intvalue != 0) as i32 as isize;
                 (*v1).floatvalue = ((*v1).floatvalue != 0. && (*v2).floatvalue != 0.) as i32 as f32
             }
             6 => {
                 (*v1).intvalue =
-                    ((*v1).intvalue != 0 || (*v2).intvalue != 0) as i32 as libc::c_long;
+                    ((*v1).intvalue != 0 || (*v2).intvalue != 0) as i32 as isize;
                 (*v1).floatvalue = ((*v1).floatvalue != 0. || (*v2).floatvalue != 0.) as i32 as f32
             }
             7 => {
-                (*v1).intvalue = ((*v1).intvalue >= (*v2).intvalue) as i32 as libc::c_long;
+                (*v1).intvalue = ((*v1).intvalue >= (*v2).intvalue) as i32 as isize;
                 (*v1).floatvalue = ((*v1).floatvalue >= (*v2).floatvalue) as i32 as f32
             }
             8 => {
-                (*v1).intvalue = ((*v1).intvalue <= (*v2).intvalue) as i32 as libc::c_long;
+                (*v1).intvalue = ((*v1).intvalue <= (*v2).intvalue) as i32 as isize;
                 (*v1).floatvalue = ((*v1).floatvalue <= (*v2).floatvalue) as i32 as f32
             }
             9 => {
-                (*v1).intvalue = ((*v1).intvalue == (*v2).intvalue) as i32 as libc::c_long;
+                (*v1).intvalue = ((*v1).intvalue == (*v2).intvalue) as i32 as isize;
                 (*v1).floatvalue = ((*v1).floatvalue == (*v2).floatvalue) as i32 as f32
             }
             10 => {
-                (*v1).intvalue = ((*v1).intvalue != (*v2).intvalue) as i32 as libc::c_long;
+                (*v1).intvalue = ((*v1).intvalue != (*v2).intvalue) as i32 as isize;
                 (*v1).floatvalue = ((*v1).floatvalue != (*v2).floatvalue) as i32 as f32
             }
             37 => {
-                (*v1).intvalue = ((*v1).intvalue > (*v2).intvalue) as i32 as libc::c_long;
+                (*v1).intvalue = ((*v1).intvalue > (*v2).intvalue) as i32 as isize;
                 (*v1).floatvalue = ((*v1).floatvalue > (*v2).floatvalue) as i32 as f32
             }
             38 => {
-                (*v1).intvalue = ((*v1).intvalue < (*v2).intvalue) as i32 as libc::c_long;
+                (*v1).intvalue = ((*v1).intvalue < (*v2).intvalue) as i32 as isize;
                 (*v1).floatvalue = ((*v1).floatvalue < (*v2).floatvalue) as i32 as f32
             }
             21 => (*v1).intvalue >>= (*v2).intvalue,
@@ -3105,7 +3105,7 @@ pub unsafe extern "C" fn PC_EvaluateTokens(
         return crate::src::qcommon::q_shared::qtrue as i32;
     }
     if !intvalue.is_null() {
-        *intvalue = 0 as i32 as libc::c_long
+        *intvalue = 0 as i32 as isize
     }
     if !floatvalue.is_null() {
         *floatvalue = 0 as i32 as f32
@@ -3123,7 +3123,7 @@ pub unsafe extern "C" fn PC_EvaluateTokens(
 
 pub unsafe extern "C" fn PC_Evaluate(
     mut source: *mut crate::src::botlib::l_precomp::source_t,
-    mut intvalue: *mut libc::c_long,
+    mut intvalue: *mut isize,
     mut floatvalue: *mut f32,
     mut integer: i32,
 ) -> i32 {
@@ -3151,7 +3151,7 @@ pub unsafe extern "C" fn PC_Evaluate(
         0 as *mut crate::src::botlib::l_precomp::define_t;
     let mut defined: i32 = crate::src::qcommon::q_shared::qfalse as i32;
     if !intvalue.is_null() {
-        *intvalue = 0 as i32 as libc::c_long
+        *intvalue = 0 as i32 as isize
     }
     if !floatvalue.is_null() {
         *floatvalue = 0 as i32 as f32
@@ -3264,7 +3264,7 @@ pub unsafe extern "C" fn PC_Evaluate(
 
 pub unsafe extern "C" fn PC_DollarEvaluate(
     mut source: *mut crate::src::botlib::l_precomp::source_t,
-    mut intvalue: *mut libc::c_long,
+    mut intvalue: *mut isize,
     mut floatvalue: *mut f32,
     mut integer: i32,
 ) -> i32 {
@@ -3293,7 +3293,7 @@ pub unsafe extern "C" fn PC_DollarEvaluate(
     let mut define: *mut crate::src::botlib::l_precomp::define_t =
         0 as *mut crate::src::botlib::l_precomp::define_t;
     if !intvalue.is_null() {
-        *intvalue = 0 as i32 as libc::c_long
+        *intvalue = 0 as i32 as isize
     }
     if !floatvalue.is_null() {
         *floatvalue = 0 as i32 as f32
@@ -3424,7 +3424,7 @@ pub unsafe extern "C" fn PC_DollarEvaluate(
 pub unsafe extern "C" fn PC_Directive_elif(
     mut source: *mut crate::src::botlib::l_precomp::source_t,
 ) -> i32 {
-    let mut value: libc::c_long = 0; //end if
+    let mut value: isize = 0; //end if
     let mut type_0: i32 = 0;
     let mut skip: i32 = 0;
     PC_PopIndent(source, &mut type_0, &mut skip);
@@ -3444,7 +3444,7 @@ pub unsafe extern "C" fn PC_Directive_elif(
     {
         return crate::src::qcommon::q_shared::qfalse as i32;
     }
-    skip = (value == 0 as i32 as libc::c_long) as i32;
+    skip = (value == 0 as i32 as isize) as i32;
     PC_PushIndent(source, 0x4 as i32, skip);
     return crate::src::qcommon::q_shared::qtrue as i32;
 }
@@ -3460,7 +3460,7 @@ pub unsafe extern "C" fn PC_Directive_elif(
 pub unsafe extern "C" fn PC_Directive_if(
     mut source: *mut crate::src::botlib::l_precomp::source_t,
 ) -> i32 {
-    let mut value: libc::c_long = 0;
+    let mut value: isize = 0;
     let mut skip: i32 = 0;
     if PC_Evaluate(
         source,
@@ -3471,7 +3471,7 @@ pub unsafe extern "C" fn PC_Directive_if(
     {
         return crate::src::qcommon::q_shared::qfalse as i32;
     }
-    skip = (value == 0 as i32 as libc::c_long) as i32;
+    skip = (value == 0 as i32 as isize) as i32;
     PC_PushIndent(source, 0x1 as i32, skip);
     return crate::src::qcommon::q_shared::qtrue as i32;
 }
@@ -3608,7 +3608,7 @@ pub unsafe extern "C" fn UnreadSignToken(mut source: *mut crate::src::botlib::l_
 pub unsafe extern "C" fn PC_Directive_eval(
     mut source: *mut crate::src::botlib::l_precomp::source_t,
 ) -> i32 {
-    let mut value: libc::c_long = 0;
+    let mut value: isize = 0;
     let mut token: crate::src::botlib::l_script::token_t = crate::src::botlib::l_script::token_t {
         string: [0; 1024],
         type_0: 0,
@@ -3638,12 +3638,12 @@ pub unsafe extern "C" fn PC_Directive_eval(
     ::libc::sprintf(
         token.string.as_mut_ptr(),
         b"%ld\x00" as *const u8 as *const libc::c_char,
-        ::libc::labs(value),
+        ::libc::labs(value as libc::c_long),
     );
     token.type_0 = 3 as i32;
     token.subtype = 0x1000 as i32 | 0x2000 as i32 | 0x8 as i32;
     PC_UnreadSourceToken(source, &mut token);
-    if value < 0 as i32 as libc::c_long {
+    if value < 0 as i32 as isize {
         UnreadSignToken(source);
     }
     return crate::src::qcommon::q_shared::qtrue as i32;
@@ -3675,7 +3675,7 @@ pub unsafe extern "C" fn PC_Directive_evalfloat(
     };
     if PC_Evaluate(
         source,
-        0 as *mut libc::c_long,
+        0 as *mut isize,
         &mut value,
         crate::src::qcommon::q_shared::qfalse as i32,
     ) == 0
@@ -3978,7 +3978,7 @@ pub unsafe extern "C" fn PC_ReadDirective(
 pub unsafe extern "C" fn PC_DollarDirective_evalint(
     mut source: *mut crate::src::botlib::l_precomp::source_t,
 ) -> i32 {
-    let mut value: libc::c_long = 0;
+    let mut value: isize = 0;
     let mut token: crate::src::botlib::l_script::token_t = crate::src::botlib::l_script::token_t {
         string: [0; 1024],
         type_0: 0,
@@ -4008,15 +4008,15 @@ pub unsafe extern "C" fn PC_DollarDirective_evalint(
     ::libc::sprintf(
         token.string.as_mut_ptr(),
         b"%ld\x00" as *const u8 as *const libc::c_char,
-        ::libc::labs(value),
+        ::libc::labs(value as libc::c_long),
     );
     token.type_0 = 3 as i32;
     token.subtype = 0x1000 as i32 | 0x2000 as i32 | 0x8 as i32;
-    token.intvalue = ::libc::labs(value) as libc::c_ulong;
+    token.intvalue = ::libc::labs(value as libc::c_long) as libc::c_ulong;
     token.floatvalue = token.intvalue as f32;
     //NUMBERVALUE
     PC_UnreadSourceToken(source, &mut token);
-    if value < 0 as i32 as libc::c_long {
+    if value < 0 as i32 as isize {
         UnreadSignToken(source);
     }
     return crate::src::qcommon::q_shared::qtrue as i32;
@@ -4048,7 +4048,7 @@ pub unsafe extern "C" fn PC_DollarDirective_evalfloat(
     };
     if PC_DollarEvaluate(
         source,
-        0 as *mut libc::c_long,
+        0 as *mut isize,
         &mut value,
         crate::src::qcommon::q_shared::qfalse as i32,
     ) == 0

--- a/quake3-rs/ioquake3/src/botlib/l_script.rs
+++ b/quake3-rs/ioquake3/src/botlib/l_script.rs
@@ -2278,7 +2278,7 @@ pub unsafe extern "C" fn ReadSignedFloat(
 
 pub unsafe extern "C" fn ReadSignedInt(
     mut script: *mut crate::src::botlib::l_script::script_t,
-) -> libc::c_long {
+) -> isize {
     let mut token: crate::src::botlib::l_script::token_t = crate::src::botlib::l_script::token_t {
         string: [0; 1024],
         type_0: 0,
@@ -2291,7 +2291,7 @@ pub unsafe extern "C" fn ReadSignedInt(
         linescrossed: 0,
         next: 0 as *mut crate::src::botlib::l_script::token_s,
     };
-    let mut sign: libc::c_long = 1 as i32 as libc::c_long;
+    let mut sign: isize = 1 as i32 as isize;
     PS_ExpectAnyToken(script, &mut token);
     if ::libc::strcmp(
         token.string.as_mut_ptr(),
@@ -2304,9 +2304,9 @@ pub unsafe extern "C" fn ReadSignedInt(
                 b"Missing integer value\x00" as *const u8 as *const libc::c_char
                     as *mut libc::c_char,
             );
-            return 0 as i32 as libc::c_long;
+            return 0 as i32 as isize;
         }
-        sign = -(1 as i32) as libc::c_long
+        sign = -(1 as i32) as isize
     }
     if token.type_0 != 3 as i32 || token.subtype == 0x800 as i32 {
         ScriptError(
@@ -2315,9 +2315,9 @@ pub unsafe extern "C" fn ReadSignedInt(
                 as *mut libc::c_char,
             token.string.as_mut_ptr(),
         );
-        return 0 as i32 as libc::c_long;
+        return 0 as i32 as isize;
     }
-    return (sign as libc::c_ulong).wrapping_mul(token.intvalue) as libc::c_long;
+    return (sign as libc::c_ulong).wrapping_mul(token.intvalue) as isize;
 }
 //set script flags
 //end of the function ReadSignedInt

--- a/quake3-rs/ioquake3/src/botlib/l_struct.rs
+++ b/quake3-rs/ioquake3/src/botlib/l_struct.rs
@@ -138,9 +138,9 @@ pub unsafe extern "C" fn ReadNumber(
         next: 0 as *mut crate::src::botlib::l_script::token_s,
     };
     let mut negative: i32 = crate::src::qcommon::q_shared::qfalse as i32;
-    let mut intval: libc::c_long = 0;
-    let mut intmin: libc::c_long = 0 as i32 as libc::c_long;
-    let mut intmax: libc::c_long = 0 as i32 as libc::c_long;
+    let mut intval: isize = 0;
+    let mut intmin: isize = 0 as i32 as isize;
+    let mut intmax: isize = 0 as i32 as isize;
     let mut floatval: f64 = 0.;
     if crate::src::botlib::l_precomp::PC_ExpectAnyToken(
         source as *mut crate::src::botlib::l_precomp::source_s,
@@ -226,27 +226,27 @@ pub unsafe extern "C" fn ReadNumber(
         return crate::src::qcommon::q_shared::qtrue;
     }
     //
-    intval = token.intvalue as libc::c_long;
+    intval = token.intvalue as isize;
     if negative != 0 {
         intval = -intval
     }
     //check bounds
     if (*fd).type_0 & 0xff as i32 == 1 as i32 {
         if (*fd).type_0 & 0x400 as i32 != 0 {
-            intmin = 0 as i32 as libc::c_long; //end if
-            intmax = 255 as i32 as libc::c_long
+            intmin = 0 as i32 as isize; //end if
+            intmax = 255 as i32 as isize
         } else {
-            intmin = -(128 as i32) as libc::c_long; //end else if
-            intmax = 127 as i32 as libc::c_long
+            intmin = -(128 as i32) as isize; //end else if
+            intmax = 127 as i32 as isize
         }
     } //end else if
     if (*fd).type_0 & 0xff as i32 == 2 as i32 {
         if (*fd).type_0 & 0x400 as i32 != 0 {
-            intmin = 0 as i32 as libc::c_long; //end if
-            intmax = 65535 as i32 as libc::c_long
+            intmin = 0 as i32 as isize; //end if
+            intmax = 65535 as i32 as isize
         } else {
-            intmin = -(32768 as i32) as libc::c_long;
-            intmax = 32767 as i32 as libc::c_long
+            intmin = -(32768 as i32) as isize;
+            intmax = 32767 as i32 as isize
         }
     }
     if (*fd).type_0 & 0xff as i32 == 1 as i32 || (*fd).type_0 & 0xff as i32 == 2 as i32 {
@@ -255,12 +255,12 @@ pub unsafe extern "C" fn ReadNumber(
                 intmin as f32
             } else {
                 (*fd).floatmin
-            } as libc::c_long;
+            } as isize;
             intmax = if (intmax as f32) < (*fd).floatmax {
                 intmax as f32
             } else {
                 (*fd).floatmax
-            } as libc::c_long
+            } as isize
         }
         if intval < intmin || intval > intmax {
             crate::src::botlib::l_precomp::SourceError(

--- a/quake3-rs/ioquake3/src/client/cl_avi.rs
+++ b/quake3-rs/ioquake3/src/client/cl_avi.rs
@@ -44826,7 +44826,7 @@ pub unsafe extern "C" fn CL_CloseAVI() -> crate::src::qcommon::q_shared::qboolea
     afd.fileOpen = crate::src::qcommon::q_shared::qfalse;
     crate::src::qcommon::files::FS_Seek(
         afd.idxF,
-        4 as i32 as libc::c_long,
+        4 as i32 as isize,
         crate::src::qcommon::q_shared::FS_SEEK_SET as i32,
     );
     bufIndex = 0 as i32;
@@ -44881,7 +44881,7 @@ pub unsafe extern "C" fn CL_CloseAVI() -> crate::src::qcommon::q_shared::qboolea
     // Write the real header
     crate::src::qcommon::files::FS_Seek(
         afd.f,
-        0 as i32 as libc::c_long,
+        0 as i32 as isize,
         crate::src::qcommon::q_shared::FS_SEEK_SET as i32,
     ); // "RIFF" size
     CL_WriteAVIHeader(); // Skip "LIST"

--- a/quake3-rs/ioquake3/src/client/cl_cgame.rs
+++ b/quake3-rs/ioquake3/src/client/cl_cgame.rs
@@ -1546,7 +1546,7 @@ pub unsafe extern "C" fn CL_CgameSystemCalls(
             // Don't allow the cgame module to close the console
             crate::src::client::cl_keys::Key_SetCatcher(
                 (*args.offset(1 as i32 as isize)
-                    | (crate::src::client::cl_keys::Key_GetCatcher() & 0x1 as i32) as libc::c_long)
+                    | (crate::src::client::cl_keys::Key_GetCatcher() & 0x1 as i32) as isize)
                     as i32,
             );
             return 0 as i32 as crate::stdlib::intptr_t;

--- a/quake3-rs/ioquake3/src/client/cl_cin.rs
+++ b/quake3-rs/ioquake3/src/client/cl_cin.rs
@@ -170,15 +170,15 @@ pub struct cin_cache {
     pub status: crate::src::qcommon::q_shared::e_status,
     pub startTime: i32,
     pub lastTime: i32,
-    pub tfps: libc::c_long,
-    pub RoQPlayed: libc::c_long,
-    pub ROQSize: libc::c_long,
+    pub tfps: isize,
+    pub RoQPlayed: isize,
+    pub ROQSize: isize,
     pub RoQFrameSize: u32,
-    pub onQuad: libc::c_long,
-    pub numQuads: libc::c_long,
-    pub samplesPerLine: libc::c_long,
+    pub onQuad: isize,
+    pub numQuads: isize,
+    pub samplesPerLine: isize,
     pub roq_id: u32,
-    pub screenDelta: libc::c_long,
+    pub screenDelta: isize,
     pub VQ0: Option<
         unsafe extern "C" fn(
             _: *mut crate::src::qcommon::q_shared::byte,
@@ -203,7 +203,7 @@ pub struct cin_cache {
             _: *mut libc::c_void,
         ) -> (),
     >,
-    pub samplesPerPixel: libc::c_long,
+    pub samplesPerPixel: isize,
     pub gray: *mut crate::src::qcommon::q_shared::byte,
     pub xsize: u32,
     pub ysize: u32,
@@ -212,16 +212,16 @@ pub struct cin_cache {
     pub half: crate::src::qcommon::q_shared::qboolean,
     pub smootheddouble: crate::src::qcommon::q_shared::qboolean,
     pub inMemory: crate::src::qcommon::q_shared::qboolean,
-    pub normalBuffer0: libc::c_long,
-    pub roq_flags: libc::c_long,
-    pub roqF0: libc::c_long,
-    pub roqF1: libc::c_long,
-    pub t: [libc::c_long; 2],
-    pub roqFPS: libc::c_long,
+    pub normalBuffer0: isize,
+    pub roq_flags: isize,
+    pub roqF0: isize,
+    pub roqF1: isize,
+    pub t: [isize; 2],
+    pub roqFPS: isize,
     pub playonwalls: i32,
     pub buf: *mut crate::src::qcommon::q_shared::byte,
-    pub drawX: libc::c_long,
-    pub drawY: libc::c_long,
+    pub drawX: isize,
+    pub drawY: isize,
 }
 
 #[repr(C)]
@@ -232,10 +232,10 @@ pub struct cinematics_t {
     pub sqrTable: [i16; 256],
     pub mcomp: [i32; 256],
     pub qStatus: [[*mut crate::src::qcommon::q_shared::byte; 32768]; 2],
-    pub oldXOff: libc::c_long,
-    pub oldYOff: libc::c_long,
-    pub oldysize: libc::c_long,
-    pub oldxsize: libc::c_long,
+    pub oldXOff: isize,
+    pub oldYOff: isize,
+    pub oldysize: isize,
+    pub oldxsize: isize,
     pub currentHandle: i32,
 }
 
@@ -254,15 +254,15 @@ pub union C2RustUnnamed_14 {
 *
 ******************************************************************************/
 
-static mut ROQ_YY_tab: [libc::c_long; 256] = [0; 256];
+static mut ROQ_YY_tab: [isize; 256] = [0; 256];
 
-static mut ROQ_UB_tab: [libc::c_long; 256] = [0; 256];
+static mut ROQ_UB_tab: [isize; 256] = [0; 256];
 
-static mut ROQ_UG_tab: [libc::c_long; 256] = [0; 256];
+static mut ROQ_UG_tab: [isize; 256] = [0; 256];
 
-static mut ROQ_VG_tab: [libc::c_long; 256] = [0; 256];
+static mut ROQ_VG_tab: [isize; 256] = [0; 256];
 
-static mut ROQ_VR_tab: [libc::c_long; 256] = [0; 256];
+static mut ROQ_VR_tab: [isize; 256] = [0; 256];
 
 static mut vq2: [u16; 16384] = [0; 16384];
 
@@ -409,7 +409,7 @@ pub unsafe extern "C" fn RllDecodeMonoToMono(
     mut size: u32,
     mut signedOutput: libc::c_char,
     mut flag: u16,
-) -> libc::c_long {
+) -> isize {
     let mut z: u32 = 0;
     let mut prev: i32 = 0;
     if signedOutput != 0 {
@@ -424,7 +424,7 @@ pub unsafe extern "C" fn RllDecodeMonoToMono(
         prev = *fresh0 as i32;
         z = z.wrapping_add(1)
     }
-    return size as libc::c_long;
+    return size as isize;
     //*sizeof(short));
 }
 //-----------------------------------------------------------------------------
@@ -449,7 +449,7 @@ pub unsafe extern "C" fn RllDecodeMonoToStereo(
     mut size: u32,
     mut signedOutput: libc::c_char,
     mut flag: u16,
-) -> libc::c_long {
+) -> isize {
     let mut z: u32 = 0;
     let mut prev: i32 = 0;
     if signedOutput != 0 {
@@ -471,7 +471,7 @@ pub unsafe extern "C" fn RllDecodeMonoToStereo(
         ) = *fresh1;
         z = z.wrapping_add(1)
     }
-    return size as libc::c_long;
+    return size as isize;
     // * 2 * sizeof(short));
 }
 //-----------------------------------------------------------------------------
@@ -495,7 +495,7 @@ pub unsafe extern "C" fn RllDecodeStereoToStereo(
     mut size: u32,
     mut signedOutput: libc::c_char,
     mut flag: u16,
-) -> libc::c_long {
+) -> isize {
     let mut z: u32 = 0;
     let mut zz: *mut u8 = from;
     let mut prevL: i32 = 0;
@@ -519,7 +519,7 @@ pub unsafe extern "C" fn RllDecodeStereoToStereo(
         *to.offset(z.wrapping_add(1 as i32 as u32) as isize) = prevR as i16;
         z = z.wrapping_add(2 as i32 as u32)
     }
-    return (size >> 1 as i32) as libc::c_long;
+    return (size >> 1 as i32) as isize;
     //*sizeof(short));
 }
 //-----------------------------------------------------------------------------
@@ -543,7 +543,7 @@ pub unsafe extern "C" fn RllDecodeStereoToMono(
     mut size: u32,
     mut signedOutput: libc::c_char,
     mut flag: u16,
-) -> libc::c_long {
+) -> isize {
     let mut z: u32 = 0;
     let mut prevL: i32 = 0;
     let mut prevR: i32 = 0;
@@ -566,7 +566,7 @@ pub unsafe extern "C" fn RllDecodeStereoToMono(
         *to.offset(z as isize) = ((prevL + prevR) / 2 as i32) as i16;
         z = z.wrapping_add(1 as i32 as u32)
     }
-    return size as libc::c_long;
+    return size as isize;
 }
 /* *****************************************************************************
 *
@@ -856,18 +856,18 @@ unsafe extern "C" fn ROQ_GenYUVTables() {
     let mut t_vr: f32 = 0.;
     let mut t_ug: f32 = 0.;
     let mut t_vg: f32 = 0.;
-    let mut i: libc::c_long = 0;
+    let mut i: isize = 0;
     t_ub = 1.77200f32 / 2.0f32 * ((1 as i32) << 6 as i32) as f32 + 0.5f32;
     t_vr = 1.40200f32 / 2.0f32 * ((1 as i32) << 6 as i32) as f32 + 0.5f32;
     t_ug = 0.34414f32 / 2.0f32 * ((1 as i32) << 6 as i32) as f32 + 0.5f32;
     t_vg = 0.71414f32 / 2.0f32 * ((1 as i32) << 6 as i32) as f32 + 0.5f32;
-    i = 0 as i32 as libc::c_long;
-    while i < 256 as i32 as libc::c_long {
-        let mut x: f32 = (2 as i32 as libc::c_long * i - 255 as i32 as libc::c_long) as f32;
-        ROQ_UB_tab[i as usize] = (t_ub * x + ((1 as i32) << 5 as i32) as f32) as libc::c_long;
-        ROQ_VR_tab[i as usize] = (t_vr * x + ((1 as i32) << 5 as i32) as f32) as libc::c_long;
-        ROQ_UG_tab[i as usize] = (-t_ug * x) as libc::c_long;
-        ROQ_VG_tab[i as usize] = (-t_vg * x + ((1 as i32) << 5 as i32) as f32) as libc::c_long;
+    i = 0 as i32 as isize;
+    while i < 256 as i32 as isize {
+        let mut x: f32 = (2 as i32 as isize * i - 255 as i32 as isize) as f32;
+        ROQ_UB_tab[i as usize] = (t_ub * x + ((1 as i32) << 5 as i32) as f32) as isize;
+        ROQ_VR_tab[i as usize] = (t_vr * x + ((1 as i32) << 5 as i32) as f32) as isize;
+        ROQ_UG_tab[i as usize] = (-t_ug * x) as isize;
+        ROQ_VG_tab[i as usize] = (-t_vg * x + ((1 as i32) << 5 as i32) as f32) as isize;
         ROQ_YY_tab[i as usize] = i << 6 as i32 | i >> 2 as i32;
         i += 1
     }
@@ -881,34 +881,34 @@ unsafe extern "C" fn ROQ_GenYUVTables() {
 ******************************************************************************/
 
 unsafe extern "C" fn yuv_to_rgb(
-    mut y: libc::c_long,
-    mut u: libc::c_long,
-    mut v: libc::c_long,
+    mut y: isize,
+    mut u: isize,
+    mut v: isize,
 ) -> u16 {
-    let mut r: libc::c_long = 0;
-    let mut g: libc::c_long = 0;
-    let mut b: libc::c_long = 0;
-    let mut YY: libc::c_long = ROQ_YY_tab[y as usize];
+    let mut r: isize = 0;
+    let mut g: isize = 0;
+    let mut b: isize = 0;
+    let mut YY: isize = ROQ_YY_tab[y as usize];
     r = YY + ROQ_VR_tab[v as usize] >> 9 as i32;
     g = YY + ROQ_UG_tab[u as usize] + ROQ_VG_tab[v as usize] >> 8 as i32;
     b = YY + ROQ_UB_tab[u as usize] >> 9 as i32;
-    if r < 0 as i32 as libc::c_long {
-        r = 0 as i32 as libc::c_long
+    if r < 0 as i32 as isize {
+        r = 0 as i32 as isize
     }
-    if g < 0 as i32 as libc::c_long {
-        g = 0 as i32 as libc::c_long
+    if g < 0 as i32 as isize {
+        g = 0 as i32 as isize
     }
-    if b < 0 as i32 as libc::c_long {
-        b = 0 as i32 as libc::c_long
+    if b < 0 as i32 as isize {
+        b = 0 as i32 as isize
     }
-    if r > 31 as i32 as libc::c_long {
-        r = 31 as i32 as libc::c_long
+    if r > 31 as i32 as isize {
+        r = 31 as i32 as isize
     }
-    if g > 63 as i32 as libc::c_long {
-        g = 63 as i32 as libc::c_long
+    if g > 63 as i32 as isize {
+        g = 63 as i32 as isize
     }
-    if b > 31 as i32 as libc::c_long {
-        b = 31 as i32 as libc::c_long
+    if b > 31 as i32 as isize {
+        b = 31 as i32 as isize
     }
     return ((r << 11 as i32) + (g << 5 as i32) + b) as u16;
 }
@@ -921,34 +921,34 @@ unsafe extern "C" fn yuv_to_rgb(
 ******************************************************************************/
 
 unsafe extern "C" fn yuv_to_rgb24(
-    mut y: libc::c_long,
-    mut u: libc::c_long,
-    mut v: libc::c_long,
+    mut y: isize,
+    mut u: isize,
+    mut v: isize,
 ) -> u32 {
-    let mut r: libc::c_long = 0;
-    let mut g: libc::c_long = 0;
-    let mut b: libc::c_long = 0;
-    let mut YY: libc::c_long = ROQ_YY_tab[y as usize];
+    let mut r: isize = 0;
+    let mut g: isize = 0;
+    let mut b: isize = 0;
+    let mut YY: isize = ROQ_YY_tab[y as usize];
     r = YY + ROQ_VR_tab[v as usize] >> 6 as i32;
     g = YY + ROQ_UG_tab[u as usize] + ROQ_VG_tab[v as usize] >> 6 as i32;
     b = YY + ROQ_UB_tab[u as usize] >> 6 as i32;
-    if r < 0 as i32 as libc::c_long {
-        r = 0 as i32 as libc::c_long
+    if r < 0 as i32 as isize {
+        r = 0 as i32 as isize
     }
-    if g < 0 as i32 as libc::c_long {
-        g = 0 as i32 as libc::c_long
+    if g < 0 as i32 as isize {
+        g = 0 as i32 as isize
     }
-    if b < 0 as i32 as libc::c_long {
-        b = 0 as i32 as libc::c_long
+    if b < 0 as i32 as isize {
+        b = 0 as i32 as isize
     }
-    if r > 255 as i32 as libc::c_long {
-        r = 255 as i32 as libc::c_long
+    if r > 255 as i32 as isize {
+        r = 255 as i32 as isize
     }
-    if g > 255 as i32 as libc::c_long {
-        g = 255 as i32 as libc::c_long
+    if g > 255 as i32 as isize {
+        g = 255 as i32 as isize
     }
-    if b > 255 as i32 as libc::c_long {
-        b = 255 as i32 as libc::c_long
+    if b > 255 as i32 as isize {
+        b = 255 as i32 as isize
     }
     return ((r | g << 8 as i32 | b << 16 as i32) as libc::c_ulong
         | (255 as libc::c_ulong) << 24 as i32) as u32;
@@ -965,20 +965,20 @@ unsafe extern "C" fn decodeCodeBook(
     mut input: *mut crate::src::qcommon::q_shared::byte,
     mut roq_flags: u16,
 ) {
-    let mut i: libc::c_long = 0;
-    let mut j: libc::c_long = 0;
-    let mut two: libc::c_long = 0;
-    let mut four: libc::c_long = 0;
+    let mut i: isize = 0;
+    let mut j: isize = 0;
+    let mut two: isize = 0;
+    let mut four: isize = 0;
     let mut aptr: *mut u16 = 0 as *mut u16;
     let mut bptr: *mut u16 = 0 as *mut u16;
     let mut cptr: *mut u16 = 0 as *mut u16;
     let mut dptr: *mut u16 = 0 as *mut u16;
-    let mut y0: libc::c_long = 0;
-    let mut y1: libc::c_long = 0;
-    let mut y2: libc::c_long = 0;
-    let mut y3: libc::c_long = 0;
-    let mut cr: libc::c_long = 0;
-    let mut cb: libc::c_long = 0;
+    let mut y0: isize = 0;
+    let mut y1: isize = 0;
+    let mut y2: isize = 0;
+    let mut y3: isize = 0;
+    let mut cr: isize = 0;
+    let mut cb: isize = 0;
     let mut bbptr: *mut crate::src::qcommon::q_shared::byte =
         0 as *mut crate::src::qcommon::q_shared::byte;
     let mut baptr: *mut crate::src::qcommon::q_shared::byte =
@@ -992,43 +992,43 @@ unsafe extern "C" fn decodeCodeBook(
     let mut icptr: C2RustUnnamed_14 = C2RustUnnamed_14 { i: 0 as *mut u32 };
     let mut idptr: C2RustUnnamed_14 = C2RustUnnamed_14 { i: 0 as *mut u32 };
     if roq_flags == 0 {
-        four = 256 as i32 as libc::c_long;
+        four = 256 as i32 as isize;
         two = four
     } else {
-        two = (roq_flags as i32 >> 8 as i32) as libc::c_long;
+        two = (roq_flags as i32 >> 8 as i32) as isize;
         if two == 0 {
-            two = 256 as i32 as libc::c_long
+            two = 256 as i32 as isize
         }
-        four = (roq_flags as i32 & 0xff as i32) as libc::c_long
+        four = (roq_flags as i32 & 0xff as i32) as isize
     }
-    four *= 2 as i32 as libc::c_long;
+    four *= 2 as i32 as isize;
     bptr = vq2.as_mut_ptr();
     if cinTable[currentHandle as usize].half as u64 == 0 {
         if cinTable[currentHandle as usize].smootheddouble as u64 == 0 {
             //
             // normal height
             //
-            if cinTable[currentHandle as usize].samplesPerPixel == 2 as i32 as libc::c_long {
-                i = 0 as i32 as libc::c_long;
+            if cinTable[currentHandle as usize].samplesPerPixel == 2 as i32 as isize {
+                i = 0 as i32 as isize;
                 while i < two {
                     let fresh4 = input;
                     input = input.offset(1);
-                    y0 = *fresh4 as libc::c_long;
+                    y0 = *fresh4 as isize;
                     let fresh5 = input;
                     input = input.offset(1);
-                    y1 = *fresh5 as libc::c_long;
+                    y1 = *fresh5 as isize;
                     let fresh6 = input;
                     input = input.offset(1);
-                    y2 = *fresh6 as libc::c_long;
+                    y2 = *fresh6 as isize;
                     let fresh7 = input;
                     input = input.offset(1);
-                    y3 = *fresh7 as libc::c_long;
+                    y3 = *fresh7 as isize;
                     let fresh8 = input;
                     input = input.offset(1);
-                    cr = *fresh8 as libc::c_long;
+                    cr = *fresh8 as isize;
                     let fresh9 = input;
                     input = input.offset(1);
-                    cb = *fresh9 as libc::c_long;
+                    cb = *fresh9 as isize;
                     let fresh10 = bptr;
                     bptr = bptr.offset(1);
                     *fresh10 = yuv_to_rgb(y0, cr, cb);
@@ -1045,7 +1045,7 @@ unsafe extern "C" fn decodeCodeBook(
                 }
                 cptr = vq4.as_mut_ptr();
                 dptr = vq8.as_mut_ptr();
-                i = 0 as i32 as libc::c_long;
+                i = 0 as i32 as isize;
                 while i < four {
                     let fresh14 = input;
                     input = input.offset(1);
@@ -1057,8 +1057,8 @@ unsafe extern "C" fn decodeCodeBook(
                     bptr = vq2
                         .as_mut_ptr()
                         .offset((*fresh15 as i32 * 4 as i32) as isize);
-                    j = 0 as i32 as libc::c_long;
-                    while j < 2 as i32 as libc::c_long {
+                    j = 0 as i32 as isize;
+                    while j < 2 as i32 as isize {
                         let fresh16 = cptr;
                         cptr = cptr.offset(1);
                         *fresh16 = *aptr.offset(0 as i32 as isize);
@@ -1125,28 +1125,28 @@ unsafe extern "C" fn decodeCodeBook(
                     }
                     i += 1
                 }
-            } else if cinTable[currentHandle as usize].samplesPerPixel == 4 as i32 as libc::c_long {
+            } else if cinTable[currentHandle as usize].samplesPerPixel == 4 as i32 as isize {
                 ibptr.s = bptr;
-                i = 0 as i32 as libc::c_long;
+                i = 0 as i32 as isize;
                 while i < two {
                     let fresh36 = input;
                     input = input.offset(1);
-                    y0 = *fresh36 as libc::c_long;
+                    y0 = *fresh36 as isize;
                     let fresh37 = input;
                     input = input.offset(1);
-                    y1 = *fresh37 as libc::c_long;
+                    y1 = *fresh37 as isize;
                     let fresh38 = input;
                     input = input.offset(1);
-                    y2 = *fresh38 as libc::c_long;
+                    y2 = *fresh38 as isize;
                     let fresh39 = input;
                     input = input.offset(1);
-                    y3 = *fresh39 as libc::c_long;
+                    y3 = *fresh39 as isize;
                     let fresh40 = input;
                     input = input.offset(1);
-                    cr = *fresh40 as libc::c_long;
+                    cr = *fresh40 as isize;
                     let fresh41 = input;
                     input = input.offset(1);
-                    cb = *fresh41 as libc::c_long;
+                    cb = *fresh41 as isize;
                     let fresh42 = ibptr.i;
                     ibptr.i = ibptr.i.offset(1);
                     *fresh42 = yuv_to_rgb24(y0, cr, cb);
@@ -1163,7 +1163,7 @@ unsafe extern "C" fn decodeCodeBook(
                 }
                 icptr.s = vq4.as_mut_ptr();
                 idptr.s = vq8.as_mut_ptr();
-                i = 0 as i32 as libc::c_long;
+                i = 0 as i32 as isize;
                 while i < four {
                     iaptr.s = vq2.as_mut_ptr();
                     let fresh46 = input;
@@ -1173,8 +1173,8 @@ unsafe extern "C" fn decodeCodeBook(
                     let fresh47 = input;
                     input = input.offset(1);
                     ibptr.i = ibptr.i.offset((*fresh47 as i32 * 4 as i32) as isize);
-                    j = 0 as i32 as libc::c_long;
-                    while j < 2 as i32 as libc::c_long {
+                    j = 0 as i32 as isize;
+                    while j < 2 as i32 as isize {
                         let fresh48 = icptr.i;
                         icptr.i = icptr.i.offset(1);
                         *fresh48 = *iaptr.i.offset(0 as i32 as isize);
@@ -1241,9 +1241,9 @@ unsafe extern "C" fn decodeCodeBook(
                     }
                     i += 1
                 }
-            } else if cinTable[currentHandle as usize].samplesPerPixel == 1 as i32 as libc::c_long {
+            } else if cinTable[currentHandle as usize].samplesPerPixel == 1 as i32 as isize {
                 bbptr = bptr as *mut crate::src::qcommon::q_shared::byte;
-                i = 0 as i32 as libc::c_long;
+                i = 0 as i32 as isize;
                 while i < two {
                     let fresh68 = input;
                     input = input.offset(1);
@@ -1276,7 +1276,7 @@ unsafe extern "C" fn decodeCodeBook(
                 }
                 bcptr = vq4.as_mut_ptr() as *mut crate::src::qcommon::q_shared::byte;
                 bdptr = vq8.as_mut_ptr() as *mut crate::src::qcommon::q_shared::byte;
-                i = 0 as i32 as libc::c_long;
+                i = 0 as i32 as isize;
                 while i < four {
                     let fresh75 = input;
                     input = input.offset(1);
@@ -1286,8 +1286,8 @@ unsafe extern "C" fn decodeCodeBook(
                     input = input.offset(1);
                     bbptr = (vq2.as_mut_ptr() as *mut crate::src::qcommon::q_shared::byte)
                         .offset((*fresh76 as i32 * 4 as i32) as isize);
-                    j = 0 as i32 as libc::c_long;
-                    while j < 2 as i32 as libc::c_long {
+                    j = 0 as i32 as isize;
+                    while j < 2 as i32 as isize {
                         let fresh77 = bcptr;
                         bcptr = bcptr.offset(1);
                         *fresh77 = *baptr.offset(0 as i32 as isize);
@@ -1355,27 +1355,27 @@ unsafe extern "C" fn decodeCodeBook(
                     i += 1
                 }
             }
-        } else if cinTable[currentHandle as usize].samplesPerPixel == 2 as i32 as libc::c_long {
-            i = 0 as i32 as libc::c_long;
+        } else if cinTable[currentHandle as usize].samplesPerPixel == 2 as i32 as isize {
+            i = 0 as i32 as isize;
             while i < two {
                 let fresh97 = input;
                 input = input.offset(1);
-                y0 = *fresh97 as libc::c_long;
+                y0 = *fresh97 as isize;
                 let fresh98 = input;
                 input = input.offset(1);
-                y1 = *fresh98 as libc::c_long;
+                y1 = *fresh98 as isize;
                 let fresh99 = input;
                 input = input.offset(1);
-                y2 = *fresh99 as libc::c_long;
+                y2 = *fresh99 as isize;
                 let fresh100 = input;
                 input = input.offset(1);
-                y3 = *fresh100 as libc::c_long;
+                y3 = *fresh100 as isize;
                 let fresh101 = input;
                 input = input.offset(1);
-                cr = *fresh101 as libc::c_long;
+                cr = *fresh101 as isize;
                 let fresh102 = input;
                 input = input.offset(1);
-                cb = *fresh102 as libc::c_long;
+                cb = *fresh102 as isize;
                 let fresh103 = bptr;
                 bptr = bptr.offset(1);
                 *fresh103 = yuv_to_rgb(y0, cr, cb);
@@ -1385,28 +1385,28 @@ unsafe extern "C" fn decodeCodeBook(
                 let fresh105 = bptr;
                 bptr = bptr.offset(1);
                 *fresh105 = yuv_to_rgb(
-                    (y0 * 3 as i32 as libc::c_long + y2) / 4 as i32 as libc::c_long,
+                    (y0 * 3 as i32 as isize + y2) / 4 as i32 as isize,
                     cr,
                     cb,
                 );
                 let fresh106 = bptr;
                 bptr = bptr.offset(1);
                 *fresh106 = yuv_to_rgb(
-                    (y1 * 3 as i32 as libc::c_long + y3) / 4 as i32 as libc::c_long,
+                    (y1 * 3 as i32 as isize + y3) / 4 as i32 as isize,
                     cr,
                     cb,
                 );
                 let fresh107 = bptr;
                 bptr = bptr.offset(1);
                 *fresh107 = yuv_to_rgb(
-                    (y0 + y2 * 3 as i32 as libc::c_long) / 4 as i32 as libc::c_long,
+                    (y0 + y2 * 3 as i32 as isize) / 4 as i32 as isize,
                     cr,
                     cb,
                 );
                 let fresh108 = bptr;
                 bptr = bptr.offset(1);
                 *fresh108 = yuv_to_rgb(
-                    (y1 + y3 * 3 as i32 as libc::c_long) / 4 as i32 as libc::c_long,
+                    (y1 + y3 * 3 as i32 as isize) / 4 as i32 as isize,
                     cr,
                     cb,
                 );
@@ -1420,7 +1420,7 @@ unsafe extern "C" fn decodeCodeBook(
             }
             cptr = vq4.as_mut_ptr();
             dptr = vq8.as_mut_ptr();
-            i = 0 as i32 as libc::c_long;
+            i = 0 as i32 as isize;
             while i < four {
                 let fresh111 = input;
                 input = input.offset(1);
@@ -1432,8 +1432,8 @@ unsafe extern "C" fn decodeCodeBook(
                 bptr = vq2
                     .as_mut_ptr()
                     .offset((*fresh112 as i32 * 8 as i32) as isize);
-                j = 0 as i32 as libc::c_long;
-                while j < 2 as i32 as libc::c_long {
+                j = 0 as i32 as isize;
+                while j < 2 as i32 as isize {
                     let fresh113 = cptr;
                     cptr = cptr.offset(1);
                     *fresh113 = *aptr.offset(0 as i32 as isize);
@@ -1562,28 +1562,28 @@ unsafe extern "C" fn decodeCodeBook(
                 }
                 i += 1
             }
-        } else if cinTable[currentHandle as usize].samplesPerPixel == 4 as i32 as libc::c_long {
+        } else if cinTable[currentHandle as usize].samplesPerPixel == 4 as i32 as isize {
             ibptr.s = bptr;
-            i = 0 as i32 as libc::c_long;
+            i = 0 as i32 as isize;
             while i < two {
                 let fresh153 = input;
                 input = input.offset(1);
-                y0 = *fresh153 as libc::c_long;
+                y0 = *fresh153 as isize;
                 let fresh154 = input;
                 input = input.offset(1);
-                y1 = *fresh154 as libc::c_long;
+                y1 = *fresh154 as isize;
                 let fresh155 = input;
                 input = input.offset(1);
-                y2 = *fresh155 as libc::c_long;
+                y2 = *fresh155 as isize;
                 let fresh156 = input;
                 input = input.offset(1);
-                y3 = *fresh156 as libc::c_long;
+                y3 = *fresh156 as isize;
                 let fresh157 = input;
                 input = input.offset(1);
-                cr = *fresh157 as libc::c_long;
+                cr = *fresh157 as isize;
                 let fresh158 = input;
                 input = input.offset(1);
-                cb = *fresh158 as libc::c_long;
+                cb = *fresh158 as isize;
                 let fresh159 = ibptr.i;
                 ibptr.i = ibptr.i.offset(1);
                 *fresh159 = yuv_to_rgb24(y0, cr, cb);
@@ -1593,28 +1593,28 @@ unsafe extern "C" fn decodeCodeBook(
                 let fresh161 = ibptr.i;
                 ibptr.i = ibptr.i.offset(1);
                 *fresh161 = yuv_to_rgb24(
-                    (y0 * 3 as i32 as libc::c_long + y2) / 4 as i32 as libc::c_long,
+                    (y0 * 3 as i32 as isize + y2) / 4 as i32 as isize,
                     cr,
                     cb,
                 );
                 let fresh162 = ibptr.i;
                 ibptr.i = ibptr.i.offset(1);
                 *fresh162 = yuv_to_rgb24(
-                    (y1 * 3 as i32 as libc::c_long + y3) / 4 as i32 as libc::c_long,
+                    (y1 * 3 as i32 as isize + y3) / 4 as i32 as isize,
                     cr,
                     cb,
                 );
                 let fresh163 = ibptr.i;
                 ibptr.i = ibptr.i.offset(1);
                 *fresh163 = yuv_to_rgb24(
-                    (y0 + y2 * 3 as i32 as libc::c_long) / 4 as i32 as libc::c_long,
+                    (y0 + y2 * 3 as i32 as isize) / 4 as i32 as isize,
                     cr,
                     cb,
                 );
                 let fresh164 = ibptr.i;
                 ibptr.i = ibptr.i.offset(1);
                 *fresh164 = yuv_to_rgb24(
-                    (y1 + y3 * 3 as i32 as libc::c_long) / 4 as i32 as libc::c_long,
+                    (y1 + y3 * 3 as i32 as isize) / 4 as i32 as isize,
                     cr,
                     cb,
                 );
@@ -1628,7 +1628,7 @@ unsafe extern "C" fn decodeCodeBook(
             }
             icptr.s = vq4.as_mut_ptr();
             idptr.s = vq8.as_mut_ptr();
-            i = 0 as i32 as libc::c_long;
+            i = 0 as i32 as isize;
             while i < four {
                 iaptr.s = vq2.as_mut_ptr();
                 let fresh167 = input;
@@ -1638,8 +1638,8 @@ unsafe extern "C" fn decodeCodeBook(
                 let fresh168 = input;
                 input = input.offset(1);
                 ibptr.i = ibptr.i.offset((*fresh168 as i32 * 8 as i32) as isize);
-                j = 0 as i32 as libc::c_long;
-                while j < 2 as i32 as libc::c_long {
+                j = 0 as i32 as isize;
+                while j < 2 as i32 as isize {
                     let fresh169 = icptr.i;
                     icptr.i = icptr.i.offset(1);
                     *fresh169 = *iaptr.i.offset(0 as i32 as isize);
@@ -1768,20 +1768,20 @@ unsafe extern "C" fn decodeCodeBook(
                 }
                 i += 1
             }
-        } else if cinTable[currentHandle as usize].samplesPerPixel == 1 as i32 as libc::c_long {
+        } else if cinTable[currentHandle as usize].samplesPerPixel == 1 as i32 as isize {
             bbptr = bptr as *mut crate::src::qcommon::q_shared::byte;
-            i = 0 as i32 as libc::c_long;
+            i = 0 as i32 as isize;
             while i < two {
                 let fresh209 = input;
                 input = input.offset(1);
-                y0 = *fresh209 as libc::c_long;
+                y0 = *fresh209 as isize;
                 let fresh210 = input;
                 input = input.offset(1);
-                y1 = *fresh210 as libc::c_long;
+                y1 = *fresh210 as isize;
                 let fresh211 = input;
                 input = input.offset(1);
-                y2 = *fresh211 as libc::c_long;
-                y3 = *input as libc::c_long;
+                y2 = *fresh211 as isize;
+                y3 = *input as isize;
                 input = input.offset(3 as i32 as isize);
                 let fresh212 = bbptr;
                 bbptr = bbptr.offset(1);
@@ -1792,22 +1792,22 @@ unsafe extern "C" fn decodeCodeBook(
                 let fresh214 = bbptr;
                 bbptr = bbptr.offset(1);
                 *fresh214 = *cinTable[currentHandle as usize].gray.offset(
-                    ((y0 * 3 as i32 as libc::c_long + y2) / 4 as i32 as libc::c_long) as isize,
+                    ((y0 * 3 as i32 as isize + y2) / 4 as i32 as isize) as isize,
                 );
                 let fresh215 = bbptr;
                 bbptr = bbptr.offset(1);
                 *fresh215 = *cinTable[currentHandle as usize].gray.offset(
-                    ((y1 * 3 as i32 as libc::c_long + y3) / 4 as i32 as libc::c_long) as isize,
+                    ((y1 * 3 as i32 as isize + y3) / 4 as i32 as isize) as isize,
                 );
                 let fresh216 = bbptr;
                 bbptr = bbptr.offset(1);
                 *fresh216 = *cinTable[currentHandle as usize].gray.offset(
-                    ((y0 + y2 * 3 as i32 as libc::c_long) / 4 as i32 as libc::c_long) as isize,
+                    ((y0 + y2 * 3 as i32 as isize) / 4 as i32 as isize) as isize,
                 );
                 let fresh217 = bbptr;
                 bbptr = bbptr.offset(1);
                 *fresh217 = *cinTable[currentHandle as usize].gray.offset(
-                    ((y1 + y3 * 3 as i32 as libc::c_long) / 4 as i32 as libc::c_long) as isize,
+                    ((y1 + y3 * 3 as i32 as isize) / 4 as i32 as isize) as isize,
                 );
                 let fresh218 = bbptr;
                 bbptr = bbptr.offset(1);
@@ -1819,7 +1819,7 @@ unsafe extern "C" fn decodeCodeBook(
             }
             bcptr = vq4.as_mut_ptr() as *mut crate::src::qcommon::q_shared::byte;
             bdptr = vq8.as_mut_ptr() as *mut crate::src::qcommon::q_shared::byte;
-            i = 0 as i32 as libc::c_long;
+            i = 0 as i32 as isize;
             while i < four {
                 let fresh220 = input;
                 input = input.offset(1);
@@ -1829,8 +1829,8 @@ unsafe extern "C" fn decodeCodeBook(
                 input = input.offset(1);
                 bbptr = (vq2.as_mut_ptr() as *mut crate::src::qcommon::q_shared::byte)
                     .offset((*fresh221 as i32 * 8 as i32) as isize);
-                j = 0 as i32 as libc::c_long;
-                while j < 2 as i32 as libc::c_long {
+                j = 0 as i32 as isize;
+                while j < 2 as i32 as isize {
                     let fresh222 = bcptr;
                     bcptr = bcptr.offset(1);
                     *fresh222 = *baptr.offset(0 as i32 as isize);
@@ -1960,19 +1960,19 @@ unsafe extern "C" fn decodeCodeBook(
                 i += 1
             }
         }
-    } else if cinTable[currentHandle as usize].samplesPerPixel == 2 as i32 as libc::c_long {
-        i = 0 as i32 as libc::c_long;
+    } else if cinTable[currentHandle as usize].samplesPerPixel == 2 as i32 as isize {
+        i = 0 as i32 as isize;
         while i < two {
-            y0 = *input as libc::c_long;
+            y0 = *input as isize;
             input = input.offset(2 as i32 as isize);
-            y2 = *input as libc::c_long;
+            y2 = *input as isize;
             input = input.offset(2 as i32 as isize);
             let fresh262 = input;
             input = input.offset(1);
-            cr = *fresh262 as libc::c_long;
+            cr = *fresh262 as isize;
             let fresh263 = input;
             input = input.offset(1);
-            cb = *fresh263 as libc::c_long;
+            cb = *fresh263 as isize;
             let fresh264 = bptr;
             bptr = bptr.offset(1);
             *fresh264 = yuv_to_rgb(y0, cr, cb);
@@ -1983,7 +1983,7 @@ unsafe extern "C" fn decodeCodeBook(
         }
         cptr = vq4.as_mut_ptr();
         dptr = vq8.as_mut_ptr();
-        i = 0 as i32 as libc::c_long;
+        i = 0 as i32 as isize;
         while i < four {
             let fresh266 = input;
             input = input.offset(1);
@@ -1995,8 +1995,8 @@ unsafe extern "C" fn decodeCodeBook(
             bptr = vq2
                 .as_mut_ptr()
                 .offset((*fresh267 as i32 * 2 as i32) as isize);
-            j = 0 as i32 as libc::c_long;
-            while j < 2 as i32 as libc::c_long {
+            j = 0 as i32 as isize;
+            while j < 2 as i32 as isize {
                 let fresh268 = cptr;
                 cptr = cptr.offset(1);
                 *fresh268 = *aptr;
@@ -2033,9 +2033,9 @@ unsafe extern "C" fn decodeCodeBook(
             }
             i += 1
         }
-    } else if cinTable[currentHandle as usize].samplesPerPixel == 1 as i32 as libc::c_long {
+    } else if cinTable[currentHandle as usize].samplesPerPixel == 1 as i32 as isize {
         bbptr = bptr as *mut crate::src::qcommon::q_shared::byte;
-        i = 0 as i32 as libc::c_long;
+        i = 0 as i32 as isize;
         while i < two {
             let fresh278 = bbptr;
             bbptr = bbptr.offset(1);
@@ -2053,7 +2053,7 @@ unsafe extern "C" fn decodeCodeBook(
         }
         bcptr = vq4.as_mut_ptr() as *mut crate::src::qcommon::q_shared::byte;
         bdptr = vq8.as_mut_ptr() as *mut crate::src::qcommon::q_shared::byte;
-        i = 0 as i32 as libc::c_long;
+        i = 0 as i32 as isize;
         while i < four {
             let fresh280 = input;
             input = input.offset(1);
@@ -2063,8 +2063,8 @@ unsafe extern "C" fn decodeCodeBook(
             input = input.offset(1);
             bbptr = (vq2.as_mut_ptr() as *mut crate::src::qcommon::q_shared::byte)
                 .offset((*fresh281 as i32 * 2 as i32) as isize);
-            j = 0 as i32 as libc::c_long;
-            while j < 2 as i32 as libc::c_long {
+            j = 0 as i32 as isize;
+            while j < 2 as i32 as isize {
                 let fresh282 = bcptr;
                 bcptr = bcptr.offset(1);
                 *fresh282 = *baptr;
@@ -2101,20 +2101,20 @@ unsafe extern "C" fn decodeCodeBook(
             }
             i += 1
         }
-    } else if cinTable[currentHandle as usize].samplesPerPixel == 4 as i32 as libc::c_long {
+    } else if cinTable[currentHandle as usize].samplesPerPixel == 4 as i32 as isize {
         ibptr.s = bptr;
-        i = 0 as i32 as libc::c_long;
+        i = 0 as i32 as isize;
         while i < two {
-            y0 = *input as libc::c_long;
+            y0 = *input as isize;
             input = input.offset(2 as i32 as isize);
-            y2 = *input as libc::c_long;
+            y2 = *input as isize;
             input = input.offset(2 as i32 as isize);
             let fresh292 = input;
             input = input.offset(1);
-            cr = *fresh292 as libc::c_long;
+            cr = *fresh292 as isize;
             let fresh293 = input;
             input = input.offset(1);
-            cb = *fresh293 as libc::c_long;
+            cb = *fresh293 as isize;
             let fresh294 = ibptr.i;
             ibptr.i = ibptr.i.offset(1);
             *fresh294 = yuv_to_rgb24(y0, cr, cb);
@@ -2125,7 +2125,7 @@ unsafe extern "C" fn decodeCodeBook(
         }
         icptr.s = vq4.as_mut_ptr();
         idptr.s = vq8.as_mut_ptr();
-        i = 0 as i32 as libc::c_long;
+        i = 0 as i32 as isize;
         while i < four {
             iaptr.s = vq2.as_mut_ptr();
             let fresh296 = input;
@@ -2139,8 +2139,8 @@ unsafe extern "C" fn decodeCodeBook(
             let fresh298 = input;
             input = input.offset(1);
             ibptr.i = ibptr.i.offset((*fresh298 as i32 * 2 as i32) as isize);
-            j = 0 as i32 as libc::c_long;
-            while j < 2 as i32 as libc::c_long {
+            j = 0 as i32 as isize;
+            while j < 2 as i32 as isize {
                 let fresh299 = icptr.i;
                 icptr.i = icptr.i.offset(1);
                 *fresh299 = *iaptr.i;
@@ -2194,36 +2194,36 @@ unsafe extern "C" fn decodeCodeBook(
 ******************************************************************************/
 
 unsafe extern "C" fn recurseQuad(
-    mut startX: libc::c_long,
-    mut startY: libc::c_long,
-    mut quadSize: libc::c_long,
-    mut xOff: libc::c_long,
-    mut yOff: libc::c_long,
+    mut startX: isize,
+    mut startY: isize,
+    mut quadSize: isize,
+    mut xOff: isize,
+    mut yOff: isize,
 ) {
     let mut scroff: *mut crate::src::qcommon::q_shared::byte =
         0 as *mut crate::src::qcommon::q_shared::byte;
-    let mut bigx: libc::c_long = 0;
-    let mut bigy: libc::c_long = 0;
-    let mut lowx: libc::c_long = 0;
-    let mut lowy: libc::c_long = 0;
-    let mut useY: libc::c_long = 0;
-    let mut offset: libc::c_long = 0;
+    let mut bigx: isize = 0;
+    let mut bigy: isize = 0;
+    let mut lowx: isize = 0;
+    let mut lowy: isize = 0;
+    let mut useY: isize = 0;
+    let mut offset: isize = 0;
     offset = cinTable[currentHandle as usize].screenDelta;
-    lowy = 0 as i32 as libc::c_long;
+    lowy = 0 as i32 as isize;
     lowx = lowy;
-    bigx = cinTable[currentHandle as usize].xsize as libc::c_long;
-    bigy = cinTable[currentHandle as usize].ysize as libc::c_long;
-    if bigx > cinTable[currentHandle as usize].CIN_WIDTH as libc::c_long {
-        bigx = cinTable[currentHandle as usize].CIN_WIDTH as libc::c_long
+    bigx = cinTable[currentHandle as usize].xsize as isize;
+    bigy = cinTable[currentHandle as usize].ysize as isize;
+    if bigx > cinTable[currentHandle as usize].CIN_WIDTH as isize {
+        bigx = cinTable[currentHandle as usize].CIN_WIDTH as isize
     }
-    if bigy > cinTable[currentHandle as usize].CIN_HEIGHT as libc::c_long {
-        bigy = cinTable[currentHandle as usize].CIN_HEIGHT as libc::c_long
+    if bigy > cinTable[currentHandle as usize].CIN_HEIGHT as isize {
+        bigy = cinTable[currentHandle as usize].CIN_HEIGHT as isize
     }
     if startX >= lowx
         && startX + quadSize <= bigx
         && startY + quadSize <= bigy
         && startY >= lowy
-        && quadSize <= 8 as i32 as libc::c_long
+        && quadSize <= 8 as i32 as isize
     {
         useY = startY;
         scroff = cin
@@ -2231,7 +2231,7 @@ unsafe extern "C" fn recurseQuad(
             .as_mut_ptr()
             .offset(
                 ((useY
-                    + (cinTable[currentHandle as usize].CIN_HEIGHT as libc::c_long - bigy
+                    + (cinTable[currentHandle as usize].CIN_HEIGHT as isize - bigy
                         >> 1 as i32)
                     + yOff)
                     * cinTable[currentHandle as usize].samplesPerLine) as isize,
@@ -2242,7 +2242,7 @@ unsafe extern "C" fn recurseQuad(
         cinTable[currentHandle as usize].onQuad = cinTable[currentHandle as usize].onQuad + 1;
         cin.qStatus[1 as i32 as usize][fresh309 as usize] = scroff.offset(offset as isize)
     }
-    if quadSize != 4 as i32 as libc::c_long {
+    if quadSize != 4 as i32 as isize {
         quadSize >>= 1 as i32;
         recurseQuad(startX, startY, quadSize, xOff, yOff);
         recurseQuad(startX + quadSize, startY, quadSize, xOff, yOff);
@@ -2258,42 +2258,42 @@ unsafe extern "C" fn recurseQuad(
 *
 ******************************************************************************/
 
-unsafe extern "C" fn setupQuad(mut xOff: libc::c_long, mut yOff: libc::c_long) {
-    let mut numQuadCels: libc::c_long = 0; // for overflow
-    let mut i: libc::c_long = 0; // eoq
-    let mut x: libc::c_long = 0;
-    let mut y: libc::c_long = 0;
+unsafe extern "C" fn setupQuad(mut xOff: isize, mut yOff: isize) {
+    let mut numQuadCels: isize = 0; // for overflow
+    let mut i: isize = 0; // eoq
+    let mut x: isize = 0;
+    let mut y: isize = 0;
     let mut temp: *mut crate::src::qcommon::q_shared::byte =
         0 as *mut crate::src::qcommon::q_shared::byte;
     if xOff == cin.oldXOff
         && yOff == cin.oldYOff
-        && cinTable[currentHandle as usize].ysize as libc::c_long == cin.oldysize
-        && cinTable[currentHandle as usize].xsize as libc::c_long == cin.oldxsize
+        && cinTable[currentHandle as usize].ysize as isize == cin.oldysize
+        && cinTable[currentHandle as usize].xsize as isize == cin.oldxsize
     {
         return;
     }
     cin.oldXOff = xOff;
     cin.oldYOff = yOff;
-    cin.oldysize = cinTable[currentHandle as usize].ysize as libc::c_long;
-    cin.oldxsize = cinTable[currentHandle as usize].xsize as libc::c_long;
+    cin.oldysize = cinTable[currentHandle as usize].ysize as isize;
+    cin.oldxsize = cinTable[currentHandle as usize].xsize as isize;
     numQuadCels = cinTable[currentHandle as usize]
         .xsize
         .wrapping_mul(cinTable[currentHandle as usize].ysize)
-        .wrapping_div(16 as i32 as u32) as libc::c_long;
-    numQuadCels += numQuadCels / 4 as i32 as libc::c_long;
-    numQuadCels += 64 as i32 as libc::c_long;
-    cinTable[currentHandle as usize].onQuad = 0 as i32 as libc::c_long;
-    y = 0 as i32 as libc::c_long;
-    while y < cinTable[currentHandle as usize].ysize as libc::c_long {
-        x = 0 as i32 as libc::c_long;
-        while x < cinTable[currentHandle as usize].xsize as libc::c_long {
-            recurseQuad(x, y, 16 as i32 as libc::c_long, xOff, yOff);
-            x += 16 as i32 as libc::c_long
+        .wrapping_div(16 as i32 as u32) as isize;
+    numQuadCels += numQuadCels / 4 as i32 as isize;
+    numQuadCels += 64 as i32 as isize;
+    cinTable[currentHandle as usize].onQuad = 0 as i32 as isize;
+    y = 0 as i32 as isize;
+    while y < cinTable[currentHandle as usize].ysize as isize {
+        x = 0 as i32 as isize;
+        while x < cinTable[currentHandle as usize].xsize as isize {
+            recurseQuad(x, y, 16 as i32 as isize, xOff, yOff);
+            x += 16 as i32 as isize
         }
-        y += 16 as i32 as libc::c_long
+        y += 16 as i32 as isize
     }
     temp = 0 as *mut crate::src::qcommon::q_shared::byte;
-    i = numQuadCels - 64 as i32 as libc::c_long;
+    i = numQuadCels - 64 as i32 as isize;
     while i < numQuadCels {
         cin.qStatus[0 as i32 as usize][i as usize] = temp;
         cin.qStatus[1 as i32 as usize][i as usize] = temp;
@@ -2328,10 +2328,10 @@ unsafe extern "C" fn readQuadInfo(mut qData: *mut crate::src::qcommon::q_shared:
     cinTable[currentHandle as usize].CIN_HEIGHT = cinTable[currentHandle as usize].ysize as i32;
     cinTable[currentHandle as usize].CIN_WIDTH = cinTable[currentHandle as usize].xsize as i32;
     cinTable[currentHandle as usize].samplesPerLine = cinTable[currentHandle as usize].CIN_WIDTH
-        as libc::c_long
+        as isize
         * cinTable[currentHandle as usize].samplesPerPixel;
     cinTable[currentHandle as usize].screenDelta = cinTable[currentHandle as usize].CIN_HEIGHT
-        as libc::c_long
+        as isize
         * cinTable[currentHandle as usize].samplesPerLine;
     cinTable[currentHandle as usize].half = crate::src::qcommon::q_shared::qfalse;
     cinTable[currentHandle as usize].smootheddouble = crate::src::qcommon::q_shared::qfalse;
@@ -2342,19 +2342,19 @@ unsafe extern "C" fn readQuadInfo(mut qData: *mut crate::src::qcommon::q_shared:
     cinTable[currentHandle as usize].t[1 as i32 as usize] =
         -cinTable[currentHandle as usize].screenDelta;
     cinTable[currentHandle as usize].drawX =
-        cinTable[currentHandle as usize].CIN_WIDTH as libc::c_long;
+        cinTable[currentHandle as usize].CIN_WIDTH as isize;
     cinTable[currentHandle as usize].drawY =
-        cinTable[currentHandle as usize].CIN_HEIGHT as libc::c_long;
+        cinTable[currentHandle as usize].CIN_HEIGHT as isize;
     // rage pro is very slow at 512 wide textures, voodoo can't do it at all
     if crate::src::client::cl_main::cls.glconfig.hardwareType as u32
         == crate::tr_types_h::GLHW_RAGEPRO as i32 as u32
         || crate::src::client::cl_main::cls.glconfig.maxTextureSize <= 256 as i32
     {
-        if cinTable[currentHandle as usize].drawX > 256 as i32 as libc::c_long {
-            cinTable[currentHandle as usize].drawX = 256 as i32 as libc::c_long
+        if cinTable[currentHandle as usize].drawX > 256 as i32 as isize {
+            cinTable[currentHandle as usize].drawX = 256 as i32 as isize
         }
-        if cinTable[currentHandle as usize].drawY > 256 as i32 as libc::c_long {
-            cinTable[currentHandle as usize].drawY = 256 as i32 as libc::c_long
+        if cinTable[currentHandle as usize].drawY > 256 as i32 as isize {
+            cinTable[currentHandle as usize].drawY = 256 as i32 as isize
         }
         if cinTable[currentHandle as usize].CIN_WIDTH != 256 as i32
             || cinTable[currentHandle as usize].CIN_HEIGHT != 256 as i32
@@ -2374,13 +2374,13 @@ unsafe extern "C" fn readQuadInfo(mut qData: *mut crate::src::qcommon::q_shared:
 *
 ******************************************************************************/
 
-unsafe extern "C" fn RoQPrepMcomp(mut xoff: libc::c_long, mut yoff: libc::c_long) {
-    let mut i: libc::c_long = 0;
-    let mut j: libc::c_long = 0;
-    let mut x: libc::c_long = 0;
-    let mut y: libc::c_long = 0;
-    let mut temp: libc::c_long = 0;
-    let mut temp2: libc::c_long = 0;
+unsafe extern "C" fn RoQPrepMcomp(mut xoff: isize, mut yoff: isize) {
+    let mut i: isize = 0;
+    let mut j: isize = 0;
+    let mut x: isize = 0;
+    let mut y: isize = 0;
+    let mut temp: isize = 0;
+    let mut temp2: isize = 0;
     i = cinTable[currentHandle as usize].samplesPerLine;
     j = cinTable[currentHandle as usize].samplesPerPixel;
     if cinTable[currentHandle as usize].xsize
@@ -2392,13 +2392,13 @@ unsafe extern "C" fn RoQPrepMcomp(mut xoff: libc::c_long, mut yoff: libc::c_long
         j = j + j;
         i = i + i
     }
-    y = 0 as i32 as libc::c_long;
-    while y < 16 as i32 as libc::c_long {
-        temp2 = (y + yoff - 8 as i32 as libc::c_long) * i;
-        x = 0 as i32 as libc::c_long;
-        while x < 16 as i32 as libc::c_long {
-            temp = (x + xoff - 8 as i32 as libc::c_long) * j;
-            cin.mcomp[(x * 16 as i32 as libc::c_long + y) as usize] =
+    y = 0 as i32 as isize;
+    while y < 16 as i32 as isize {
+        temp2 = (y + yoff - 8 as i32 as isize) * i;
+        x = 0 as i32 as isize;
+        while x < 16 as i32 as isize {
+            temp = (x + xoff - 8 as i32 as isize) * j;
+            cin.mcomp[(x * 16 as i32 as isize + y) as usize] =
                 (cinTable[currentHandle as usize].normalBuffer0 - (temp2 + temp)) as i32;
             x += 1
         }
@@ -2457,7 +2457,7 @@ unsafe extern "C" fn initRoQ() {
                 _: *mut u8,
             ) -> (),
     ));
-    cinTable[currentHandle as usize].samplesPerPixel = 4 as i32 as libc::c_long;
+    cinTable[currentHandle as usize].samplesPerPixel = 4 as i32 as isize;
     ROQ_GenYUVTables();
     RllSetupTable();
 }
@@ -2549,7 +2549,7 @@ unsafe extern "C" fn RoQInterrupt() {
     {
         match cinTable[currentHandle as usize].roq_id {
             4113 => {
-                if cinTable[currentHandle as usize].numQuads & 1 as i32 as libc::c_long != 0 {
+                if cinTable[currentHandle as usize].numQuads & 1 as i32 as isize != 0 {
                     cinTable[currentHandle as usize].normalBuffer0 =
                         cinTable[currentHandle as usize].t[1 as i32 as usize];
                     RoQPrepMcomp(
@@ -2583,7 +2583,7 @@ unsafe extern "C" fn RoQInterrupt() {
                     );
                     cinTable[currentHandle as usize].buf = cin.linbuf.as_mut_ptr()
                 }
-                if cinTable[currentHandle as usize].numQuads == 0 as i32 as libc::c_long {
+                if cinTable[currentHandle as usize].numQuads == 0 as i32 as isize {
                     // first frame
                     crate::stdlib::memcpy(
                         cin.linbuf
@@ -2592,7 +2592,7 @@ unsafe extern "C" fn RoQInterrupt() {
                             as *mut libc::c_void,
                         cin.linbuf.as_mut_ptr() as *const libc::c_void,
                         (cinTable[currentHandle as usize].samplesPerLine
-                            * cinTable[currentHandle as usize].ysize as libc::c_long)
+                            * cinTable[currentHandle as usize].ysize as isize)
                             as libc::c_ulong,
                     ); // for header
                 }
@@ -2625,7 +2625,7 @@ unsafe extern "C" fn RoQInterrupt() {
             }
             4129 => {
                 if cinTable[currentHandle as usize].silent as u64 == 0 {
-                    if cinTable[currentHandle as usize].numQuads == -(1 as i32) as libc::c_long {
+                    if cinTable[currentHandle as usize].numQuads == -(1 as i32) as isize {
                         crate::src::client::snd_main::S_Update();
                         crate::src::client::snd_dma::s_rawend[0 as i32 as usize] = s_soundtime
                     }
@@ -2649,15 +2649,15 @@ unsafe extern "C" fn RoQInterrupt() {
                 }
             }
             4097 => {
-                if cinTable[currentHandle as usize].numQuads == -(1 as i32) as libc::c_long {
+                if cinTable[currentHandle as usize].numQuads == -(1 as i32) as isize {
                     readQuadInfo(framedata);
-                    setupQuad(0 as i32 as libc::c_long, 0 as i32 as libc::c_long);
+                    setupQuad(0 as i32 as isize, 0 as i32 as isize);
                     cinTable[currentHandle as usize].lastTime = CL_ScaledMilliseconds();
                     cinTable[currentHandle as usize].startTime =
                         cinTable[currentHandle as usize].lastTime
                 }
-                if cinTable[currentHandle as usize].numQuads != 1 as i32 as libc::c_long {
-                    cinTable[currentHandle as usize].numQuads = 0 as i32 as libc::c_long
+                if cinTable[currentHandle as usize].numQuads != 1 as i32 as isize {
+                    cinTable[currentHandle as usize].numQuads = 0 as i32 as isize
                 }
             }
             4144 => {
@@ -2697,11 +2697,11 @@ unsafe extern "C" fn RoQInterrupt() {
                 + *framedata.offset(4 as i32 as isize) as i32 * 65536 as i32) as u32;
         cinTable[currentHandle as usize].roq_flags = (*framedata.offset(6 as i32 as isize) as i32
             + *framedata.offset(7 as i32 as isize) as i32 * 256 as i32)
-            as libc::c_long;
+            as isize;
         cinTable[currentHandle as usize].roqF0 =
-            *framedata.offset(7 as i32 as isize) as i8 as libc::c_long;
+            *framedata.offset(7 as i32 as isize) as i8 as isize;
         cinTable[currentHandle as usize].roqF1 =
-            *framedata.offset(6 as i32 as isize) as i8 as libc::c_long;
+            *framedata.offset(6 as i32 as isize) as i8 as isize;
         if cinTable[currentHandle as usize].RoQFrameSize > 65536 as i32 as u32
             || cinTable[currentHandle as usize].roq_id == 0x1084 as i32 as u32
         {
@@ -2731,7 +2731,7 @@ unsafe extern "C" fn RoQInterrupt() {
     cinTable[currentHandle as usize].RoQPlayed += cinTable[currentHandle as usize]
         .RoQFrameSize
         .wrapping_add(8 as i32 as u32)
-        as libc::c_long;
+        as isize;
 }
 /* *****************************************************************************
 *
@@ -2744,15 +2744,15 @@ unsafe extern "C" fn RoQInterrupt() {
 unsafe extern "C" fn RoQ_init() {
     cinTable[currentHandle as usize].lastTime = CL_ScaledMilliseconds();
     cinTable[currentHandle as usize].startTime = cinTable[currentHandle as usize].lastTime;
-    cinTable[currentHandle as usize].RoQPlayed = 24 as i32 as libc::c_long;
+    cinTable[currentHandle as usize].RoQPlayed = 24 as i32 as isize;
     /*	get frame rate */
     cinTable[currentHandle as usize].roqFPS = (cin.file[6 as i32 as usize] as i32
         + cin.file[7 as i32 as usize] as i32 * 256 as i32)
-        as libc::c_long;
+        as isize;
     if cinTable[currentHandle as usize].roqFPS == 0 {
-        cinTable[currentHandle as usize].roqFPS = 30 as i32 as libc::c_long
+        cinTable[currentHandle as usize].roqFPS = 30 as i32 as isize
     }
-    cinTable[currentHandle as usize].numQuads = -(1 as i32) as libc::c_long;
+    cinTable[currentHandle as usize].numQuads = -(1 as i32) as isize;
     cinTable[currentHandle as usize].roq_id = (cin.file[8 as i32 as usize] as i32
         + cin.file[9 as i32 as usize] as i32 * 256 as i32)
         as u32;
@@ -2762,7 +2762,7 @@ unsafe extern "C" fn RoQ_init() {
         as u32;
     cinTable[currentHandle as usize].roq_flags = (cin.file[14 as i32 as usize] as i32
         + cin.file[15 as i32 as usize] as i32 * 256 as i32)
-        as libc::c_long;
+        as isize;
     if cinTable[currentHandle as usize].RoQFrameSize > 65536 as i32 as u32
         || cinTable[currentHandle as usize].RoQFrameSize == 0
     {
@@ -2910,7 +2910,7 @@ pub unsafe extern "C" fn CIN_RunCinematic(
     }
     cinTable[currentHandle as usize].tfps =
         ((CL_ScaledMilliseconds() - cinTable[currentHandle as usize].startTime) * 3 as i32
-            / 100 as i32) as libc::c_long;
+            / 100 as i32) as isize;
     start = cinTable[currentHandle as usize].startTime;
     while cinTable[currentHandle as usize].tfps != cinTable[currentHandle as usize].numQuads
         && cinTable[currentHandle as usize].status as u32
@@ -2920,7 +2920,7 @@ pub unsafe extern "C" fn CIN_RunCinematic(
         if start != cinTable[currentHandle as usize].startTime {
             cinTable[currentHandle as usize].tfps =
                 ((CL_ScaledMilliseconds() - cinTable[currentHandle as usize].startTime) * 3 as i32
-                    / 100 as i32) as libc::c_long;
+                    / 100 as i32) as isize;
             start = cinTable[currentHandle as usize].startTime
         }
     }
@@ -3005,13 +3005,13 @@ pub unsafe extern "C" fn CIN_PlayCinematic(
         cinTable[currentHandle as usize].fileName.as_mut_ptr(),
         name.as_mut_ptr(),
     );
-    cinTable[currentHandle as usize].ROQSize = 0 as i32 as libc::c_long;
+    cinTable[currentHandle as usize].ROQSize = 0 as i32 as isize;
     cinTable[currentHandle as usize].ROQSize = crate::src::qcommon::files::FS_FOpenFileRead(
         cinTable[currentHandle as usize].fileName.as_mut_ptr(),
         &mut (*cinTable.as_mut_ptr().offset(currentHandle as isize)).iFile,
         crate::src::qcommon::q_shared::qtrue,
     );
-    if cinTable[currentHandle as usize].ROQSize <= 0 as i32 as libc::c_long {
+    if cinTable[currentHandle as usize].ROQSize <= 0 as i32 as isize {
         crate::src::qcommon::common::Com_DPrintf(
             b"play(%s), ROQSize<=0\n\x00" as *const u8 as *const libc::c_char,
             arg,
@@ -3242,8 +3242,8 @@ pub unsafe extern "C" fn CIN_DrawCinematic(mut handle: i32) {
     buf = cinTable[handle as usize].buf;
     crate::src::client::cl_scrn::SCR_AdjustFrom640(&mut x, &mut y, &mut w, &mut h);
     if cinTable[handle as usize].dirty as u32 != 0
-        && (cinTable[handle as usize].CIN_WIDTH as libc::c_long != cinTable[handle as usize].drawX
-            || cinTable[handle as usize].CIN_HEIGHT as libc::c_long
+        && (cinTable[handle as usize].CIN_WIDTH as isize != cinTable[handle as usize].drawX
+            || cinTable[handle as usize].CIN_HEIGHT as isize
                 != cinTable[handle as usize].drawY)
     {
         let mut buf2: *mut i32 = 0 as *mut i32;
@@ -3568,9 +3568,9 @@ pub unsafe extern "C" fn CIN_UploadCinematic(mut handle: i32) {
         }
         // Resample the video if needed
         if cinTable[handle as usize].dirty as u32 != 0
-            && (cinTable[handle as usize].CIN_WIDTH as libc::c_long
+            && (cinTable[handle as usize].CIN_WIDTH as isize
                 != cinTable[handle as usize].drawX
-                || cinTable[handle as usize].CIN_HEIGHT as libc::c_long
+                || cinTable[handle as usize].CIN_HEIGHT as isize
                     != cinTable[handle as usize].drawY)
         {
             let mut buf2: *mut i32 = 0 as *mut i32;

--- a/quake3-rs/ioquake3/src/client/cl_curl.rs
+++ b/quake3-rs/ioquake3/src/client/cl_curl.rs
@@ -943,7 +943,7 @@ pub unsafe extern "C" fn qcurl_easy_setopt_warn(
     let mut argp: ::std::ffi::VaListImpl;
     argp = args.clone();
     if (option as u32) < 10000 as i32 as u32 {
-        let mut longValue: libc::c_long = argp.as_va_list().arg::<libc::c_long>();
+        let mut longValue: isize = argp.as_va_list().arg::<isize>();
         result = qcurl_easy_setopt.expect("non-null function pointer")(curl, option, longValue)
     } else if (option as u32) < 30000 as i32 as u32 {
         let mut pointerValue: *mut libc::c_void = argp.as_va_list().arg::<*mut libc::c_void>();
@@ -1249,11 +1249,11 @@ pub unsafe extern "C" fn CL_cURL_PerformDownload() {
         );
         crate::src::client::cl_main::clc.downloadRestart = crate::src::qcommon::q_shared::qtrue
     } else {
-        let mut code: libc::c_long = 0;
+        let mut code: isize = 0;
         qcurl_easy_getinfo.expect("non-null function pointer")(
             (*msg).easy_handle,
             crate::curl_h::CURLINFO_RESPONSE_CODE,
-            &mut code as *mut libc::c_long,
+            &mut code as *mut isize,
         );
         crate::src::qcommon::common::Com_Error(
             crate::src::qcommon::q_shared::ERR_DROP as i32,

--- a/quake3-rs/ioquake3/src/client/cl_keys.rs
+++ b/quake3-rs/ioquake3/src/client/cl_keys.rs
@@ -4150,7 +4150,7 @@ pub unsafe extern "C" fn CL_LoadConsoleHistory() {
             text_p = text_p.offset(1);
             if numChars as libc::c_ulong
                 > crate::stdlib::strlen(consoleSaveBuffer.as_mut_ptr()).wrapping_sub(
-                    text_p.offset_from(consoleSaveBuffer.as_mut_ptr()) as libc::c_long
+                    text_p.offset_from(consoleSaveBuffer.as_mut_ptr()) as isize
                         as libc::c_ulong,
                 )
             {

--- a/quake3-rs/ioquake3/src/client/cl_main.rs
+++ b/quake3-rs/ioquake3/src/client/cl_main.rs
@@ -2731,7 +2731,7 @@ pub unsafe extern "C" fn CL_PlayDemo_f() {
                 b"Protocol %d not supported for demos\n\x00" as *const u8 as *const libc::c_char,
                 protocol,
             );
-            len = ext_test.offset_from(arg.as_mut_ptr()) as libc::c_long as i32;
+            len = ext_test.offset_from(arg.as_mut_ptr()) as isize as i32;
             if len as libc::c_ulong
                 >= (::std::mem::size_of::<[libc::c_char; 4096]>() as libc::c_ulong)
                     .wrapping_div(::std::mem::size_of::<libc::c_char>() as libc::c_ulong)
@@ -4538,7 +4538,7 @@ pub unsafe extern "C" fn CL_ServersResponsePacket(
         // IPv4 address
         if *buffptr as i32 == '\\' as i32 {
             buffptr = buffptr.offset(1);
-            if (buffend.offset_from(buffptr) as libc::c_long as libc::c_ulong)
+            if (buffend.offset_from(buffptr) as isize as libc::c_ulong)
                 < (::std::mem::size_of::<[crate::src::qcommon::q_shared::byte; 4]>()
                     as libc::c_ulong)
                     .wrapping_add(::std::mem::size_of::<u16>() as libc::c_ulong)
@@ -4562,7 +4562,7 @@ pub unsafe extern "C" fn CL_ServersResponsePacket(
                 break;
             }
             buffptr = buffptr.offset(1);
-            if (buffend.offset_from(buffptr) as libc::c_long as libc::c_ulong)
+            if (buffend.offset_from(buffptr) as isize as libc::c_ulong)
                 < (::std::mem::size_of::<[crate::src::qcommon::q_shared::byte; 16]>()
                     as libc::c_ulong)
                     .wrapping_add(::std::mem::size_of::<u16>() as libc::c_ulong)
@@ -5580,7 +5580,7 @@ pub unsafe extern "C" fn CL_InitRef() {
             as unsafe extern "C" fn(
                 _: *const libc::c_char,
                 _: *mut *mut libc::c_void,
-            ) -> libc::c_long,
+            ) -> isize,
     );
     ri.FS_FreeFile = Some(
         crate::src::qcommon::files::FS_FreeFile as unsafe extern "C" fn(_: *mut libc::c_void) -> (),
@@ -5675,7 +5675,7 @@ pub unsafe extern "C" fn CL_InitRef() {
     ri.IN_Shutdown = Some(crate::src::sdl::sdl_input::IN_Shutdown as unsafe extern "C" fn() -> ());
     ri.IN_Restart = Some(crate::src::sdl::sdl_input::IN_Restart as unsafe extern "C" fn() -> ());
     ri.ftol =
-        Some(crate::src::asm::ftola::qftolsse as unsafe extern "C" fn(_: f32) -> libc::c_long);
+        Some(crate::src::asm::ftola::qftolsse as unsafe extern "C" fn(_: f32) -> isize);
     ri.Sys_SetEnv = Some(
         crate::src::sys::sys_unix::Sys_SetEnv
             as unsafe extern "C" fn(_: *const libc::c_char, _: *const libc::c_char) -> (),

--- a/quake3-rs/ioquake3/src/client/cl_net_chan.rs
+++ b/quake3-rs/ioquake3/src/client/cl_net_chan.rs
@@ -157,9 +157,9 @@ CL_Netchan_Decode
 */
 
 unsafe extern "C" fn CL_Netchan_Decode(mut msg: *mut crate::qcommon_h::msg_t) {
-    let mut reliableAcknowledge: libc::c_long = 0;
-    let mut i: libc::c_long = 0;
-    let mut index: libc::c_long = 0;
+    let mut reliableAcknowledge: isize = 0;
+    let mut i: isize = 0;
+    let mut index: isize = 0;
     let mut key: crate::src::qcommon::q_shared::byte = 0;
     let mut string: *mut crate::src::qcommon::q_shared::byte =
         0 as *mut crate::src::qcommon::q_shared::byte;
@@ -171,31 +171,31 @@ unsafe extern "C" fn CL_Netchan_Decode(mut msg: *mut crate::qcommon_h::msg_t) {
     soob = (*msg).oob as i32;
     (*msg).oob = crate::src::qcommon::q_shared::qfalse;
     reliableAcknowledge =
-        crate::src::qcommon::msg::MSG_ReadLong(msg as *mut crate::qcommon_h::msg_t) as libc::c_long;
+        crate::src::qcommon::msg::MSG_ReadLong(msg as *mut crate::qcommon_h::msg_t) as isize;
     (*msg).oob = soob as crate::src::qcommon::q_shared::qboolean;
     (*msg).bit = sbit;
     (*msg).readcount = srdc;
     string = crate::src::client::cl_main::clc.reliableCommands
-        [(reliableAcknowledge & (64 as i32 - 1 as i32) as libc::c_long) as usize]
+        [(reliableAcknowledge & (64 as i32 - 1 as i32) as isize) as usize]
         .as_mut_ptr() as *mut crate::src::qcommon::q_shared::byte;
-    index = 0 as i32 as libc::c_long;
+    index = 0 as i32 as isize;
     // xor the client challenge with the netchan sequence number (need something that changes every message)
     key = (crate::src::client::cl_main::clc.challenge as u32 ^ *((*msg).data as *mut u32))
         as crate::src::qcommon::q_shared::byte;
-    i = ((*msg).readcount + 4 as i32) as libc::c_long;
-    while i < (*msg).cursize as libc::c_long {
+    i = ((*msg).readcount + 4 as i32) as isize;
+    while i < (*msg).cursize as isize {
         // modify the key with the last sent and with this message acknowledged client command
         if *string.offset(index as isize) == 0 {
-            index = 0 as i32 as libc::c_long
+            index = 0 as i32 as isize
         }
         if *string.offset(index as isize) as i32 > 127 as i32
             || *string.offset(index as isize) as i32 == '%' as i32
         {
-            key = (key as i32 ^ ('.' as i32) << (i & 1 as i32 as libc::c_long))
+            key = (key as i32 ^ ('.' as i32) << (i & 1 as i32 as isize))
                 as crate::src::qcommon::q_shared::byte
         } else {
             key = (key as i32
-                ^ (*string.offset(index as isize) as i32) << (i & 1 as i32 as libc::c_long))
+                ^ (*string.offset(index as isize) as i32) << (i & 1 as i32 as isize))
                 as crate::src::qcommon::q_shared::byte
         }
         index += 1;

--- a/quake3-rs/ioquake3/src/client/cl_ui.rs
+++ b/quake3-rs/ioquake3/src/client/cl_ui.rs
@@ -1571,7 +1571,7 @@ pub unsafe extern "C" fn CL_UISystemCalls(
         }
         12 => {
             if *args.offset(1 as i32 as isize)
-                == crate::src::qcommon::q_shared::EXEC_NOW as i32 as libc::c_long
+                == crate::src::qcommon::q_shared::EXEC_NOW as i32 as isize
                 && (crate::stdlib::strncmp(
                     crate::src::qcommon::vm::VM_ArgPtr(*args.offset(2 as i32 as isize))
                         as *const libc::c_char,
@@ -1852,7 +1852,7 @@ pub unsafe extern "C" fn CL_UISystemCalls(
             // Don't allow the ui module to close the console
             crate::src::client::cl_keys::Key_SetCatcher(
                 (*args.offset(1 as i32 as isize)
-                    | (crate::src::client::cl_keys::Key_GetCatcher() & 0x1 as i32) as libc::c_long)
+                    | (crate::src::client::cl_keys::Key_GetCatcher() & 0x1 as i32) as isize)
                     as i32,
             );
             return 0 as i32 as crate::stdlib::intptr_t;
@@ -2519,7 +2519,7 @@ pub unsafe extern "C" fn UI_usesUniqueCDKey() -> crate::src::qcommon::q_shared::
         return (crate::src::qcommon::vm::VM_Call(
             uivm,
             crate::ui_public_h::UI_HASUNIQUECDKEY as i32,
-        ) == crate::src::qcommon::q_shared::qtrue as i32 as libc::c_long) as i32
+        ) == crate::src::qcommon::q_shared::qtrue as i32 as isize) as i32
             as crate::src::qcommon::q_shared::qboolean;
     } else {
         return crate::src::qcommon::q_shared::qfalse;

--- a/quake3-rs/ioquake3/src/client/libmumblelink.rs
+++ b/quake3-rs/ioquake3/src/client/libmumblelink.rs
@@ -49,7 +49,7 @@ unsafe extern "C" fn GetTickCount() -> crate::stdlib::int32_t {
         tv_usec: 0,
     };
     crate::stdlib::gettimeofday(&mut tv, 0 as *mut crate::stdlib::timezone);
-    return (tv.tv_usec / 1000 as i32 as libc::c_long + tv.tv_sec * 1000 as i32 as libc::c_long)
+    return ((tv.tv_usec as isize / 1000) + tv.tv_sec as isize * 1000)
         as crate::stdlib::int32_t;
 }
 /* libmumblelink.h -- mumble link interface

--- a/quake3-rs/ioquake3/src/client/snd_codec_ogg.rs
+++ b/quake3-rs/ioquake3/src/client/snd_codec_ogg.rs
@@ -220,17 +220,17 @@ pub unsafe extern "C" fn S_OGG_Callback_close(mut _datasource: *mut libc::c_void
 // ftell() replacement
 #[no_mangle]
 
-pub unsafe extern "C" fn S_OGG_Callback_tell(mut datasource: *mut libc::c_void) -> libc::c_long {
+pub unsafe extern "C" fn S_OGG_Callback_tell(mut datasource: *mut libc::c_void) -> isize {
     let mut stream: *mut crate::src::client::snd_codec::snd_stream_t =
         0 as *mut crate::src::client::snd_codec::snd_stream_t;
     // check if input is valid
     if datasource.is_null() {
         *::libc::__errno_location() = 9 as i32;
-        return -(1 as i32) as libc::c_long;
+        return -(1 as i32) as isize;
     }
     // snd_stream_t in the generic pointer
     stream = datasource as *mut crate::src::client::snd_codec::snd_stream_t;
-    return crate::src::qcommon::files::FS_FTell((*stream).file) as libc::c_long;
+    return crate::src::qcommon::files::FS_FTell((*stream).file) as isize;
 }
 // the callback structure
 #[no_mangle]
@@ -256,7 +256,7 @@ pub static mut S_OGG_Callbacks: crate::src::libvorbis_1_3_6::lib::vorbisfile::ov
         ),
         close_func: Some(S_OGG_Callback_close as unsafe extern "C" fn(_: *mut libc::c_void) -> i32),
         tell_func: Some(
-            S_OGG_Callback_tell as unsafe extern "C" fn(_: *mut libc::c_void) -> libc::c_long,
+            S_OGG_Callback_tell as unsafe extern "C" fn(_: *mut libc::c_void) -> isize,
         ),
     };
     init
@@ -307,7 +307,7 @@ pub unsafe extern "C" fn S_OGG_CodecOpenStream(
         stream as *mut libc::c_void,
         vf as *mut crate::src::libvorbis_1_3_6::lib::vorbisfile::OggVorbis_File,
         0 as *const libc::c_char,
-        0 as i32 as libc::c_long,
+        0 as i32 as isize,
         S_OGG_Callbacks as crate::src::libvorbis_1_3_6::lib::vorbisfile::ov_callbacks,
     ) != 0 as i32
     {
@@ -334,7 +334,7 @@ pub unsafe extern "C" fn S_OGG_CodecOpenStream(
     // we only support OGGs with one substream
     if crate::src::libvorbis_1_3_6::lib::vorbisfile::ov_streams(
         vf as *mut crate::src::libvorbis_1_3_6::lib::vorbisfile::OggVorbis_File,
-    ) != 1 as i32 as libc::c_long
+    ) != 1 as i32 as isize
     {
         crate::src::libvorbis_1_3_6::lib::vorbisfile::ov_clear(
             vf as *mut crate::src::libvorbis_1_3_6::lib::vorbisfile::OggVorbis_File,

--- a/quake3-rs/ioquake3/src/client/snd_codec_opus.rs
+++ b/quake3-rs/ioquake3/src/client/snd_codec_opus.rs
@@ -148,7 +148,7 @@ pub unsafe extern "C" fn S_OggOpus_Callback_seek(
             // set the file position in the actual file with the Q3 function
             retVal = crate::src::qcommon::files::FS_Seek(
                 (*stream).file,
-                offset as libc::c_long,
+                offset as isize,
                 crate::src::qcommon::q_shared::FS_SEEK_SET as i32,
             );
             // something has gone wrong, so we return here
@@ -162,7 +162,7 @@ pub unsafe extern "C" fn S_OggOpus_Callback_seek(
             // set the file position in the actual file with the Q3 function
             retVal = crate::src::qcommon::files::FS_Seek(
                 (*stream).file,
-                offset as libc::c_long,
+                offset as isize,
                 crate::src::qcommon::q_shared::FS_SEEK_CUR as i32,
             );
             // something has gone wrong, so we return here
@@ -176,7 +176,7 @@ pub unsafe extern "C" fn S_OggOpus_Callback_seek(
             // set the file position in the actual file with the Q3 function
             retVal = crate::src::qcommon::files::FS_Seek(
                 (*stream).file,
-                offset as libc::c_long,
+                offset as isize,
                 crate::src::qcommon::q_shared::FS_SEEK_END as i32,
             );
             // something has gone wrong, so we return here

--- a/quake3-rs/ioquake3/src/client/snd_codec_wav.rs
+++ b/quake3-rs/ioquake3/src/client/snd_codec_wav.rs
@@ -129,7 +129,7 @@ unsafe extern "C" fn S_FindRIFFChunk(
         // Not the right chunk - skip it
         crate::src::qcommon::files::FS_Seek(
             f,
-            len as libc::c_long,
+            len as isize,
             crate::src::qcommon::q_shared::FS_SEEK_CUR as i32,
         );
     }
@@ -210,7 +210,7 @@ unsafe extern "C" fn S_ReadRIFFHeader(
         fmtlen -= 16 as i32;
         crate::src::qcommon::files::FS_Seek(
             file,
-            fmtlen as libc::c_long,
+            fmtlen as isize,
             crate::src::qcommon::q_shared::FS_SEEK_CUR as i32,
         );
     }

--- a/quake3-rs/ioquake3/src/client/snd_dma.rs
+++ b/quake3-rs/ioquake3/src/client/snd_dma.rs
@@ -601,11 +601,11 @@ return a hash value for the sfx name
 ================
 */
 
-unsafe extern "C" fn S_HashSFXName(mut name: *const libc::c_char) -> libc::c_long {
+unsafe extern "C" fn S_HashSFXName(mut name: *const libc::c_char) -> isize {
     let mut i: i32 = 0; // don't include extension
-    let mut hash: libc::c_long = 0; // damn path names
+    let mut hash: isize = 0; // damn path names
     let mut letter: libc::c_char = 0;
-    hash = 0 as i32 as libc::c_long;
+    hash = 0 as i32 as isize;
     i = 0 as i32;
     while *name.offset(i as isize) as i32 != '\u{0}' as i32 {
         letter = ({
@@ -633,10 +633,10 @@ unsafe extern "C" fn S_HashSFXName(mut name: *const libc::c_char) -> libc::c_lon
         if letter as i32 == '\\' as i32 {
             letter = '/' as i32 as libc::c_char
         }
-        hash += letter as libc::c_long * (i + 119 as i32) as libc::c_long;
+        hash += letter as isize * (i + 119 as i32) as isize;
         i += 1
     }
-    hash &= (128 as i32 - 1 as i32) as libc::c_long;
+    hash &= (128 as i32 - 1 as i32) as isize;
     return hash;
 }
 /*
@@ -780,7 +780,7 @@ pub unsafe extern "C" fn S_Base_RegisterSound(
             );
             return 0 as i32;
         }
-        return sfx.offset_from(s_knownSfx.as_mut_ptr()) as libc::c_long
+        return sfx.offset_from(s_knownSfx.as_mut_ptr()) as isize
             as crate::src::qcommon::q_shared::sfxHandle_t;
     }
     (*sfx).inMemory = crate::src::qcommon::q_shared::qfalse;
@@ -794,7 +794,7 @@ pub unsafe extern "C" fn S_Base_RegisterSound(
         );
         return 0 as i32;
     }
-    return sfx.offset_from(s_knownSfx.as_mut_ptr()) as libc::c_long
+    return sfx.offset_from(s_knownSfx.as_mut_ptr()) as isize
         as crate::src::qcommon::q_shared::sfxHandle_t;
 }
 /*

--- a/quake3-rs/ioquake3/src/client/snd_wavelet.rs
+++ b/quake3-rs/ioquake3/src/client/snd_wavelet.rs
@@ -636,11 +636,11 @@ pub unsafe extern "C" fn MuLawEncode(mut s: i16) -> crate::src::qcommon::q_share
     if (s as i32) < 0 as i32 {
         s = -(s as i32) as i16
     }
-    adjusted = ((s as libc::c_long)
+    adjusted = ((s as isize)
         << (16 as i32 as libc::c_ulong).wrapping_sub(
             (::std::mem::size_of::<i16>() as libc::c_ulong).wrapping_mul(8 as i32 as libc::c_ulong),
         )) as libc::c_ulong;
-    adjusted = adjusted.wrapping_add((128 as libc::c_long + 4 as libc::c_long) as libc::c_ulong);
+    adjusted = adjusted.wrapping_add((128 as isize + 4 as isize) as libc::c_ulong);
     if adjusted > 32767 as i32 as libc::c_ulong {
         adjusted = 32767 as i32 as libc::c_ulong
     }
@@ -654,14 +654,14 @@ pub unsafe extern "C" fn MuLawEncode(mut s: i16) -> crate::src::qcommon::q_share
 #[no_mangle]
 
 pub unsafe extern "C" fn MuLawDecode(mut uLaw: crate::src::qcommon::q_shared::byte) -> i16 {
-    let mut adjusted: libc::c_long = 0;
+    let mut adjusted: isize = 0;
     let mut exponent: crate::src::qcommon::q_shared::byte = 0;
     let mut mantissa: crate::src::qcommon::q_shared::byte = 0;
     uLaw = !(uLaw as i32) as crate::src::qcommon::q_shared::byte;
     exponent = (uLaw as i32 >> 4 as i32 & 0x7 as i32) as crate::src::qcommon::q_shared::byte;
     mantissa = ((uLaw as i32 & 0xf as i32) + 16 as i32) as crate::src::qcommon::q_shared::byte;
     adjusted =
-        (((mantissa as i32) << exponent as i32 + 3 as i32) - 128 as i32 - 4 as i32) as libc::c_long;
+        (((mantissa as i32) << exponent as i32 + 3 as i32) - 128 as i32 - 4 as i32) as isize;
     return if uLaw as i32 & 0x80 as i32 != 0 {
         adjusted
     } else {

--- a/quake3-rs/ioquake3/src/libogg_1_3_3/src/bitwise.rs
+++ b/quake3-rs/ioquake3/src/libogg_1_3_3/src/bitwise.rs
@@ -61,7 +61,7 @@ pub unsafe extern "C" fn oggpack_writeinit(mut b: *mut crate::ogg_h::oggpack_buf
     (*b).buffer = crate::stdlib::malloc(256 as i32 as libc::c_ulong) as *mut u8;
     (*b).ptr = (*b).buffer;
     *(*b).buffer.offset(0 as i32 as isize) = '\u{0}' as i32 as u8;
-    (*b).storage = 256 as i32 as libc::c_long;
+    (*b).storage = 256 as i32 as isize;
 }
 #[no_mangle]
 
@@ -85,11 +85,11 @@ pub unsafe extern "C" fn oggpackB_writecheck(mut b: *mut crate::ogg_h::oggpack_b
 
 pub unsafe extern "C" fn oggpack_writetrunc(
     mut b: *mut crate::ogg_h::oggpack_buffer,
-    mut bits: libc::c_long,
+    mut bits: isize,
 ) {
-    let mut bytes: libc::c_long = bits >> 3 as i32;
+    let mut bytes: isize = bits >> 3 as i32;
     if !(*b).ptr.is_null() {
-        bits -= bytes * 8 as i32 as libc::c_long;
+        bits -= bytes * 8 as i32 as isize;
         (*b).ptr = (*b).buffer.offset(bytes as isize);
         (*b).endbit = bits as i32;
         (*b).endbyte = bytes;
@@ -100,11 +100,11 @@ pub unsafe extern "C" fn oggpack_writetrunc(
 
 pub unsafe extern "C" fn oggpackB_writetrunc(
     mut b: *mut crate::ogg_h::oggpack_buffer,
-    mut bits: libc::c_long,
+    mut bits: isize,
 ) {
-    let mut bytes: libc::c_long = bits >> 3 as i32;
+    let mut bytes: isize = bits >> 3 as i32;
     if !(*b).ptr.is_null() {
-        bits -= bytes * 8 as i32 as libc::c_long;
+        bits -= bytes * 8 as i32 as isize;
         (*b).ptr = (*b).buffer.offset(bytes as isize);
         (*b).endbit = bits as i32;
         (*b).endbyte = bytes;
@@ -121,23 +121,23 @@ pub unsafe extern "C" fn oggpack_write(
 ) {
     let mut current_block: u64;
     if !(bits < 0 as i32 || bits > 32 as i32) {
-        if (*b).endbyte >= (*b).storage - 4 as i32 as libc::c_long {
+        if (*b).endbyte >= (*b).storage - 4 as i32 as isize {
             let mut ret: *mut libc::c_void = 0 as *mut libc::c_void;
             if (*b).ptr.is_null() {
                 return;
             }
-            if (*b).storage > 9223372036854775807 as libc::c_long - 256 as i32 as libc::c_long {
+            if (*b).storage > 9223372036854775807 as isize - 256 as i32 as isize {
                 current_block = 11736846078876452800;
             } else {
                 ret = crate::stdlib::realloc(
                     (*b).buffer as *mut libc::c_void,
-                    ((*b).storage + 256 as i32 as libc::c_long) as libc::c_ulong,
+                    ((*b).storage + 256 as i32 as isize) as libc::c_ulong,
                 );
                 if ret.is_null() {
                     current_block = 11736846078876452800;
                 } else {
                     (*b).buffer = ret as *mut u8;
-                    (*b).storage += 256 as i32 as libc::c_long;
+                    (*b).storage += 256 as i32 as isize;
                     (*b).ptr = (*b).buffer.offset((*b).endbyte as isize);
                     current_block = 13109137661213826276;
                 }
@@ -171,7 +171,7 @@ pub unsafe extern "C" fn oggpack_write(
                         }
                     }
                 }
-                (*b).endbyte += (bits / 8 as i32) as libc::c_long;
+                (*b).endbyte += (bits / 8 as i32) as isize;
                 (*b).ptr = (*b).ptr.offset((bits / 8 as i32) as isize);
                 (*b).endbit = bits & 7 as i32;
                 return;
@@ -190,23 +190,23 @@ pub unsafe extern "C" fn oggpackB_write(
 ) {
     let mut current_block: u64;
     if !(bits < 0 as i32 || bits > 32 as i32) {
-        if (*b).endbyte >= (*b).storage - 4 as i32 as libc::c_long {
+        if (*b).endbyte >= (*b).storage - 4 as i32 as isize {
             let mut ret: *mut libc::c_void = 0 as *mut libc::c_void;
             if (*b).ptr.is_null() {
                 return;
             }
-            if (*b).storage > 9223372036854775807 as libc::c_long - 256 as i32 as libc::c_long {
+            if (*b).storage > 9223372036854775807 as isize - 256 as i32 as isize {
                 current_block = 2612814309992382393;
             } else {
                 ret = crate::stdlib::realloc(
                     (*b).buffer as *mut libc::c_void,
-                    ((*b).storage + 256 as i32 as libc::c_long) as libc::c_ulong,
+                    ((*b).storage + 256 as i32 as isize) as libc::c_ulong,
                 );
                 if ret.is_null() {
                     current_block = 2612814309992382393;
                 } else {
                     (*b).buffer = ret as *mut u8;
-                    (*b).storage += 256 as i32 as libc::c_long;
+                    (*b).storage += 256 as i32 as isize;
                     (*b).ptr = (*b).buffer.offset((*b).endbyte as isize);
                     current_block = 13109137661213826276;
                 }
@@ -239,7 +239,7 @@ pub unsafe extern "C" fn oggpackB_write(
                         }
                     }
                 }
-                (*b).endbyte += (bits / 8 as i32) as libc::c_long;
+                (*b).endbyte += (bits / 8 as i32) as isize;
                 (*b).ptr = (*b).ptr.offset((bits / 8 as i32) as isize);
                 (*b).endbit = bits & 7 as i32;
                 return;
@@ -268,7 +268,7 @@ pub unsafe extern "C" fn oggpackB_writealign(mut b: *mut crate::ogg_h::oggpack_b
 unsafe extern "C" fn oggpack_writecopy_helper(
     mut b: *mut crate::ogg_h::oggpack_buffer,
     mut source: *mut libc::c_void,
-    mut bits: libc::c_long,
+    mut bits: isize,
     mut w: Option<
         unsafe extern "C" fn(_: *mut crate::ogg_h::oggpack_buffer, _: libc::c_ulong, _: i32) -> (),
     >,
@@ -276,18 +276,18 @@ unsafe extern "C" fn oggpack_writecopy_helper(
 ) {
     let mut current_block: u64;
     let mut ptr: *mut u8 = source as *mut u8;
-    let mut bytes: libc::c_long = bits / 8 as i32 as libc::c_long;
-    let mut pbytes: libc::c_long = ((*b).endbit as libc::c_long + bits) / 8 as i32 as libc::c_long;
-    bits -= bytes * 8 as i32 as libc::c_long;
+    let mut bytes: isize = bits / 8 as i32 as isize;
+    let mut pbytes: isize = ((*b).endbit as isize + bits) / 8 as i32 as isize;
+    bits -= bytes * 8 as i32 as isize;
     /* expand storage up-front */
     if (*b).endbyte + pbytes >= (*b).storage {
         let mut ret: *mut libc::c_void = 0 as *mut libc::c_void;
         if (*b).ptr.is_null() {
             current_block = 1692384543052803397;
-        } else if (*b).storage > (*b).endbyte + pbytes + 256 as i32 as libc::c_long {
+        } else if (*b).storage > (*b).endbyte + pbytes + 256 as i32 as isize {
             current_block = 1692384543052803397;
         } else {
-            (*b).storage = (*b).endbyte + pbytes + 256 as i32 as libc::c_long;
+            (*b).storage = (*b).endbyte + pbytes + 256 as i32 as isize;
             ret = crate::stdlib::realloc(
                 (*b).buffer as *mut libc::c_void,
                 (*b).storage as libc::c_ulong,
@@ -313,7 +313,7 @@ unsafe extern "C" fn oggpack_writecopy_helper(
         let mut i: i32 = 0;
         /* unaligned copy.  Do it the hard way. */
         i = 0 as i32;
-        while (i as libc::c_long) < bytes {
+        while (i as isize) < bytes {
             w.expect("non-null function pointer")(
                 b,
                 *ptr.offset(i as isize) as libc::c_ulong,
@@ -337,7 +337,7 @@ unsafe extern "C" fn oggpack_writecopy_helper(
         if msb != 0 {
             w.expect("non-null function pointer")(
                 b,
-                (*ptr.offset(bytes as isize) as i32 >> 8 as i32 as libc::c_long - bits)
+                (*ptr.offset(bytes as isize) as i32 >> 8 as i32 as isize - bits)
                     as libc::c_ulong,
                 bits as i32,
             );
@@ -355,7 +355,7 @@ unsafe extern "C" fn oggpack_writecopy_helper(
 pub unsafe extern "C" fn oggpack_writecopy(
     mut b: *mut crate::ogg_h::oggpack_buffer,
     mut source: *mut libc::c_void,
-    mut bits: libc::c_long,
+    mut bits: isize,
 ) {
     oggpack_writecopy_helper(
         b,
@@ -377,7 +377,7 @@ pub unsafe extern "C" fn oggpack_writecopy(
 pub unsafe extern "C" fn oggpackB_writecopy(
     mut b: *mut crate::ogg_h::oggpack_buffer,
     mut source: *mut libc::c_void,
-    mut bits: libc::c_long,
+    mut bits: isize,
 ) {
     oggpack_writecopy_helper(
         b,
@@ -402,7 +402,7 @@ pub unsafe extern "C" fn oggpack_reset(mut b: *mut crate::ogg_h::oggpack_buffer)
     }
     (*b).ptr = (*b).buffer;
     *(*b).buffer.offset(0 as i32 as isize) = 0 as i32 as u8;
-    (*b).endbyte = 0 as i32 as libc::c_long;
+    (*b).endbyte = 0 as i32 as isize;
     (*b).endbit = (*b).endbyte as i32;
 }
 #[no_mangle]
@@ -441,7 +441,7 @@ pub unsafe extern "C" fn oggpack_readinit(
     );
     (*b).ptr = buf;
     (*b).buffer = (*b).ptr;
-    (*b).storage = bytes as libc::c_long;
+    (*b).storage = bytes as isize;
 }
 #[no_mangle]
 
@@ -458,23 +458,23 @@ pub unsafe extern "C" fn oggpackB_readinit(
 pub unsafe extern "C" fn oggpack_look(
     mut b: *mut crate::ogg_h::oggpack_buffer,
     mut bits: i32,
-) -> libc::c_long {
+) -> isize {
     let mut ret: libc::c_ulong = 0;
     let mut m: libc::c_ulong = 0;
     if bits < 0 as i32 || bits > 32 as i32 {
-        return -(1 as i32) as libc::c_long;
+        return -(1 as i32) as isize;
     }
     m = mask[bits as usize];
     bits += (*b).endbit;
-    if (*b).endbyte >= (*b).storage - 4 as i32 as libc::c_long {
+    if (*b).endbyte >= (*b).storage - 4 as i32 as isize {
         /* not the main path */
-        if (*b).endbyte > (*b).storage - (bits + 7 as i32 >> 3 as i32) as libc::c_long {
-            return -(1 as i32) as libc::c_long;
+        if (*b).endbyte > (*b).storage - (bits + 7 as i32 >> 3 as i32) as isize {
+            return -(1 as i32) as isize;
         } else {
             /* special case to avoid reading b->ptr[0], which might be past the end of
             the buffer; also skips some useless accounting */
             if bits == 0 {
-                return 0 as libc::c_long;
+                return 0 as isize;
             }
         }
     }
@@ -495,7 +495,7 @@ pub unsafe extern "C" fn oggpack_look(
             }
         }
     }
-    return (m & ret) as libc::c_long;
+    return (m & ret) as isize;
 }
 /* Read in bits without advancing the bitptr; bits <= 32 */
 #[no_mangle]
@@ -503,22 +503,22 @@ pub unsafe extern "C" fn oggpack_look(
 pub unsafe extern "C" fn oggpackB_look(
     mut b: *mut crate::ogg_h::oggpack_buffer,
     mut bits: i32,
-) -> libc::c_long {
+) -> isize {
     let mut ret: libc::c_ulong = 0;
     let mut m: i32 = 32 as i32 - bits;
     if m < 0 as i32 || m > 32 as i32 {
-        return -(1 as i32) as libc::c_long;
+        return -(1 as i32) as isize;
     }
     bits += (*b).endbit;
-    if (*b).endbyte >= (*b).storage - 4 as i32 as libc::c_long {
+    if (*b).endbyte >= (*b).storage - 4 as i32 as isize {
         /* not the main path */
-        if (*b).endbyte > (*b).storage - (bits + 7 as i32 >> 3 as i32) as libc::c_long {
-            return -(1 as i32) as libc::c_long;
+        if (*b).endbyte > (*b).storage - (bits + 7 as i32 >> 3 as i32) as isize {
+            return -(1 as i32) as isize;
         } else {
             /* special case to avoid reading b->ptr[0], which might be past the end of
             the buffer; also skips some useless accounting */
             if bits == 0 {
-                return 0 as libc::c_long;
+                return 0 as isize;
             }
         }
     }
@@ -542,37 +542,37 @@ pub unsafe extern "C" fn oggpackB_look(
     }
     return ((ret & 0xffffffff as u32 as libc::c_ulong)
         >> (m >> 1 as i32)
-        >> (m + 1 as i32 >> 1 as i32)) as libc::c_long;
+        >> (m + 1 as i32 >> 1 as i32)) as isize;
 }
 #[no_mangle]
 
-pub unsafe extern "C" fn oggpack_look1(mut b: *mut crate::ogg_h::oggpack_buffer) -> libc::c_long {
+pub unsafe extern "C" fn oggpack_look1(mut b: *mut crate::ogg_h::oggpack_buffer) -> isize {
     if (*b).endbyte >= (*b).storage {
-        return -(1 as i32) as libc::c_long;
+        return -(1 as i32) as isize;
     }
-    return (*(*b).ptr.offset(0 as i32 as isize) as i32 >> (*b).endbit & 1 as i32) as libc::c_long;
+    return (*(*b).ptr.offset(0 as i32 as isize) as i32 >> (*b).endbit & 1 as i32) as isize;
 }
 #[no_mangle]
 
-pub unsafe extern "C" fn oggpackB_look1(mut b: *mut crate::ogg_h::oggpack_buffer) -> libc::c_long {
+pub unsafe extern "C" fn oggpackB_look1(mut b: *mut crate::ogg_h::oggpack_buffer) -> isize {
     if (*b).endbyte >= (*b).storage {
-        return -(1 as i32) as libc::c_long;
+        return -(1 as i32) as isize;
     }
     return (*(*b).ptr.offset(0 as i32 as isize) as i32 >> 7 as i32 - (*b).endbit & 1 as i32)
-        as libc::c_long;
+        as isize;
 }
 #[no_mangle]
 
 pub unsafe extern "C" fn oggpack_adv(mut b: *mut crate::ogg_h::oggpack_buffer, mut bits: i32) {
     bits += (*b).endbit;
-    if (*b).endbyte > (*b).storage - (bits + 7 as i32 >> 3 as i32) as libc::c_long {
+    if (*b).endbyte > (*b).storage - (bits + 7 as i32 >> 3 as i32) as isize {
         (*b).ptr = 0 as *mut u8;
         (*b).endbyte = (*b).storage;
         (*b).endbit = 1 as i32;
         return;
     } else {
         (*b).ptr = (*b).ptr.offset((bits / 8 as i32) as isize);
-        (*b).endbyte += (bits / 8 as i32) as libc::c_long;
+        (*b).endbyte += (bits / 8 as i32) as isize;
         (*b).endbit = bits & 7 as i32;
         return;
     };
@@ -603,22 +603,22 @@ pub unsafe extern "C" fn oggpackB_adv1(mut b: *mut crate::ogg_h::oggpack_buffer)
 pub unsafe extern "C" fn oggpack_read(
     mut b: *mut crate::ogg_h::oggpack_buffer,
     mut bits: i32,
-) -> libc::c_long {
+) -> isize {
     let mut current_block: u64;
-    let mut ret: libc::c_long = 0;
+    let mut ret: isize = 0;
     let mut m: libc::c_ulong = 0;
     if !(bits < 0 as i32 || bits > 32 as i32) {
         m = mask[bits as usize];
         bits += (*b).endbit;
-        if (*b).endbyte >= (*b).storage - 4 as i32 as libc::c_long {
+        if (*b).endbyte >= (*b).storage - 4 as i32 as isize {
             /* not the main path */
-            if (*b).endbyte > (*b).storage - (bits + 7 as i32 >> 3 as i32) as libc::c_long {
+            if (*b).endbyte > (*b).storage - (bits + 7 as i32 >> 3 as i32) as isize {
                 current_block = 7073085723881536557;
             } else {
                 /* special case to avoid reading b->ptr[0], which might be past the end of
                 the buffer; also skips some useless accounting */
                 if bits == 0 {
-                    return 0 as libc::c_long;
+                    return 0 as isize;
                 }
                 current_block = 14523784380283086299;
             }
@@ -628,29 +628,29 @@ pub unsafe extern "C" fn oggpack_read(
         match current_block {
             7073085723881536557 => {}
             _ => {
-                ret = (*(*b).ptr.offset(0 as i32 as isize) as i32 >> (*b).endbit) as libc::c_long;
+                ret = (*(*b).ptr.offset(0 as i32 as isize) as i32 >> (*b).endbit) as isize;
                 if bits > 8 as i32 {
                     ret |= ((*(*b).ptr.offset(1 as i32 as isize) as i32) << 8 as i32 - (*b).endbit)
-                        as libc::c_long;
+                        as isize;
                     if bits > 16 as i32 {
                         ret |= ((*(*b).ptr.offset(2 as i32 as isize) as i32)
                             << 16 as i32 - (*b).endbit)
-                            as libc::c_long;
+                            as isize;
                         if bits > 24 as i32 {
                             ret |= ((*(*b).ptr.offset(3 as i32 as isize) as i32)
                                 << 24 as i32 - (*b).endbit)
-                                as libc::c_long;
+                                as isize;
                             if bits > 32 as i32 && (*b).endbit != 0 {
                                 ret |= ((*(*b).ptr.offset(4 as i32 as isize) as i32)
                                     << 32 as i32 - (*b).endbit)
-                                    as libc::c_long
+                                    as isize
                             }
                         }
                     }
                 }
-                ret = (ret as libc::c_ulong & m) as libc::c_long;
+                ret = (ret as libc::c_ulong & m) as isize;
                 (*b).ptr = (*b).ptr.offset((bits / 8 as i32) as isize);
-                (*b).endbyte += (bits / 8 as i32) as libc::c_long;
+                (*b).endbyte += (bits / 8 as i32) as isize;
                 (*b).endbit = bits & 7 as i32;
                 return ret;
             }
@@ -659,7 +659,7 @@ pub unsafe extern "C" fn oggpack_read(
     (*b).ptr = 0 as *mut u8;
     (*b).endbyte = (*b).storage;
     (*b).endbit = 1 as i32;
-    return -(1 as libc::c_long);
+    return -(1 as isize);
 }
 /* bits <= 32 */
 #[no_mangle]
@@ -667,21 +667,21 @@ pub unsafe extern "C" fn oggpack_read(
 pub unsafe extern "C" fn oggpackB_read(
     mut b: *mut crate::ogg_h::oggpack_buffer,
     mut bits: i32,
-) -> libc::c_long {
+) -> isize {
     let mut current_block: u64;
-    let mut ret: libc::c_long = 0;
-    let mut m: libc::c_long = (32 as i32 - bits) as libc::c_long;
-    if !(m < 0 as i32 as libc::c_long || m > 32 as i32 as libc::c_long) {
+    let mut ret: isize = 0;
+    let mut m: isize = (32 as i32 - bits) as isize;
+    if !(m < 0 as i32 as isize || m > 32 as i32 as isize) {
         bits += (*b).endbit;
-        if (*b).endbyte + 4 as i32 as libc::c_long >= (*b).storage {
+        if (*b).endbyte + 4 as i32 as isize >= (*b).storage {
             /* not the main path */
-            if (*b).endbyte > (*b).storage - (bits + 7 as i32 >> 3 as i32) as libc::c_long {
+            if (*b).endbyte > (*b).storage - (bits + 7 as i32 >> 3 as i32) as isize {
                 current_block = 11946596175837608108;
             } else {
                 /* special case to avoid reading b->ptr[0], which might be past the end of
                 the buffer; also skips some useless accounting */
                 if bits == 0 {
-                    return 0 as libc::c_long;
+                    return 0 as isize;
                 }
                 current_block = 7351195479953500246;
             }
@@ -692,31 +692,31 @@ pub unsafe extern "C" fn oggpackB_read(
             11946596175837608108 => {}
             _ => {
                 ret = ((*(*b).ptr.offset(0 as i32 as isize) as i32) << 24 as i32 + (*b).endbit)
-                    as libc::c_long;
+                    as isize;
                 if bits > 8 as i32 {
                     ret |= ((*(*b).ptr.offset(1 as i32 as isize) as i32) << 16 as i32 + (*b).endbit)
-                        as libc::c_long;
+                        as isize;
                     if bits > 16 as i32 {
                         ret |= ((*(*b).ptr.offset(2 as i32 as isize) as i32)
                             << 8 as i32 + (*b).endbit)
-                            as libc::c_long;
+                            as isize;
                         if bits > 24 as i32 {
                             ret |= ((*(*b).ptr.offset(3 as i32 as isize) as i32) << (*b).endbit)
-                                as libc::c_long;
+                                as isize;
                             if bits > 32 as i32 && (*b).endbit != 0 {
                                 ret |= (*(*b).ptr.offset(4 as i32 as isize) as i32
                                     >> 8 as i32 - (*b).endbit)
-                                    as libc::c_long
+                                    as isize
                             }
                         }
                     }
                 }
                 ret = ((ret as libc::c_ulong & 0xffffffff as libc::c_ulong)
                     >> (m >> 1 as i32)
-                    >> (m + 1 as i32 as libc::c_long >> 1 as i32))
-                    as libc::c_long;
+                    >> (m + 1 as i32 as isize >> 1 as i32))
+                    as isize;
                 (*b).ptr = (*b).ptr.offset((bits / 8 as i32) as isize);
-                (*b).endbyte += (bits / 8 as i32) as libc::c_long;
+                (*b).endbyte += (bits / 8 as i32) as isize;
                 (*b).endbit = bits & 7 as i32;
                 return ret;
             }
@@ -725,20 +725,20 @@ pub unsafe extern "C" fn oggpackB_read(
     (*b).ptr = 0 as *mut u8;
     (*b).endbyte = (*b).storage;
     (*b).endbit = 1 as i32;
-    return -(1 as libc::c_long);
+    return -(1 as isize);
 }
 #[no_mangle]
 
-pub unsafe extern "C" fn oggpack_read1(mut b: *mut crate::ogg_h::oggpack_buffer) -> libc::c_long {
-    let mut ret: libc::c_long = 0;
+pub unsafe extern "C" fn oggpack_read1(mut b: *mut crate::ogg_h::oggpack_buffer) -> isize {
+    let mut ret: isize = 0;
     if (*b).endbyte >= (*b).storage {
         (*b).ptr = 0 as *mut u8;
         (*b).endbyte = (*b).storage;
         (*b).endbit = 1 as i32;
-        return -(1 as libc::c_long);
+        return -(1 as isize);
     } else {
         ret =
-            (*(*b).ptr.offset(0 as i32 as isize) as i32 >> (*b).endbit & 1 as i32) as libc::c_long;
+            (*(*b).ptr.offset(0 as i32 as isize) as i32 >> (*b).endbit & 1 as i32) as isize;
         (*b).endbit += 1;
         if (*b).endbit > 7 as i32 {
             (*b).endbit = 0 as i32;
@@ -750,16 +750,16 @@ pub unsafe extern "C" fn oggpack_read1(mut b: *mut crate::ogg_h::oggpack_buffer)
 }
 #[no_mangle]
 
-pub unsafe extern "C" fn oggpackB_read1(mut b: *mut crate::ogg_h::oggpack_buffer) -> libc::c_long {
-    let mut ret: libc::c_long = 0;
+pub unsafe extern "C" fn oggpackB_read1(mut b: *mut crate::ogg_h::oggpack_buffer) -> isize {
+    let mut ret: isize = 0;
     if (*b).endbyte >= (*b).storage {
         (*b).ptr = 0 as *mut u8;
         (*b).endbyte = (*b).storage;
         (*b).endbit = 1 as i32;
-        return -(1 as libc::c_long);
+        return -(1 as isize);
     } else {
         ret = (*(*b).ptr.offset(0 as i32 as isize) as i32 >> 7 as i32 - (*b).endbit & 1 as i32)
-            as libc::c_long;
+            as isize;
         (*b).endbit += 1;
         if (*b).endbit > 7 as i32 {
             (*b).endbit = 0 as i32;
@@ -771,22 +771,22 @@ pub unsafe extern "C" fn oggpackB_read1(mut b: *mut crate::ogg_h::oggpack_buffer
 }
 #[no_mangle]
 
-pub unsafe extern "C" fn oggpack_bytes(mut b: *mut crate::ogg_h::oggpack_buffer) -> libc::c_long {
-    return (*b).endbyte + (((*b).endbit + 7 as i32) / 8 as i32) as libc::c_long;
+pub unsafe extern "C" fn oggpack_bytes(mut b: *mut crate::ogg_h::oggpack_buffer) -> isize {
+    return (*b).endbyte + (((*b).endbit + 7 as i32) / 8 as i32) as isize;
 }
 #[no_mangle]
 
-pub unsafe extern "C" fn oggpack_bits(mut b: *mut crate::ogg_h::oggpack_buffer) -> libc::c_long {
-    return (*b).endbyte * 8 as i32 as libc::c_long + (*b).endbit as libc::c_long;
+pub unsafe extern "C" fn oggpack_bits(mut b: *mut crate::ogg_h::oggpack_buffer) -> isize {
+    return (*b).endbyte * 8 as i32 as isize + (*b).endbit as isize;
 }
 #[no_mangle]
 
-pub unsafe extern "C" fn oggpackB_bytes(mut b: *mut crate::ogg_h::oggpack_buffer) -> libc::c_long {
+pub unsafe extern "C" fn oggpackB_bytes(mut b: *mut crate::ogg_h::oggpack_buffer) -> isize {
     return oggpack_bytes(b);
 }
 #[no_mangle]
 
-pub unsafe extern "C" fn oggpackB_bits(mut b: *mut crate::ogg_h::oggpack_buffer) -> libc::c_long {
+pub unsafe extern "C" fn oggpackB_bits(mut b: *mut crate::ogg_h::oggpack_buffer) -> isize {
     return oggpack_bits(b);
 }
 #[no_mangle]

--- a/quake3-rs/ioquake3/src/libogg_1_3_3/src/framing.rs
+++ b/quake3-rs/ioquake3/src/libogg_1_3_3/src/framing.rs
@@ -66,19 +66,19 @@ pub unsafe extern "C" fn ogg_page_granulepos(
         (*page.offset(13 as i32 as isize) as i32 & 0xff as i32)
             as crate::config_types_h::ogg_int64_t;
     granulepos = granulepos << 8 as i32
-        | (*page.offset(12 as i32 as isize) as i32 & 0xff as i32) as libc::c_long;
+        | (*page.offset(12 as i32 as isize) as i32 & 0xff as i32) as isize;
     granulepos = granulepos << 8 as i32
-        | (*page.offset(11 as i32 as isize) as i32 & 0xff as i32) as libc::c_long;
+        | (*page.offset(11 as i32 as isize) as i32 & 0xff as i32) as isize;
     granulepos = granulepos << 8 as i32
-        | (*page.offset(10 as i32 as isize) as i32 & 0xff as i32) as libc::c_long;
+        | (*page.offset(10 as i32 as isize) as i32 & 0xff as i32) as isize;
     granulepos = granulepos << 8 as i32
-        | (*page.offset(9 as i32 as isize) as i32 & 0xff as i32) as libc::c_long;
+        | (*page.offset(9 as i32 as isize) as i32 & 0xff as i32) as isize;
     granulepos = granulepos << 8 as i32
-        | (*page.offset(8 as i32 as isize) as i32 & 0xff as i32) as libc::c_long;
+        | (*page.offset(8 as i32 as isize) as i32 & 0xff as i32) as isize;
     granulepos = granulepos << 8 as i32
-        | (*page.offset(7 as i32 as isize) as i32 & 0xff as i32) as libc::c_long;
+        | (*page.offset(7 as i32 as isize) as i32 & 0xff as i32) as isize;
     granulepos = granulepos << 8 as i32
-        | (*page.offset(6 as i32 as isize) as i32 & 0xff as i32) as libc::c_long;
+        | (*page.offset(6 as i32 as isize) as i32 & 0xff as i32) as isize;
     return granulepos;
 }
 #[no_mangle]
@@ -91,12 +91,12 @@ pub unsafe extern "C" fn ogg_page_serialno(mut og: *const crate::ogg_h::ogg_page
 }
 #[no_mangle]
 
-pub unsafe extern "C" fn ogg_page_pageno(mut og: *const crate::ogg_h::ogg_page) -> libc::c_long {
+pub unsafe extern "C" fn ogg_page_pageno(mut og: *const crate::ogg_h::ogg_page) -> isize {
     return (*(*og).header.offset(18 as i32 as isize) as i32
         | (*(*og).header.offset(19 as i32 as isize) as i32) << 8 as i32
         | (*(*og).header.offset(20 as i32 as isize) as i32) << 16 as i32
         | (*(*og).header.offset(21 as i32 as isize) as i32) << 24 as i32)
-        as libc::c_long;
+        as isize;
 }
 /* returns the number of packets that are completed on this page (if
 the leading packet is begun on a previous page, but ends on this
@@ -401,8 +401,8 @@ pub unsafe extern "C" fn ogg_stream_init(
             0 as i32,
             ::std::mem::size_of::<crate::ogg_h::ogg_stream_state>() as libc::c_ulong,
         );
-        (*os).body_storage = (16 as i32 * 1024 as i32) as libc::c_long;
-        (*os).lacing_storage = 1024 as i32 as libc::c_long;
+        (*os).body_storage = (16 as i32 * 1024 as i32) as isize;
+        (*os).lacing_storage = 1024 as i32 as isize;
         (*os).body_data = crate::stdlib::malloc(
             ((*os).body_storage as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<u8>() as libc::c_ulong),
@@ -420,7 +420,7 @@ pub unsafe extern "C" fn ogg_stream_init(
             ogg_stream_clear(os);
             return -(1 as i32);
         }
-        (*os).serialno = serialno as libc::c_long;
+        (*os).serialno = serialno as isize;
         return 0 as i32;
     }
     return -(1 as i32);
@@ -470,18 +470,18 @@ what's happening fairly clear */
 
 unsafe extern "C" fn _os_body_expand(
     mut os: *mut crate::ogg_h::ogg_stream_state,
-    mut needed: libc::c_long,
+    mut needed: isize,
 ) -> i32 {
     if (*os).body_storage - needed <= (*os).body_fill {
-        let mut body_storage: libc::c_long = 0;
+        let mut body_storage: isize = 0;
         let mut ret: *mut libc::c_void = 0 as *mut libc::c_void;
-        if (*os).body_storage > 9223372036854775807 as libc::c_long - needed {
+        if (*os).body_storage > 9223372036854775807 as isize - needed {
             ogg_stream_clear(os);
             return -(1 as i32);
         }
         body_storage = (*os).body_storage + needed;
-        if body_storage < 9223372036854775807 as libc::c_long - 1024 as i32 as libc::c_long {
-            body_storage += 1024 as i32 as libc::c_long
+        if body_storage < 9223372036854775807 as isize - 1024 as i32 as isize {
+            body_storage += 1024 as i32 as isize
         }
         ret = crate::stdlib::realloc(
             (*os).body_data as *mut libc::c_void,
@@ -500,18 +500,18 @@ unsafe extern "C" fn _os_body_expand(
 
 unsafe extern "C" fn _os_lacing_expand(
     mut os: *mut crate::ogg_h::ogg_stream_state,
-    mut needed: libc::c_long,
+    mut needed: isize,
 ) -> i32 {
     if (*os).lacing_storage - needed <= (*os).lacing_fill {
-        let mut lacing_storage: libc::c_long = 0;
+        let mut lacing_storage: isize = 0;
         let mut ret: *mut libc::c_void = 0 as *mut libc::c_void;
-        if (*os).lacing_storage > 9223372036854775807 as libc::c_long - needed {
+        if (*os).lacing_storage > 9223372036854775807 as isize - needed {
             ogg_stream_clear(os);
             return -(1 as i32);
         }
         lacing_storage = (*os).lacing_storage + needed;
-        if lacing_storage < 9223372036854775807 as libc::c_long - 32 as i32 as libc::c_long {
-            lacing_storage += 32 as i32 as libc::c_long
+        if lacing_storage < 9223372036854775807 as isize - 32 as i32 as isize {
+            lacing_storage += 32 as i32 as isize
         }
         ret = crate::stdlib::realloc(
             (*os).lacing_vals as *mut libc::c_void,
@@ -554,7 +554,7 @@ pub unsafe extern "C" fn ogg_page_checksum_set(mut og: *mut crate::ogg_h::ogg_pa
         *(*og).header.offset(24 as i32 as isize) = 0 as i32 as u8;
         *(*og).header.offset(25 as i32 as isize) = 0 as i32 as u8;
         i = 0 as i32;
-        while (i as libc::c_long) < (*og).header_len {
+        while (i as isize) < (*og).header_len {
             crc_reg = crc_reg << 8 as i32
                 ^ crc_lookup[(crc_reg >> 24 as i32 & 0xff as i32 as u32
                     ^ *(*og).header.offset(i as isize) as u32)
@@ -562,7 +562,7 @@ pub unsafe extern "C" fn ogg_page_checksum_set(mut og: *mut crate::ogg_h::ogg_pa
             i += 1
         }
         i = 0 as i32;
-        while (i as libc::c_long) < (*og).body_len {
+        while (i as isize) < (*og).body_len {
             crc_reg = crc_reg << 8 as i32
                 ^ crc_lookup[(crc_reg >> 24 as i32 & 0xff as i32 as u32
                     ^ *(*og).body.offset(i as isize) as u32) as usize];
@@ -582,11 +582,11 @@ pub unsafe extern "C" fn ogg_stream_iovecin(
     mut os: *mut crate::ogg_h::ogg_stream_state,
     mut iov: *mut crate::ogg_h::ogg_iovec_t,
     mut count: i32,
-    mut e_o_s: libc::c_long,
+    mut e_o_s: isize,
     mut granulepos: crate::config_types_h::ogg_int64_t,
 ) -> i32 {
-    let mut bytes: libc::c_long = 0 as i32 as libc::c_long;
-    let mut lacing_vals: libc::c_long = 0;
+    let mut bytes: isize = 0 as i32 as isize;
+    let mut lacing_vals: isize = 0;
     let mut i: i32 = 0;
     if ogg_stream_check(os) != 0 {
         return -(1 as i32);
@@ -596,20 +596,20 @@ pub unsafe extern "C" fn ogg_stream_iovecin(
     }
     i = 0 as i32;
     while i < count {
-        if (*iov.offset(i as isize)).iov_len > 9223372036854775807 as libc::c_long as libc::c_ulong
+        if (*iov.offset(i as isize)).iov_len > 9223372036854775807 as isize as libc::c_ulong
         {
             return -(1 as i32);
         }
         if bytes
-            > 9223372036854775807 as libc::c_long
-                - (*iov.offset(i as isize)).iov_len as libc::c_long
+            > 9223372036854775807 as isize
+                - (*iov.offset(i as isize)).iov_len as isize
         {
             return -(1 as i32);
         }
-        bytes += (*iov.offset(i as isize)).iov_len as libc::c_long;
+        bytes += (*iov.offset(i as isize)).iov_len as isize;
         i += 1
     }
-    lacing_vals = bytes / 255 as i32 as libc::c_long + 1 as i32 as libc::c_long;
+    lacing_vals = bytes / 255 as i32 as isize + 1 as i32 as isize;
     if (*os).body_returned != 0 {
         /* advance packet data according to the body_returned pointer. We
         had to keep it around to return a pointer into the buffer last
@@ -622,7 +622,7 @@ pub unsafe extern "C" fn ogg_stream_iovecin(
                 (*os).body_fill as libc::c_ulong,
             );
         }
-        (*os).body_returned = 0 as i32 as libc::c_long
+        (*os).body_returned = 0 as i32 as isize
     }
     /* make sure we have the buffer storage */
     if _os_body_expand(os, bytes) != 0 || _os_lacing_expand(os, lacing_vals) != 0 {
@@ -639,27 +639,27 @@ pub unsafe extern "C" fn ogg_stream_iovecin(
             (*iov.offset(i as isize)).iov_base,
             (*iov.offset(i as isize)).iov_len,
         );
-        (*os).body_fill += (*iov.offset(i as isize)).iov_len as i32 as libc::c_long;
+        (*os).body_fill += (*iov.offset(i as isize)).iov_len as i32 as isize;
         i += 1
     }
     /* Store lacing vals for this packet */
     i = 0 as i32;
-    while (i as libc::c_long) < lacing_vals - 1 as i32 as libc::c_long {
+    while (i as isize) < lacing_vals - 1 as i32 as isize {
         *(*os)
             .lacing_vals
-            .offset(((*os).lacing_fill + i as libc::c_long) as isize) = 255 as i32;
+            .offset(((*os).lacing_fill + i as isize) as isize) = 255 as i32;
         *(*os)
             .granule_vals
-            .offset(((*os).lacing_fill + i as libc::c_long) as isize) = (*os).granulepos;
+            .offset(((*os).lacing_fill + i as isize) as isize) = (*os).granulepos;
         i += 1
     }
     *(*os)
         .lacing_vals
-        .offset(((*os).lacing_fill + i as libc::c_long) as isize) =
-        (bytes % 255 as i32 as libc::c_long) as i32;
+        .offset(((*os).lacing_fill + i as isize) as isize) =
+        (bytes % 255 as i32 as isize) as i32;
     let ref mut fresh0 = *(*os)
         .granule_vals
-        .offset(((*os).lacing_fill + i as libc::c_long) as isize);
+        .offset(((*os).lacing_fill + i as isize) as isize);
     *fresh0 = granulepos;
     (*os).granulepos = *fresh0;
     /* flag the first segment as the beginning of the packet */
@@ -699,13 +699,13 @@ unsafe extern "C" fn ogg_stream_flush_i(
 ) -> i32 {
     let mut i: i32 = 0;
     let mut vals: i32 = 0 as i32;
-    let mut maxvals: i32 = if (*os).lacing_fill > 255 as i32 as libc::c_long {
-        255 as i32 as libc::c_long
+    let mut maxvals: i32 = if (*os).lacing_fill > 255 as i32 as isize {
+        255 as i32 as isize
     } else {
         (*os).lacing_fill
     } as i32;
     let mut bytes: i32 = 0 as i32;
-    let mut acc: libc::c_long = 0 as i32 as libc::c_long;
+    let mut acc: isize = 0 as i32 as isize;
     let mut granule_pos: crate::config_types_h::ogg_int64_t =
         -(1 as i32) as crate::config_types_h::ogg_int64_t;
     if ogg_stream_check(os) != 0 {
@@ -743,11 +743,11 @@ unsafe extern "C" fn ogg_stream_flush_i(
         let mut packet_just_done: i32 = 0 as i32;
         vals = 0 as i32;
         while vals < maxvals {
-            if acc > nfill as libc::c_long && packet_just_done >= 4 as i32 {
+            if acc > nfill as isize && packet_just_done >= 4 as i32 {
                 force = 1 as i32;
                 break;
             } else {
-                acc += (*(*os).lacing_vals.offset(vals as isize) & 0xff as i32) as libc::c_long;
+                acc += (*(*os).lacing_vals.offset(vals as isize) & 0xff as i32) as isize;
                 if (*(*os).lacing_vals.offset(vals as isize) & 0xff as i32) < 255 as i32 {
                     granule_pos = *(*os).granule_vals.offset(vals as isize);
                     packets_done += 1;
@@ -785,7 +785,7 @@ unsafe extern "C" fn ogg_stream_flush_i(
             ((*os).header[5 as i32 as usize] as i32 | 0x2 as i32) as u8
     }
     /* last page flag? */
-    if (*os).e_o_s != 0 && (*os).lacing_fill == vals as libc::c_long {
+    if (*os).e_o_s != 0 && (*os).lacing_fill == vals as isize {
         (*os).header[5 as i32 as usize] =
             ((*os).header[5 as i32 as usize] as i32 | 0x4 as i32) as u8
     }
@@ -793,22 +793,22 @@ unsafe extern "C" fn ogg_stream_flush_i(
     /* 64 bits of PCM position */
     i = 6 as i32;
     while i < 14 as i32 {
-        (*os).header[i as usize] = (granule_pos & 0xff as i32 as libc::c_long) as u8;
+        (*os).header[i as usize] = (granule_pos & 0xff as i32 as isize) as u8;
         granule_pos >>= 8 as i32;
         i += 1
     }
     /* 32 bits of stream serial number */
-    let mut serialno: libc::c_long = (*os).serialno;
+    let mut serialno: isize = (*os).serialno;
     i = 14 as i32;
     while i < 18 as i32 {
-        (*os).header[i as usize] = (serialno & 0xff as i32 as libc::c_long) as u8;
+        (*os).header[i as usize] = (serialno & 0xff as i32 as isize) as u8;
         serialno >>= 8 as i32;
         i += 1
     }
     /* 32 bits of page counter (we have both counter and page header
     because this val can roll over) */
-    if (*os).pageno == -(1 as i32) as libc::c_long {
-        (*os).pageno = 0 as i32 as libc::c_long
+    if (*os).pageno == -(1 as i32) as isize {
+        (*os).pageno = 0 as i32 as isize
     } /* because someone called
       stream_reset; this would be a
       strange thing to do in an
@@ -816,10 +816,10 @@ unsafe extern "C" fn ogg_stream_flush_i(
       plausible uses */
     let fresh1 = (*os).pageno;
     (*os).pageno = (*os).pageno + 1;
-    let mut pageno: libc::c_long = fresh1;
+    let mut pageno: isize = fresh1;
     i = 18 as i32;
     while i < 22 as i32 {
-        (*os).header[i as usize] = (pageno & 0xff as i32 as libc::c_long) as u8;
+        (*os).header[i as usize] = (pageno & 0xff as i32 as isize) as u8;
         pageno >>= 8 as i32;
         i += 1
     }
@@ -840,11 +840,11 @@ unsafe extern "C" fn ogg_stream_flush_i(
     /* set pointers in the ogg_page struct */
     (*og).header = (*os).header.as_mut_ptr();
     (*os).header_fill = vals + 27 as i32;
-    (*og).header_len = (*os).header_fill as libc::c_long;
+    (*og).header_len = (*os).header_fill as isize;
     (*og).body = (*os).body_data.offset((*os).body_returned as isize);
-    (*og).body_len = bytes as libc::c_long;
+    (*og).body_len = bytes as isize;
     /* advance the lacing data and set the body_returned pointer */
-    (*os).lacing_fill -= vals as libc::c_long;
+    (*os).lacing_fill -= vals as isize;
     crate::stdlib::memmove(
         (*os).lacing_vals as *mut libc::c_void,
         (*os).lacing_vals.offset(vals as isize) as *const libc::c_void,
@@ -858,7 +858,7 @@ unsafe extern "C" fn ogg_stream_flush_i(
             crate::config_types_h::ogg_int64_t,
         >() as libc::c_ulong),
     );
-    (*os).body_returned += bytes as libc::c_long;
+    (*os).body_returned += bytes as isize;
     /* calculate the checksum */
     ogg_page_checksum_set(og);
     /* done */
@@ -1009,7 +1009,7 @@ pub unsafe extern "C" fn ogg_sync_check(mut oy: *mut crate::ogg_h::ogg_sync_stat
 
 pub unsafe extern "C" fn ogg_sync_buffer(
     mut oy: *mut crate::ogg_h::ogg_sync_state,
-    mut size: libc::c_long,
+    mut size: isize,
 ) -> *mut libc::c_char {
     if ogg_sync_check(oy) != 0 {
         return 0 as *mut libc::c_char;
@@ -1026,10 +1026,10 @@ pub unsafe extern "C" fn ogg_sync_buffer(
         }
         (*oy).returned = 0 as i32
     }
-    if size > ((*oy).storage - (*oy).fill) as libc::c_long {
+    if size > ((*oy).storage - (*oy).fill) as isize {
         /* We need to extend the internal buffer */
-        let mut newsize: libc::c_long =
-            size + (*oy).fill as libc::c_long + 4096 as i32 as libc::c_long; /* an extra page to be nice */
+        let mut newsize: isize =
+            size + (*oy).fill as isize + 4096 as i32 as isize; /* an extra page to be nice */
         let mut ret: *mut libc::c_void = 0 as *mut libc::c_void;
         if !(*oy).data.is_null() {
             ret = crate::stdlib::realloc((*oy).data as *mut libc::c_void, newsize as libc::c_ulong)
@@ -1050,15 +1050,15 @@ pub unsafe extern "C" fn ogg_sync_buffer(
 
 pub unsafe extern "C" fn ogg_sync_wrote(
     mut oy: *mut crate::ogg_h::ogg_sync_state,
-    mut bytes: libc::c_long,
+    mut bytes: isize,
 ) -> i32 {
     if ogg_sync_check(oy) != 0 {
         return -(1 as i32);
     }
-    if (*oy).fill as libc::c_long + bytes > (*oy).storage as libc::c_long {
+    if (*oy).fill as isize + bytes > (*oy).storage as isize {
         return -(1 as i32);
     }
-    (*oy).fill = ((*oy).fill as libc::c_long + bytes) as i32;
+    (*oy).fill = ((*oy).fill as isize + bytes) as i32;
     return 0 as i32;
 }
 /* sync the stream.  This is meant to be useful for finding page
@@ -1075,19 +1075,19 @@ pub unsafe extern "C" fn ogg_sync_wrote(
 pub unsafe extern "C" fn ogg_sync_pageseek(
     mut oy: *mut crate::ogg_h::ogg_sync_state,
     mut og: *mut crate::ogg_h::ogg_page,
-) -> libc::c_long {
+) -> isize {
     let mut current_block: u64; /* not enough for a header */
     let mut page: *mut u8 = (*oy).data.offset((*oy).returned as isize);
     let mut next: *mut u8 = 0 as *mut u8;
-    let mut bytes: libc::c_long = ((*oy).fill - (*oy).returned) as libc::c_long;
+    let mut bytes: isize = ((*oy).fill - (*oy).returned) as isize;
     if ogg_sync_check(oy) != 0 {
-        return 0 as i32 as libc::c_long;
+        return 0 as i32 as isize;
     }
     if (*oy).headerbytes == 0 as i32 {
         let mut headerbytes: i32 = 0;
         let mut i: i32 = 0;
-        if bytes < 27 as i32 as libc::c_long {
-            return 0 as i32 as libc::c_long;
+        if bytes < 27 as i32 as isize {
+            return 0 as i32 as isize;
         }
         /* verify capture pattern */
         if crate::stdlib::memcmp(
@@ -1099,8 +1099,8 @@ pub unsafe extern "C" fn ogg_sync_pageseek(
             current_block = 8719873228262180869; /* not enough for header + seg table */
         } else {
             headerbytes = *page.offset(26 as i32 as isize) as i32 + 27 as i32;
-            if bytes < headerbytes as libc::c_long {
-                return 0 as i32 as libc::c_long;
+            if bytes < headerbytes as isize {
+                return 0 as i32 as isize;
             }
             /* count up body length in the segment table */
             i = 0 as i32;
@@ -1116,8 +1116,8 @@ pub unsafe extern "C" fn ogg_sync_pageseek(
     }
     match current_block {
         12349973810996921269 => {
-            if ((*oy).bodybytes + (*oy).headerbytes) as libc::c_long > bytes {
-                return 0 as i32 as libc::c_long;
+            if ((*oy).bodybytes + (*oy).headerbytes) as isize > bytes {
+                return 0 as i32 as isize;
             }
             /* The whole test page is buffered.  Verify the checksum */
             /* Grab the checksum bytes, set the header field to zero */
@@ -1140,9 +1140,9 @@ pub unsafe extern "C" fn ogg_sync_pageseek(
             );
             /* set up a temp page struct and recompute the checksum */
             log.header = page;
-            log.header_len = (*oy).headerbytes as libc::c_long;
+            log.header_len = (*oy).headerbytes as isize;
             log.body = page.offset((*oy).headerbytes as isize);
-            log.body_len = (*oy).bodybytes as libc::c_long;
+            log.body_len = (*oy).bodybytes as isize;
             ogg_page_checksum_set(&mut log);
             /* Compare */
             if crate::stdlib::memcmp(
@@ -1162,16 +1162,16 @@ pub unsafe extern "C" fn ogg_sync_pageseek(
             } else {
                 /* yes, have a whole page all ready to go */
                 let mut page_0: *mut u8 = (*oy).data.offset((*oy).returned as isize);
-                let mut bytes_0: libc::c_long = 0;
+                let mut bytes_0: isize = 0;
                 if !og.is_null() {
                     (*og).header = page_0;
-                    (*og).header_len = (*oy).headerbytes as libc::c_long;
+                    (*og).header_len = (*oy).headerbytes as isize;
                     (*og).body = page_0.offset((*oy).headerbytes as isize);
-                    (*og).body_len = (*oy).bodybytes as libc::c_long
+                    (*og).body_len = (*oy).bodybytes as isize
                 }
                 (*oy).unsynced = 0 as i32;
-                bytes_0 = ((*oy).headerbytes + (*oy).bodybytes) as libc::c_long;
-                (*oy).returned = ((*oy).returned as libc::c_long + bytes_0) as i32;
+                bytes_0 = ((*oy).headerbytes + (*oy).bodybytes) as isize;
+                (*oy).returned = ((*oy).returned as isize + bytes_0) as i32;
                 (*oy).headerbytes = 0 as i32;
                 (*oy).bodybytes = 0 as i32;
                 return bytes_0;
@@ -1186,13 +1186,13 @@ pub unsafe extern "C" fn ogg_sync_pageseek(
     next = crate::stdlib::memchr(
         page.offset(1 as i32 as isize) as *const libc::c_void,
         'O' as i32,
-        (bytes - 1 as i32 as libc::c_long) as libc::c_ulong,
+        (bytes - 1 as i32 as isize) as libc::c_ulong,
     ) as *mut u8;
     if next.is_null() {
         next = (*oy).data.offset((*oy).fill as isize)
     }
-    (*oy).returned = next.offset_from((*oy).data) as libc::c_long as i32;
-    return -(next.offset_from(page) as libc::c_long);
+    (*oy).returned = next.offset_from((*oy).data) as isize as i32;
+    return -(next.offset_from(page) as isize);
 }
 /* sync the stream and get a page.  Keep trying until we find a page.
 Suppress 'sync errors' after reporting the first.
@@ -1218,13 +1218,13 @@ pub unsafe extern "C" fn ogg_sync_pageout(
     buffer.  If it doesn't verify, we look for the next potential
     frame */
     {
-        let mut ret: libc::c_long = ogg_sync_pageseek(oy, og);
-        if ret > 0 as i32 as libc::c_long {
+        let mut ret: isize = ogg_sync_pageseek(oy, og);
+        if ret > 0 as i32 as isize {
             /* loop. keep looking */
             /* have a page */
             return 1 as i32;
         }
-        if ret == 0 as i32 as libc::c_long {
+        if ret == 0 as i32 as isize {
             /* need more data */
             return 0 as i32;
         }
@@ -1245,7 +1245,7 @@ pub unsafe extern "C" fn ogg_stream_pagein(
 ) -> i32 {
     let mut header: *mut u8 = (*og).header;
     let mut body: *mut u8 = (*og).body;
-    let mut bodysize: libc::c_long = (*og).body_len;
+    let mut bodysize: isize = (*og).body_len;
     let mut segptr: i32 = 0 as i32;
     let mut version: i32 = ogg_page_version(og);
     let mut continued: i32 = ogg_page_continued(og);
@@ -1253,14 +1253,14 @@ pub unsafe extern "C" fn ogg_stream_pagein(
     let mut eos: i32 = ogg_page_eos(og);
     let mut granulepos: crate::config_types_h::ogg_int64_t = ogg_page_granulepos(og);
     let mut serialno: i32 = ogg_page_serialno(og);
-    let mut pageno: libc::c_long = ogg_page_pageno(og);
+    let mut pageno: isize = ogg_page_pageno(og);
     let mut segments: i32 = *header.offset(26 as i32 as isize) as i32;
     if ogg_stream_check(os) != 0 {
         return -(1 as i32);
     }
     /* clean up 'returned data' */
-    let mut lr: libc::c_long = (*os).lacing_returned;
-    let mut br: libc::c_long = (*os).body_returned;
+    let mut lr: isize = (*os).lacing_returned;
+    let mut br: isize = (*os).body_returned;
     /* body data */
     if br != 0 {
         (*os).body_fill -= br;
@@ -1271,7 +1271,7 @@ pub unsafe extern "C" fn ogg_stream_pagein(
                 (*os).body_fill as libc::c_ulong,
             );
         }
-        (*os).body_returned = 0 as i32 as libc::c_long
+        (*os).body_returned = 0 as i32 as isize
     }
     if lr != 0 {
         /* segment table */
@@ -1292,16 +1292,16 @@ pub unsafe extern "C" fn ogg_stream_pagein(
         }
         (*os).lacing_fill -= lr;
         (*os).lacing_packet -= lr;
-        (*os).lacing_returned = 0 as i32 as libc::c_long
+        (*os).lacing_returned = 0 as i32 as isize
     }
     /* check the serial number */
-    if serialno as libc::c_long != (*os).serialno {
+    if serialno as isize != (*os).serialno {
         return -(1 as i32);
     }
     if version > 0 as i32 {
         return -(1 as i32);
     }
-    if _os_lacing_expand(os, (segments + 1 as i32) as libc::c_long) != 0 {
+    if _os_lacing_expand(os, (segments + 1 as i32) as isize) != 0 {
         return -(1 as i32);
     }
     /* are we in sequence? */
@@ -1309,14 +1309,14 @@ pub unsafe extern "C" fn ogg_stream_pagein(
         let mut i: i32 = 0;
         /* unroll previous partial packet (if any) */
         i = (*os).lacing_packet as i32;
-        while (i as libc::c_long) < (*os).lacing_fill {
+        while (i as isize) < (*os).lacing_fill {
             (*os).body_fill -=
-                (*(*os).lacing_vals.offset(i as isize) & 0xff as i32) as libc::c_long;
+                (*(*os).lacing_vals.offset(i as isize) & 0xff as i32) as isize;
             i += 1
         }
         (*os).lacing_fill = (*os).lacing_packet;
         /* make a note of dropped data in segment table */
-        if (*os).pageno != -(1 as i32) as libc::c_long {
+        if (*os).pageno != -(1 as i32) as isize {
             let fresh2 = (*os).lacing_fill;
             (*os).lacing_fill = (*os).lacing_fill + 1;
             *(*os).lacing_vals.offset(fresh2 as isize) = 0x400 as i32;
@@ -1326,22 +1326,22 @@ pub unsafe extern "C" fn ogg_stream_pagein(
     /* are we a 'continued packet' page?  If so, we may need to skip
     some segments */
     if continued != 0 {
-        if (*os).lacing_fill < 1 as i32 as libc::c_long
+        if (*os).lacing_fill < 1 as i32 as isize
             || (*(*os)
                 .lacing_vals
-                .offset(((*os).lacing_fill - 1 as i32 as libc::c_long) as isize)
+                .offset(((*os).lacing_fill - 1 as i32 as isize) as isize)
                 & 0xff as i32)
                 < 255 as i32
             || *(*os)
                 .lacing_vals
-                .offset(((*os).lacing_fill - 1 as i32 as libc::c_long) as isize)
+                .offset(((*os).lacing_fill - 1 as i32 as isize) as isize)
                 == 0x400 as i32
         {
             bos = 0 as i32;
             while segptr < segments {
                 let mut val: i32 = *header.offset((27 as i32 + segptr) as isize) as i32;
                 body = body.offset(val as isize);
-                bodysize -= val as libc::c_long;
+                bodysize -= val as isize;
                 if val < 255 as i32 {
                     segptr += 1;
                     break;
@@ -1387,13 +1387,13 @@ pub unsafe extern "C" fn ogg_stream_pagein(
     }
     if eos != 0 {
         (*os).e_o_s = 1 as i32;
-        if (*os).lacing_fill > 0 as i32 as libc::c_long {
+        if (*os).lacing_fill > 0 as i32 as isize {
             *(*os)
                 .lacing_vals
-                .offset(((*os).lacing_fill - 1 as i32 as libc::c_long) as isize) |= 0x200 as i32
+                .offset(((*os).lacing_fill - 1 as i32 as isize) as isize) |= 0x200 as i32
         }
     }
-    (*os).pageno = pageno + 1 as i32 as libc::c_long;
+    (*os).pageno = pageno + 1 as i32 as isize;
     return 0 as i32;
 }
 /* clear things to an initial state.  Good to call, eg, before seeking */
@@ -1416,15 +1416,15 @@ pub unsafe extern "C" fn ogg_stream_reset(mut os: *mut crate::ogg_h::ogg_stream_
     if ogg_stream_check(os) != 0 {
         return -(1 as i32);
     }
-    (*os).body_fill = 0 as i32 as libc::c_long;
-    (*os).body_returned = 0 as i32 as libc::c_long;
-    (*os).lacing_fill = 0 as i32 as libc::c_long;
-    (*os).lacing_packet = 0 as i32 as libc::c_long;
-    (*os).lacing_returned = 0 as i32 as libc::c_long;
+    (*os).body_fill = 0 as i32 as isize;
+    (*os).body_returned = 0 as i32 as isize;
+    (*os).lacing_fill = 0 as i32 as isize;
+    (*os).lacing_packet = 0 as i32 as isize;
+    (*os).lacing_returned = 0 as i32 as isize;
     (*os).header_fill = 0 as i32;
     (*os).e_o_s = 0 as i32;
     (*os).b_o_s = 0 as i32;
-    (*os).pageno = -(1 as i32) as libc::c_long;
+    (*os).pageno = -(1 as i32) as isize;
     (*os).packetno = 0 as i32 as crate::config_types_h::ogg_int64_t;
     (*os).granulepos = 0 as i32 as crate::config_types_h::ogg_int64_t;
     return 0 as i32;
@@ -1439,7 +1439,7 @@ pub unsafe extern "C" fn ogg_stream_reset_serialno(
         return -(1 as i32);
     }
     ogg_stream_reset(os);
-    (*os).serialno = serialno as libc::c_long;
+    (*os).serialno = serialno as isize;
     return 0 as i32;
 }
 
@@ -1452,7 +1452,7 @@ unsafe extern "C" fn _packetout(
     segments.  Now we need to group them into packets (or return the
     out of sync markers) */
     let mut ptr: i32 = (*os).lacing_returned as i32;
-    if (*os).lacing_packet <= ptr as libc::c_long {
+    if (*os).lacing_packet <= ptr as isize {
         return 0 as i32;
     }
     if *(*os).lacing_vals.offset(ptr as isize) & 0x400 as i32 != 0 {
@@ -1469,7 +1469,7 @@ unsafe extern "C" fn _packetout(
     }
     /* Gather the whole packet. We'll have no holes or a partial packet */
     let mut size: i32 = *(*os).lacing_vals.offset(ptr as isize) & 0xff as i32; /* last packet of the stream? */
-    let mut bytes: libc::c_long = size as libc::c_long; /* first packet of the stream? */
+    let mut bytes: isize = size as isize; /* first packet of the stream? */
     let mut eos: i32 = *(*os).lacing_vals.offset(ptr as isize) & 0x200 as i32;
     let mut bos: i32 = *(*os).lacing_vals.offset(ptr as isize) & 0x100 as i32;
     while size == 255 as i32 {
@@ -1479,11 +1479,11 @@ unsafe extern "C" fn _packetout(
         if val & 0x200 as i32 != 0 {
             eos = 0x200 as i32
         }
-        bytes += size as libc::c_long
+        bytes += size as isize
     }
     if !op.is_null() {
-        (*op).e_o_s = eos as libc::c_long;
-        (*op).b_o_s = bos as libc::c_long;
+        (*op).e_o_s = eos as isize;
+        (*op).b_o_s = bos as isize;
         (*op).packet = (*os).body_data.offset((*os).body_returned as isize);
         (*op).packetno = (*os).packetno;
         (*op).granulepos = *(*os).granule_vals.offset(ptr as isize);
@@ -1491,7 +1491,7 @@ unsafe extern "C" fn _packetout(
     }
     if adv != 0 {
         (*os).body_returned += bytes;
-        (*os).lacing_returned = (ptr + 1 as i32) as libc::c_long;
+        (*os).lacing_returned = (ptr + 1 as i32) as isize;
         (*os).packetno += 1
     }
     return 1 as i32;

--- a/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/analysis.rs
+++ b/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/analysis.rs
@@ -43,10 +43,10 @@ pub unsafe extern "C" fn vorbis_analysis(
     let mut i: i32 = 0;
     let mut vbi: *mut crate::codec_internal_h::vorbis_block_internal =
         (*vb).internal as *mut crate::codec_internal_h::vorbis_block_internal;
-    (*vb).glue_bits = 0 as i32 as libc::c_long;
-    (*vb).time_bits = 0 as i32 as libc::c_long;
-    (*vb).floor_bits = 0 as i32 as libc::c_long;
-    (*vb).res_bits = 0 as i32 as libc::c_long;
+    (*vb).glue_bits = 0 as i32 as isize;
+    (*vb).time_bits = 0 as i32 as isize;
+    (*vb).floor_bits = 0 as i32 as isize;
+    (*vb).res_bits = 0 as i32 as isize;
     /* first things first.  Make sure encode is ready */
     i = 0 as i32;
     while i < 15 as i32 {
@@ -81,8 +81,8 @@ pub unsafe extern "C" fn vorbis_analysis(
         (*op).bytes = crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(
             &mut (*vb).opb as *mut _ as *mut crate::ogg_h::oggpack_buffer,
         );
-        (*op).b_o_s = 0 as i32 as libc::c_long;
-        (*op).e_o_s = (*vb).eofflag as libc::c_long;
+        (*op).b_o_s = 0 as i32 as isize;
+        (*op).e_o_s = (*vb).eofflag as isize;
         (*op).granulepos = (*vb).granulepos;
         (*op).packetno = (*vb).sequence
         /* for sake of completeness */

--- a/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/bitrate.rs
+++ b/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/bitrate.rs
@@ -3,12 +3,12 @@
 #[derive(Copy, Clone)]
 pub struct bitrate_manager_state {
     pub managed: i32,
-    pub avg_reservoir: libc::c_long,
-    pub minmax_reservoir: libc::c_long,
-    pub avg_bitsper: libc::c_long,
-    pub min_bitsper: libc::c_long,
-    pub max_bitsper: libc::c_long,
-    pub short_per_long: libc::c_long,
+    pub avg_reservoir: isize,
+    pub minmax_reservoir: isize,
+    pub avg_bitsper: isize,
+    pub min_bitsper: isize,
+    pub max_bitsper: isize,
+    pub short_per_long: isize,
     pub avgfloat: f64,
     pub vb: *mut crate::codec_h::vorbis_block,
     pub choice: i32,
@@ -17,10 +17,10 @@ pub struct bitrate_manager_state {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct bitrate_manager_info {
-    pub avg_rate: libc::c_long,
-    pub min_rate: libc::c_long,
-    pub max_rate: libc::c_long,
-    pub reservoir_bits: libc::c_long,
+    pub avg_rate: isize,
+    pub min_rate: isize,
+    pub max_rate: isize,
+    pub reservoir_bits: isize,
     pub reservoir_bias: f64,
     pub slew_damp: f64,
 }
@@ -100,26 +100,26 @@ pub unsafe extern "C" fn vorbis_bitrate_init(
         ::std::mem::size_of::<crate::src::libvorbis_1_3_6::lib::bitrate::bitrate_manager_state>()
             as libc::c_ulong,
     );
-    if !bi.is_null() && (*bi).reservoir_bits > 0 as i32 as libc::c_long {
-        let mut ratesamples: libc::c_long = (*vi).rate;
+    if !bi.is_null() && (*bi).reservoir_bits > 0 as i32 as isize {
+        let mut ratesamples: isize = (*vi).rate;
         let mut halfsamples: i32 = ((*ci).blocksizes[0 as i32 as usize] >> 1 as i32) as i32;
         (*bm).short_per_long =
             (*ci).blocksizes[1 as i32 as usize] / (*ci).blocksizes[0 as i32 as usize];
         (*bm).managed = 1 as i32;
         (*bm).avg_bitsper = crate::stdlib::rint(
             1.0f64 * (*bi).avg_rate as f64 * halfsamples as f64 / ratesamples as f64,
-        ) as libc::c_long;
+        ) as isize;
         (*bm).min_bitsper = crate::stdlib::rint(
             1.0f64 * (*bi).min_rate as f64 * halfsamples as f64 / ratesamples as f64,
-        ) as libc::c_long;
+        ) as isize;
         (*bm).max_bitsper = crate::stdlib::rint(
             1.0f64 * (*bi).max_rate as f64 * halfsamples as f64 / ratesamples as f64,
-        ) as libc::c_long;
+        ) as isize;
         (*bm).avgfloat = (15 as i32 / 2 as i32) as f64;
         /* not a necessary fix, but one that leads to a more balanced
         typical initialization */
-        let mut desired_fill: libc::c_long =
-            ((*bi).reservoir_bits as f64 * (*bi).reservoir_bias) as libc::c_long;
+        let mut desired_fill: isize =
+            ((*bi).reservoir_bits as f64 * (*bi).reservoir_bias) as isize;
         (*bm).minmax_reservoir = desired_fill;
         (*bm).avg_reservoir = desired_fill
     };
@@ -166,22 +166,22 @@ pub unsafe extern "C" fn vorbis_bitrate_addblock(mut vb: *mut crate::codec_h::vo
     let mut bi: *mut crate::src::libvorbis_1_3_6::lib::bitrate::bitrate_manager_info =
         &mut (*ci).bi;
     let mut choice: i32 = crate::stdlib::rint((*bm).avgfloat) as i32;
-    let mut this_bits: libc::c_long = crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(
+    let mut this_bits: isize = crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(
         (*vbi).packetblob[choice as usize] as *mut crate::ogg_h::oggpack_buffer,
-    ) * 8 as i32 as libc::c_long;
-    let mut min_target_bits: libc::c_long = if (*vb).W != 0 {
+    ) * 8 as i32 as isize;
+    let mut min_target_bits: isize = if (*vb).W != 0 {
         ((*bm).min_bitsper) * (*bm).short_per_long
     } else {
         (*bm).min_bitsper
     };
-    let mut max_target_bits: libc::c_long = if (*vb).W != 0 {
+    let mut max_target_bits: isize = if (*vb).W != 0 {
         ((*bm).max_bitsper) * (*bm).short_per_long
     } else {
         (*bm).max_bitsper
     };
     let mut samples: i32 = ((*ci).blocksizes[(*vb).W as usize] >> 1 as i32) as i32;
-    let mut desired_fill: libc::c_long =
-        ((*bi).reservoir_bits as f64 * (*bi).reservoir_bias) as libc::c_long;
+    let mut desired_fill: isize =
+        ((*bi).reservoir_bits as f64 * (*bi).reservoir_bias) as isize;
     if (*bm).managed == 0 {
         /* not a bitrate managed stream, but for API simplicity, we'll
         buffer the packet to keep the code path clean */
@@ -194,9 +194,9 @@ pub unsafe extern "C" fn vorbis_bitrate_addblock(mut vb: *mut crate::codec_h::vo
     }
     (*bm).vb = vb;
     /* look ahead for avg floater */
-    if (*bm).avg_bitsper > 0 as i32 as libc::c_long {
+    if (*bm).avg_bitsper > 0 as i32 as isize {
         let mut slew: f64 = 0.0f64;
-        let mut avg_target_bits: libc::c_long = if (*vb).W != 0 {
+        let mut avg_target_bits: isize = if (*vb).W != 0 {
             ((*bm).avg_bitsper) * (*bm).short_per_long
         } else {
             (*bm).avg_bitsper
@@ -220,7 +220,7 @@ pub unsafe extern "C" fn vorbis_bitrate_addblock(mut vb: *mut crate::codec_h::vo
                 choice -= 1;
                 this_bits = crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(
                     (*vbi).packetblob[choice as usize] as *mut crate::ogg_h::oggpack_buffer,
-                ) * 8 as i32 as libc::c_long
+                ) * 8 as i32 as isize
             }
         } else if (*bm).avg_reservoir + (this_bits - avg_target_bits) < desired_fill {
             while (choice + 1 as i32) < 15 as i32
@@ -230,7 +230,7 @@ pub unsafe extern "C" fn vorbis_bitrate_addblock(mut vb: *mut crate::codec_h::vo
                 choice += 1;
                 this_bits = crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(
                     (*vbi).packetblob[choice as usize] as *mut crate::ogg_h::oggpack_buffer,
-                ) * 8 as i32 as libc::c_long
+                ) * 8 as i32 as isize
             }
         }
         slew = crate::stdlib::rint(choice as f64 - (*bm).avgfloat) / samples as f64
@@ -245,13 +245,13 @@ pub unsafe extern "C" fn vorbis_bitrate_addblock(mut vb: *mut crate::codec_h::vo
         choice = crate::stdlib::rint((*bm).avgfloat) as i32;
         this_bits = crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(
             (*vbi).packetblob[choice as usize] as *mut crate::ogg_h::oggpack_buffer,
-        ) * 8 as i32 as libc::c_long
+        ) * 8 as i32 as isize
     }
     /* enforce min(if used) on the current floater (if used) */
-    if (*bm).min_bitsper > 0 as i32 as libc::c_long {
+    if (*bm).min_bitsper > 0 as i32 as isize {
         /* do we need to force the bitrate up? */
         if this_bits < min_target_bits {
-            while (*bm).minmax_reservoir - (min_target_bits - this_bits) < 0 as i32 as libc::c_long
+            while (*bm).minmax_reservoir - (min_target_bits - this_bits) < 0 as i32 as isize
             {
                 choice += 1;
                 if choice >= 15 as i32 {
@@ -259,12 +259,12 @@ pub unsafe extern "C" fn vorbis_bitrate_addblock(mut vb: *mut crate::codec_h::vo
                 }
                 this_bits = crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(
                     (*vbi).packetblob[choice as usize] as *mut crate::ogg_h::oggpack_buffer,
-                ) * 8 as i32 as libc::c_long
+                ) * 8 as i32 as isize
             }
         }
     }
     /* enforce max (if used) on the current floater (if used) */
-    if (*bm).max_bitsper > 0 as i32 as libc::c_long {
+    if (*bm).max_bitsper > 0 as i32 as isize {
         /* do we need to force the bitrate down? */
         if this_bits > max_target_bits {
             while (*bm).minmax_reservoir + (this_bits - max_target_bits) > (*bi).reservoir_bits {
@@ -274,7 +274,7 @@ pub unsafe extern "C" fn vorbis_bitrate_addblock(mut vb: *mut crate::codec_h::vo
                 }
                 this_bits = crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(
                     (*vbi).packetblob[choice as usize] as *mut crate::ogg_h::oggpack_buffer,
-                ) * 8 as i32 as libc::c_long
+                ) * 8 as i32 as isize
             }
         }
     }
@@ -283,9 +283,9 @@ pub unsafe extern "C" fn vorbis_bitrate_addblock(mut vb: *mut crate::codec_h::vo
     if choice < 0 as i32 {
         /* choosing a smaller packetblob is insufficient to trim bitrate.
         frame will need to be truncated */
-        let mut maxsize: libc::c_long = (max_target_bits
+        let mut maxsize: isize = (max_target_bits
             + ((*bi).reservoir_bits - (*bm).minmax_reservoir))
-            / 8 as i32 as libc::c_long;
+            / 8 as i32 as isize;
         choice = 0 as i32;
         (*bm).choice = choice;
         if crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(
@@ -294,16 +294,16 @@ pub unsafe extern "C" fn vorbis_bitrate_addblock(mut vb: *mut crate::codec_h::vo
         {
             crate::src::libogg_1_3_3::src::bitwise::oggpack_writetrunc(
                 (*vbi).packetblob[choice as usize] as *mut crate::ogg_h::oggpack_buffer,
-                maxsize * 8 as i32 as libc::c_long,
+                maxsize * 8 as i32 as isize,
             );
             this_bits = crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(
                 (*vbi).packetblob[choice as usize] as *mut crate::ogg_h::oggpack_buffer,
-            ) * 8 as i32 as libc::c_long
+            ) * 8 as i32 as isize
         }
     } else {
-        let mut minsize: libc::c_long = (min_target_bits - (*bm).minmax_reservoir
-            + 7 as i32 as libc::c_long)
-            / 8 as i32 as libc::c_long;
+        let mut minsize: isize = (min_target_bits - (*bm).minmax_reservoir
+            + 7 as i32 as isize)
+            / 8 as i32 as isize;
         if choice >= 15 as i32 {
             choice = 15 as i32 - 1 as i32
         }
@@ -315,7 +315,7 @@ pub unsafe extern "C" fn vorbis_bitrate_addblock(mut vb: *mut crate::codec_h::vo
         loop {
             let fresh0 = minsize;
             minsize = minsize - 1;
-            if !(fresh0 > 0 as i32 as libc::c_long) {
+            if !(fresh0 > 0 as i32 as isize) {
                 break;
             }
             crate::src::libogg_1_3_3::src::bitwise::oggpack_write(
@@ -326,18 +326,18 @@ pub unsafe extern "C" fn vorbis_bitrate_addblock(mut vb: *mut crate::codec_h::vo
         }
         this_bits = crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(
             (*vbi).packetblob[choice as usize] as *mut crate::ogg_h::oggpack_buffer,
-        ) * 8 as i32 as libc::c_long
+        ) * 8 as i32 as isize
     }
     /* now we have the final packet and the final packet size.  Update statistics */
     /* min and max reservoir */
-    if (*bm).min_bitsper > 0 as i32 as libc::c_long || (*bm).max_bitsper > 0 as i32 as libc::c_long
+    if (*bm).min_bitsper > 0 as i32 as isize || (*bm).max_bitsper > 0 as i32 as isize
     {
-        if max_target_bits > 0 as i32 as libc::c_long && this_bits > max_target_bits {
+        if max_target_bits > 0 as i32 as isize && this_bits > max_target_bits {
             (*bm).minmax_reservoir += this_bits - max_target_bits
-        } else if min_target_bits > 0 as i32 as libc::c_long && this_bits < min_target_bits {
+        } else if min_target_bits > 0 as i32 as isize && this_bits < min_target_bits {
             (*bm).minmax_reservoir += this_bits - min_target_bits
         } else if (*bm).minmax_reservoir > desired_fill {
-            if max_target_bits > 0 as i32 as libc::c_long {
+            if max_target_bits > 0 as i32 as isize {
                 /* inbetween; we want to take reservoir toward but not past desired_fill */
                 /* logical bulletproofing against initialization state */
                 (*bm).minmax_reservoir += this_bits - max_target_bits;
@@ -347,7 +347,7 @@ pub unsafe extern "C" fn vorbis_bitrate_addblock(mut vb: *mut crate::codec_h::vo
             } else {
                 (*bm).minmax_reservoir = desired_fill
             }
-        } else if min_target_bits > 0 as i32 as libc::c_long {
+        } else if min_target_bits > 0 as i32 as isize {
             /* logical bulletproofing against initialization state */
             (*bm).minmax_reservoir += this_bits - min_target_bits;
             if (*bm).minmax_reservoir > desired_fill {
@@ -358,8 +358,8 @@ pub unsafe extern "C" fn vorbis_bitrate_addblock(mut vb: *mut crate::codec_h::vo
         }
     }
     /* avg reservoir */
-    if (*bm).avg_bitsper > 0 as i32 as libc::c_long {
-        let mut avg_target_bits_0: libc::c_long = if (*vb).W != 0 {
+    if (*bm).avg_bitsper > 0 as i32 as isize {
+        let mut avg_target_bits_0: isize = if (*vb).W != 0 {
             ((*bm).avg_bitsper) * (*bm).short_per_long
         } else {
             (*bm).avg_bitsper
@@ -395,8 +395,8 @@ pub unsafe extern "C" fn vorbis_bitrate_flushpacket(
         (*op).bytes = crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(
             (*vbi).packetblob[choice as usize] as *mut crate::ogg_h::oggpack_buffer,
         );
-        (*op).b_o_s = 0 as i32 as libc::c_long;
-        (*op).e_o_s = (*vb).eofflag as libc::c_long;
+        (*op).b_o_s = 0 as i32 as isize;
+        (*op).e_o_s = (*vb).eofflag as isize;
         (*op).granulepos = (*vb).granulepos;
         (*op).packetno = (*vb).sequence
         /* for sake of completeness */

--- a/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/block.rs
+++ b/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/block.rs
@@ -75,7 +75,7 @@ pub unsafe extern "C" fn vorbis_block_init(
         ::std::mem::size_of::<crate::codec_h::vorbis_block>() as libc::c_ulong,
     );
     (*vb).vd = v;
-    (*vb).localalloc = 0 as i32 as libc::c_long;
+    (*vb).localalloc = 0 as i32 as isize;
     (*vb).localstore = 0 as *mut libc::c_void;
     if (*v).analysisp != 0 {
         (*vb).internal = crate::stdlib::calloc(
@@ -109,9 +109,9 @@ pub unsafe extern "C" fn vorbis_block_init(
 
 pub unsafe extern "C" fn _vorbis_block_alloc(
     mut vb: *mut crate::codec_h::vorbis_block,
-    mut bytes: libc::c_long,
+    mut bytes: isize,
 ) -> *mut libc::c_void {
-    bytes = bytes + (8 as i32 - 1 as i32) as libc::c_long & !(8 as i32 - 1 as i32) as libc::c_long;
+    bytes = bytes + (8 as i32 - 1 as i32) as isize & !(8 as i32 - 1 as i32) as isize;
     if bytes + (*vb).localtop > (*vb).localalloc {
         /* can't just _ogg_realloc... there are outstanding pointers */
         if !(*vb).localstore.is_null() {
@@ -127,7 +127,7 @@ pub unsafe extern "C" fn _vorbis_block_alloc(
         /* highly conservative */
         (*vb).localalloc = bytes;
         (*vb).localstore = crate::stdlib::malloc((*vb).localalloc as libc::c_ulong);
-        (*vb).localtop = 0 as i32 as libc::c_long
+        (*vb).localtop = 0 as i32 as isize
     }
     let mut ret: *mut libc::c_void = ((*vb).localstore as *mut libc::c_char)
         .offset((*vb).localtop as isize) as *mut libc::c_void;
@@ -173,10 +173,10 @@ pub unsafe extern "C" fn _vorbis_block_ripcord(mut vb: *mut crate::codec_h::vorb
             ((*vb).totaluse + (*vb).localalloc) as libc::c_ulong,
         );
         (*vb).localalloc += (*vb).totaluse;
-        (*vb).totaluse = 0 as i32 as libc::c_long
+        (*vb).totaluse = 0 as i32 as isize
     }
     /* pull the ripcord */
-    (*vb).localtop = 0 as i32 as libc::c_long;
+    (*vb).localtop = 0 as i32 as isize;
     (*vb).reap = 0 as *mut crate::codec_h::alloc_chain;
 }
 #[no_mangle]
@@ -227,7 +227,7 @@ unsafe extern "C" fn _vds_shared_init(
     let mut hs: i32 = 0;
     if ci.is_null()
         || (*ci).modes <= 0 as i32
-        || (*ci).blocksizes[0 as i32 as usize] < 64 as i32 as libc::c_long
+        || (*ci).blocksizes[0 as i32 as usize] < 64 as i32 as isize
         || (*ci).blocksizes[1 as i32 as usize] < (*ci).blocksizes[0 as i32 as usize]
     {
         return 1 as i32;
@@ -340,7 +340,7 @@ unsafe extern "C" fn _vds_shared_init(
                 &mut (*ci).psy_g_param as *mut _
                     as *mut crate::src::libvorbis_1_3_6::lib::psy::vorbis_info_psy_global,
                 ((*ci).blocksizes[(*(*ci).psy_param[i as usize]).blockflag as usize]
-                    / 2 as i32 as libc::c_long) as i32,
+                    / 2 as i32 as isize) as i32,
                 (*vi).rate,
             );
             i += 1
@@ -425,10 +425,10 @@ unsafe extern "C" fn _vds_shared_init(
     }
     /* all 1 (large block) or 0 (small block) */
     /* explicitly set for the sake of clarity */
-    (*v).lW = 0 as i32 as libc::c_long; /* previous window size */
-    (*v).W = 0 as i32 as libc::c_long; /* current window size */
+    (*v).lW = 0 as i32 as isize; /* previous window size */
+    (*v).W = 0 as i32 as isize; /* current window size */
     /* all vector indexes */
-    (*v).centerW = (*ci).blocksizes[1 as i32 as usize] / 2 as i32 as libc::c_long;
+    (*v).centerW = (*ci).blocksizes[1 as i32 as usize] / 2 as i32 as isize;
     (*v).pcm_current = (*v).centerW as i32;
     /* initialize all the backend lookups */
     (*b).flr = crate::stdlib::calloc(
@@ -698,17 +698,17 @@ unsafe extern "C" fn _preextrapolate_helper(mut v: *mut crate::codec_h::vorbis_d
             .wrapping_mul(::std::mem::size_of::<f32>() as libc::c_ulong) as usize,
     );
     let mut work: *mut f32 = fresh8.as_mut_ptr() as *mut f32;
-    let mut j: libc::c_long = 0;
+    let mut j: isize = 0;
     (*v).preextrapolate = 1 as i32;
-    if (*v).pcm_current as libc::c_long - (*v).centerW > (order * 2 as i32) as libc::c_long {
+    if (*v).pcm_current as isize - (*v).centerW > (order * 2 as i32) as isize {
         /* safety */
         i = 0 as i32;
         while i < (*(*v).vi).channels {
             /* need to run the extrapolation in reverse! */
-            j = 0 as i32 as libc::c_long;
-            while j < (*v).pcm_current as libc::c_long {
+            j = 0 as i32 as isize;
+            while j < (*v).pcm_current as isize {
                 *work.offset(j as isize) = *(*(*v).pcm.offset(i as isize)).offset(
-                    ((*v).pcm_current as libc::c_long - j - 1 as i32 as libc::c_long) as isize,
+                    ((*v).pcm_current as isize - j - 1 as i32 as isize) as isize,
                 );
                 j += 1
             }
@@ -716,7 +716,7 @@ unsafe extern "C" fn _preextrapolate_helper(mut v: *mut crate::codec_h::vorbis_d
             crate::src::libvorbis_1_3_6::lib::lpc::vorbis_lpc_from_data(
                 work,
                 lpc,
-                ((*v).pcm_current as libc::c_long - (*v).centerW) as i32,
+                ((*v).pcm_current as isize - (*v).centerW) as i32,
                 order,
             );
             /* run the predictor filter */
@@ -730,10 +730,10 @@ unsafe extern "C" fn _preextrapolate_helper(mut v: *mut crate::codec_h::vorbis_d
                     .offset(-((*v).centerW as isize)),
                 (*v).centerW,
             );
-            j = 0 as i32 as libc::c_long;
-            while j < (*v).pcm_current as libc::c_long {
+            j = 0 as i32 as isize;
+            while j < (*v).pcm_current as isize {
                 *(*(*v).pcm.offset(i as isize)).offset(
-                    ((*v).pcm_current as libc::c_long - j - 1 as i32 as libc::c_long) as isize,
+                    ((*v).pcm_current as isize - j - 1 as i32 as isize) as isize,
                 ) = *work.offset(j as isize);
                 j += 1
             }
@@ -771,19 +771,19 @@ pub unsafe extern "C" fn vorbis_analysis_wrote(
         suck to encode.  Extrapolate for the sake of cleanliness. */
         vorbis_analysis_buffer(
             v,
-            ((*ci).blocksizes[1 as i32 as usize] * 3 as i32 as libc::c_long) as i32,
+            ((*ci).blocksizes[1 as i32 as usize] * 3 as i32 as isize) as i32,
         );
         (*v).eofflag = (*v).pcm_current;
-        (*v).pcm_current = ((*v).pcm_current as libc::c_long
-            + (*ci).blocksizes[1 as i32 as usize] * 3 as i32 as libc::c_long)
+        (*v).pcm_current = ((*v).pcm_current as isize
+            + (*ci).blocksizes[1 as i32 as usize] * 3 as i32 as isize)
             as i32;
         i = 0 as i32;
         while i < (*vi).channels {
             if (*v).eofflag > order * 2 as i32 {
                 /* extrapolate with LPC to fill in */
-                let mut n: libc::c_long = 0;
+                let mut n: isize = 0;
                 /* make a predictor filter */
-                n = (*v).eofflag as libc::c_long;
+                n = (*v).eofflag as isize;
                 if n > (*ci).blocksizes[1 as i32 as usize] {
                     n = (*ci).blocksizes[1 as i32 as usize]
                 }
@@ -803,7 +803,7 @@ pub unsafe extern "C" fn vorbis_analysis_wrote(
                         .offset(-(order as isize)),
                     order,
                     (*(*v).pcm.offset(i as isize)).offset((*v).eofflag as isize),
-                    ((*v).pcm_current - (*v).eofflag) as libc::c_long,
+                    ((*v).pcm_current - (*v).eofflag) as isize,
                 );
             } else {
                 /* not enough data to extrapolate (unlikely to happen due to
@@ -828,7 +828,7 @@ pub unsafe extern "C" fn vorbis_analysis_wrote(
         too... in case we're beginning on a cliff! */
         /* clumsy, but simple.  It only runs once, so simple is good. */
         if (*v).preextrapolate == 0
-            && (*v).pcm_current as libc::c_long - (*v).centerW > (*ci).blocksizes[1 as i32 as usize]
+            && (*v).pcm_current as isize - (*v).centerW > (*ci).blocksizes[1 as i32 as usize]
         {
             _preextrapolate_helper(v);
         }
@@ -850,9 +850,9 @@ pub unsafe extern "C" fn vorbis_analysis_blockout(
     let mut b: *mut crate::codec_internal_h::private_state =
         (*v).backend_state as *mut crate::codec_internal_h::private_state;
     let mut g: *mut crate::src::libvorbis_1_3_6::lib::psy::vorbis_look_psy_global = (*b).psy_g_look;
-    let mut beginW: libc::c_long =
-        (*v).centerW - (*ci).blocksizes[(*v).W as usize] / 2 as i32 as libc::c_long;
-    let mut centerNext: libc::c_long = 0;
+    let mut beginW: isize =
+        (*v).centerW - (*ci).blocksizes[(*v).W as usize] / 2 as i32 as isize;
+    let mut centerNext: isize = 0;
     let mut vbi: *mut crate::codec_internal_h::vorbis_block_internal =
         (*vb).internal as *mut crate::codec_internal_h::vorbis_block_internal;
     /* check to see if we're started... */
@@ -869,27 +869,27 @@ pub unsafe extern "C" fn vorbis_analysis_blockout(
     /* we do an envelope search even on a single blocksize; we may still
     be throwing more bits at impulses, and envelope search handles
     marking impulses too. */
-    let mut bp: libc::c_long = crate::src::libvorbis_1_3_6::lib::envelope::_ve_envelope_search(
+    let mut bp: isize = crate::src::libvorbis_1_3_6::lib::envelope::_ve_envelope_search(
         v as *mut crate::codec_h::vorbis_dsp_state,
     ); /* not enough data currently to search for a
        full long block */
-    if bp == -(1 as i32) as libc::c_long {
+    if bp == -(1 as i32) as isize {
         if (*v).eofflag == 0 as i32 {
             return 0 as i32;
         }
-        (*v).nW = 0 as i32 as libc::c_long
+        (*v).nW = 0 as i32 as isize
     } else if (*ci).blocksizes[0 as i32 as usize] == (*ci).blocksizes[1 as i32 as usize] {
-        (*v).nW = 0 as i32 as libc::c_long
+        (*v).nW = 0 as i32 as isize
     } else {
         (*v).nW = bp
     }
     centerNext = (*v).centerW
-        + (*ci).blocksizes[(*v).W as usize] / 4 as i32 as libc::c_long
-        + (*ci).blocksizes[(*v).nW as usize] / 4 as i32 as libc::c_long;
+        + (*ci).blocksizes[(*v).W as usize] / 4 as i32 as isize
+        + (*ci).blocksizes[(*v).nW as usize] / 4 as i32 as isize;
     /* center of next block + next block maximum right side. */
-    let mut blockbound: libc::c_long =
-        centerNext + (*ci).blocksizes[(*v).nW as usize] / 2 as i32 as libc::c_long;
-    if ((*v).pcm_current as libc::c_long) < blockbound {
+    let mut blockbound: isize =
+        centerNext + (*ci).blocksizes[(*v).nW as usize] / 2 as i32 as isize;
+    if ((*v).pcm_current as isize) < blockbound {
         return 0 as i32;
     }
     /* fill in the block.  Note that for a short window, lW and nW are *short*
@@ -936,26 +936,26 @@ pub unsafe extern "C" fn vorbis_analysis_blockout(
     (*vb).pcm = _vorbis_block_alloc(
         vb,
         (::std::mem::size_of::<*mut f32>() as libc::c_ulong)
-            .wrapping_mul((*vi).channels as libc::c_ulong) as libc::c_long,
+            .wrapping_mul((*vi).channels as libc::c_ulong) as isize,
     ) as *mut *mut f32;
     (*vbi).pcmdelay = _vorbis_block_alloc(
         vb,
         (::std::mem::size_of::<*mut f32>() as libc::c_ulong)
-            .wrapping_mul((*vi).channels as libc::c_ulong) as libc::c_long,
+            .wrapping_mul((*vi).channels as libc::c_ulong) as isize,
     ) as *mut *mut f32;
     i = 0 as i32;
     while i < (*vi).channels {
         let ref mut fresh11 = *(*vbi).pcmdelay.offset(i as isize);
         *fresh11 = _vorbis_block_alloc(
             vb,
-            (((*vb).pcmend as libc::c_long + beginW) as libc::c_ulong)
+            (((*vb).pcmend as isize + beginW) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<f32>() as libc::c_ulong)
-                as libc::c_long,
+                as isize,
         ) as *mut f32;
         crate::stdlib::memcpy(
             *(*vbi).pcmdelay.offset(i as isize) as *mut libc::c_void,
             *(*v).pcm.offset(i as isize) as *const libc::c_void,
-            (((*vb).pcmend as libc::c_long + beginW) as libc::c_ulong)
+            (((*vb).pcmend as isize + beginW) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<f32>() as libc::c_ulong),
         );
         let ref mut fresh12 = *(*vb).pcm.offset(i as isize);
@@ -970,7 +970,7 @@ pub unsafe extern "C" fn vorbis_analysis_blockout(
     eof>0  marks the last 'real' sample in pcm[]
     eof<0  'no more to do'; doesn't get here */
     if (*v).eofflag != 0 {
-        if (*v).centerW >= (*v).eofflag as libc::c_long {
+        if (*v).centerW >= (*v).eofflag as isize {
             (*v).eofflag = -(1 as i32);
             (*vb).eofflag = 1 as i32;
             return 1 as i32;
@@ -978,12 +978,12 @@ pub unsafe extern "C" fn vorbis_analysis_blockout(
     }
     /* advance storage vectors and clean up */
     let mut new_centerNext: i32 =
-        ((*ci).blocksizes[1 as i32 as usize] / 2 as i32 as libc::c_long) as i32;
-    let mut movementW: i32 = (centerNext - new_centerNext as libc::c_long) as i32;
+        ((*ci).blocksizes[1 as i32 as usize] / 2 as i32 as isize) as i32;
+    let mut movementW: i32 = (centerNext - new_centerNext as isize) as i32;
     if movementW > 0 as i32 {
         crate::src::libvorbis_1_3_6::lib::envelope::_ve_envelope_shift(
             (*b).ve as *mut crate::src::libvorbis_1_3_6::lib::envelope::envelope_lookup,
-            movementW as libc::c_long,
+            movementW as isize,
         );
         (*v).pcm_current -= movementW;
         i = 0 as i32;
@@ -998,21 +998,21 @@ pub unsafe extern "C" fn vorbis_analysis_blockout(
         }
         (*v).lW = (*v).W;
         (*v).W = (*v).nW;
-        (*v).centerW = new_centerNext as libc::c_long;
+        (*v).centerW = new_centerNext as isize;
         if (*v).eofflag != 0 {
             (*v).eofflag -= movementW;
             if (*v).eofflag <= 0 as i32 {
                 (*v).eofflag = -(1 as i32)
             }
             /* do not add padding to end of stream! */
-            if (*v).centerW >= (*v).eofflag as libc::c_long {
+            if (*v).centerW >= (*v).eofflag as isize {
                 (*v).granulepos +=
-                    movementW as libc::c_long - ((*v).centerW - (*v).eofflag as libc::c_long)
+                    movementW as isize - ((*v).centerW - (*v).eofflag as isize)
             } else {
-                (*v).granulepos += movementW as libc::c_long
+                (*v).granulepos += movementW as isize
             }
         } else {
-            (*v).granulepos += movementW as libc::c_long
+            (*v).granulepos += movementW as isize
         }
     }
     /* done */
@@ -1086,9 +1086,9 @@ pub unsafe extern "C" fn vorbis_synthesis_blockin(
     }
     (*v).lW = (*v).W;
     (*v).W = (*vb).W;
-    (*v).nW = -(1 as i32) as libc::c_long;
-    if (*v).sequence == -(1 as i32) as libc::c_long
-        || (*v).sequence + 1 as i32 as libc::c_long != (*vb).sequence
+    (*v).nW = -(1 as i32) as isize;
+    if (*v).sequence == -(1 as i32) as isize
+        || (*v).sequence + 1 as i32 as isize != (*vb).sequence
     {
         (*v).granulepos = -(1 as i32) as crate::config_types_h::ogg_int64_t;
         (*b).sample_count = -(1 as i32) as crate::config_types_h::ogg_int64_t
@@ -1205,9 +1205,9 @@ pub unsafe extern "C" fn vorbis_synthesis_blockin(
             j += 1
         }
         if (*v).centerW != 0 {
-            (*v).centerW = 0 as i32 as libc::c_long
+            (*v).centerW = 0 as i32 as isize
         } else {
-            (*v).centerW = n1 as libc::c_long
+            (*v).centerW = n1 as isize
         }
         /* deal with initial packet state; we do this using the explicit
         pcm_returned==-1 flag otherwise we're sensitive to first block
@@ -1217,9 +1217,9 @@ pub unsafe extern "C" fn vorbis_synthesis_blockin(
             (*v).pcm_current = thisCenter
         } else {
             (*v).pcm_returned = prevCenter;
-            (*v).pcm_current = (prevCenter as libc::c_long
-                + ((*ci).blocksizes[(*v).lW as usize] / 4 as i32 as libc::c_long
-                    + (*ci).blocksizes[(*v).W as usize] / 4 as i32 as libc::c_long
+            (*v).pcm_current = (prevCenter as isize
+                + ((*ci).blocksizes[(*v).lW as usize] / 4 as i32 as isize
+                    + (*ci).blocksizes[(*v).W as usize] / 4 as i32 as isize
                     >> hs)) as i32
         }
     }
@@ -1233,27 +1233,27 @@ pub unsafe extern "C" fn vorbis_synthesis_blockin(
     we don't have a starting point to judge where the last frame
     is.  For this reason, vorbisfile will always try to make sure
     it reads the last two marked pages in proper sequence */
-    if (*b).sample_count == -(1 as i32) as libc::c_long {
+    if (*b).sample_count == -(1 as i32) as isize {
         (*b).sample_count = 0 as i32 as crate::config_types_h::ogg_int64_t
     } else {
-        (*b).sample_count += (*ci).blocksizes[(*v).lW as usize] / 4 as i32 as libc::c_long
-            + (*ci).blocksizes[(*v).W as usize] / 4 as i32 as libc::c_long
+        (*b).sample_count += (*ci).blocksizes[(*v).lW as usize] / 4 as i32 as isize
+            + (*ci).blocksizes[(*v).W as usize] / 4 as i32 as isize
     }
-    if (*v).granulepos == -(1 as i32) as libc::c_long {
-        if (*vb).granulepos != -(1 as i32) as libc::c_long {
+    if (*v).granulepos == -(1 as i32) as isize {
+        if (*vb).granulepos != -(1 as i32) as isize {
             /* only set if we have a position to set to */
             (*v).granulepos = (*vb).granulepos;
             /* is this a short page? */
             if (*b).sample_count > (*v).granulepos {
                 /* corner case; if this is both the first and last audio page,
                 then spec says the end is cut, not beginning */
-                let mut extra: libc::c_long = (*b).sample_count - (*vb).granulepos;
+                let mut extra: isize = (*b).sample_count - (*vb).granulepos;
                 /* we use ogg_int64_t for granule positions because a
                 uint64 isn't universally available.  Unfortunately,
                 that means granposes can be 'negative' and result in
                 extra being negative */
-                if extra < 0 as i32 as libc::c_long {
-                    extra = 0 as i32 as libc::c_long
+                if extra < 0 as i32 as isize {
+                    extra = 0 as i32 as isize
                 }
                 if (*vb).eofflag != 0 {
                     /* trim the end */
@@ -1264,13 +1264,13 @@ pub unsafe extern "C" fn vorbis_synthesis_blockin(
                     /* Guard against corrupt/malicious frames that set EOP and
                     a backdated granpos; don't rewind more samples than we
                     actually have */
-                    if extra > ((*v).pcm_current - (*v).pcm_returned << hs) as libc::c_long {
-                        extra = ((*v).pcm_current - (*v).pcm_returned << hs) as libc::c_long
+                    if extra > ((*v).pcm_current - (*v).pcm_returned << hs) as isize {
+                        extra = ((*v).pcm_current - (*v).pcm_returned << hs) as isize
                     }
-                    (*v).pcm_current = ((*v).pcm_current as libc::c_long - (extra >> hs)) as i32
+                    (*v).pcm_current = ((*v).pcm_current as isize - (extra >> hs)) as i32
                 } else {
                     /* trim the beginning */
-                    (*v).pcm_returned = ((*v).pcm_returned as libc::c_long + (extra >> hs)) as i32; /* else {Shouldn't happen *unless* the bitstream is out of
+                    (*v).pcm_returned = ((*v).pcm_returned as isize + (extra >> hs)) as i32; /* else {Shouldn't happen *unless* the bitstream is out of
                                                                                                     spec.  Either way, believe the bitstream } */
                     if (*v).pcm_returned > (*v).pcm_current {
                         (*v).pcm_returned = (*v).pcm_current
@@ -1279,11 +1279,11 @@ pub unsafe extern "C" fn vorbis_synthesis_blockin(
             }
         }
     } else {
-        (*v).granulepos += (*ci).blocksizes[(*v).lW as usize] / 4 as i32 as libc::c_long
-            + (*ci).blocksizes[(*v).W as usize] / 4 as i32 as libc::c_long;
-        if (*vb).granulepos != -(1 as i32) as libc::c_long && (*v).granulepos != (*vb).granulepos {
+        (*v).granulepos += (*ci).blocksizes[(*v).lW as usize] / 4 as i32 as isize
+            + (*ci).blocksizes[(*v).W as usize] / 4 as i32 as isize;
+        if (*vb).granulepos != -(1 as i32) as isize && (*v).granulepos != (*vb).granulepos {
             if (*v).granulepos > (*vb).granulepos {
-                let mut extra_0: libc::c_long = (*v).granulepos - (*vb).granulepos;
+                let mut extra_0: isize = (*v).granulepos - (*vb).granulepos;
                 if extra_0 != 0 {
                     if (*vb).eofflag != 0 {
                         /* else {Shouldn't happen *unless* the bitstream is out of
@@ -1292,18 +1292,18 @@ pub unsafe extern "C" fn vorbis_synthesis_blockin(
                         /* Guard against corrupt/malicious frames that set EOP and
                         a backdated granpos; don't rewind more samples than we
                         actually have */
-                        if extra_0 > ((*v).pcm_current - (*v).pcm_returned << hs) as libc::c_long {
-                            extra_0 = ((*v).pcm_current - (*v).pcm_returned << hs) as libc::c_long
+                        if extra_0 > ((*v).pcm_current - (*v).pcm_returned << hs) as isize {
+                            extra_0 = ((*v).pcm_current - (*v).pcm_returned << hs) as isize
                         }
                         /* we use ogg_int64_t for granule positions because a
                         uint64 isn't universally available.  Unfortunately,
                         that means granposes can be 'negative' and result in
                         extra being negative */
-                        if extra_0 < 0 as i32 as libc::c_long {
-                            extra_0 = 0 as i32 as libc::c_long
+                        if extra_0 < 0 as i32 as isize {
+                            extra_0 = 0 as i32 as isize
                         }
                         (*v).pcm_current =
-                            ((*v).pcm_current as libc::c_long - (extra_0 >> hs)) as i32
+                            ((*v).pcm_current as isize - (extra_0 >> hs)) as i32
                     }
                 }
             }
@@ -1383,7 +1383,7 @@ pub unsafe extern "C" fn vorbis_synthesis_lapout(
     simplicity. */
     /* centerW was advanced by blockin; it would be the center of the
      *next* block */
-    if (*v).centerW == n1 as libc::c_long {
+    if (*v).centerW == n1 as isize {
         /* the data buffer wraps; swap the halves */
         /* slow, sure, small */
         j = 0 as i32;
@@ -1400,10 +1400,10 @@ pub unsafe extern "C" fn vorbis_synthesis_lapout(
         }
         (*v).pcm_current -= n1;
         (*v).pcm_returned -= n1;
-        (*v).centerW = 0 as i32 as libc::c_long
+        (*v).centerW = 0 as i32 as isize
     }
     /* solidify buffer into contiguous space */
-    if (*v).lW ^ (*v).W == 1 as i32 as libc::c_long {
+    if (*v).lW ^ (*v).W == 1 as i32 as isize {
         /* long/short or short/long */
         j = 0 as i32;
         while j < (*vi).channels {
@@ -1419,7 +1419,7 @@ pub unsafe extern "C" fn vorbis_synthesis_lapout(
         }
         (*v).pcm_returned += (n1 - n0) / 2 as i32;
         (*v).pcm_current += (n1 - n0) / 2 as i32
-    } else if (*v).lW == 0 as i32 as libc::c_long {
+    } else if (*v).lW == 0 as i32 as isize {
         /* short/short */
         j = 0 as i32;
         while j < (*vi).channels {

--- a/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/codebook.rs
+++ b/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/codebook.rs
@@ -2,24 +2,24 @@
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct static_codebook {
-    pub dim: libc::c_long,
-    pub entries: libc::c_long,
+    pub dim: isize,
+    pub entries: isize,
     pub lengthlist: *mut libc::c_char,
     pub maptype: i32,
-    pub q_min: libc::c_long,
-    pub q_delta: libc::c_long,
+    pub q_min: isize,
+    pub q_delta: isize,
     pub q_quant: i32,
     pub q_sequencep: i32,
-    pub quantlist: *mut libc::c_long,
+    pub quantlist: *mut isize,
     pub allocedp: i32,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct codebook {
-    pub dim: libc::c_long,
-    pub entries: libc::c_long,
-    pub used_entries: libc::c_long,
+    pub dim: isize,
+    pub entries: isize,
+    pub used_entries: isize,
     pub c: *const crate::src::libvorbis_1_3_6::lib::codebook::static_codebook,
     pub valuelist: *mut f32,
     pub codelist: *mut crate::config_types_h::ogg_uint32_t,
@@ -70,8 +70,8 @@ pub unsafe extern "C" fn vorbis_staticbook_pack(
     mut c: *const crate::src::libvorbis_1_3_6::lib::codebook::static_codebook,
     mut opb: *mut crate::ogg_h::oggpack_buffer,
 ) -> i32 {
-    let mut i: libc::c_long = 0;
-    let mut j: libc::c_long = 0;
+    let mut i: isize = 0;
+    let mut j: isize = 0;
     let mut ordered: i32 = 0 as i32;
     /* first the basic parameters */
     crate::src::libogg_1_3_3::src::bitwise::oggpack_write(
@@ -91,16 +91,16 @@ pub unsafe extern "C" fn vorbis_staticbook_pack(
     );
     /* pack the codewords.  There are two packings; length ordered and
     length random.  Decide between the two now. */
-    i = 1 as i32 as libc::c_long;
+    i = 1 as i32 as isize;
     while i < (*c).entries {
         if *(*c)
             .lengthlist
-            .offset((i - 1 as i32 as libc::c_long) as isize) as i32
+            .offset((i - 1 as i32 as isize) as isize) as i32
             == 0 as i32
             || (*(*c).lengthlist.offset(i as isize) as i32)
                 < *(*c)
                     .lengthlist
-                    .offset((i - 1 as i32 as libc::c_long) as isize) as i32
+                    .offset((i - 1 as i32 as isize) as isize) as i32
         {
             break;
         }
@@ -113,7 +113,7 @@ pub unsafe extern "C" fn vorbis_staticbook_pack(
         /* length ordered.  We only need to say how many codewords of
         each length.  The actual codewords are generated
         deterministically */
-        let mut count: libc::c_long = 0 as i32 as libc::c_long; /* ordered */
+        let mut count: isize = 0 as i32 as isize; /* ordered */
         crate::src::libogg_1_3_3::src::bitwise::oggpack_write(
             opb as *mut crate::ogg_h::oggpack_buffer,
             1 as i32 as libc::c_ulong,
@@ -124,15 +124,15 @@ pub unsafe extern "C" fn vorbis_staticbook_pack(
             (*(*c).lengthlist.offset(0 as i32 as isize) as i32 - 1 as i32) as libc::c_ulong,
             5 as i32,
         );
-        i = 1 as i32 as libc::c_long;
+        i = 1 as i32 as isize;
         while i < (*c).entries {
             let mut this: libc::c_char = *(*c).lengthlist.offset(i as isize);
             let mut last: libc::c_char = *(*c)
                 .lengthlist
-                .offset((i - 1 as i32 as libc::c_long) as isize);
+                .offset((i - 1 as i32 as isize) as isize);
             if this as i32 > last as i32 {
-                j = last as libc::c_long;
-                while j < this as libc::c_long {
+                j = last as isize;
+                while j < this as isize {
                     crate::src::libogg_1_3_3::src::bitwise::oggpack_write(
                         opb as *mut crate::ogg_h::oggpack_buffer,
                         (i - count) as libc::c_ulong,
@@ -164,7 +164,7 @@ pub unsafe extern "C" fn vorbis_staticbook_pack(
         /* algortihmic mapping has use for 'unused entries', which we tag
         here.  The algorithmic mapping happens as usual, but the unused
         entry has no codeword. */
-        i = 0 as i32 as libc::c_long; /* no unused entries */
+        i = 0 as i32 as isize; /* no unused entries */
         while i < (*c).entries {
             if *(*c).lengthlist.offset(i as isize) as i32 == 0 as i32 {
                 break; /* we have unused entries; thus we tag */
@@ -177,7 +177,7 @@ pub unsafe extern "C" fn vorbis_staticbook_pack(
                 0 as i32 as libc::c_ulong,
                 1 as i32,
             );
-            i = 0 as i32 as libc::c_long;
+            i = 0 as i32 as isize;
             while i < (*c).entries {
                 crate::src::libogg_1_3_3::src::bitwise::oggpack_write(
                     opb as *mut crate::ogg_h::oggpack_buffer,
@@ -192,7 +192,7 @@ pub unsafe extern "C" fn vorbis_staticbook_pack(
                 1 as i32 as libc::c_ulong,
                 1 as i32,
             );
-            i = 0 as i32 as libc::c_long;
+            i = 0 as i32 as isize;
             while i < (*c).entries {
                 if *(*c).lengthlist.offset(i as isize) as i32 == 0 as i32 {
                     crate::src::libogg_1_3_3::src::bitwise::oggpack_write(
@@ -273,11 +273,11 @@ pub unsafe extern "C" fn vorbis_staticbook_pack(
                 }
             }
             /* quantized values */
-            i = 0 as i32 as libc::c_long;
-            while i < quantvals as libc::c_long {
+            i = 0 as i32 as isize;
+            while i < quantvals as isize {
                 crate::src::libogg_1_3_3::src::bitwise::oggpack_write(
                     opb as *mut crate::ogg_h::oggpack_buffer,
-                    ::libc::labs(*(*c).quantlist.offset(i as isize)) as libc::c_ulong,
+                    ::libc::labs(*(*c).quantlist.offset(i as isize) as libc::c_long) as libc::c_ulong,
                     (*c).q_quant,
                 );
                 i += 1
@@ -298,8 +298,8 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
     mut opb: *mut crate::ogg_h::oggpack_buffer,
 ) -> *mut crate::src::libvorbis_1_3_6::lib::codebook::static_codebook {
     let mut current_block: u64;
-    let mut i: libc::c_long = 0;
-    let mut j: libc::c_long = 0;
+    let mut i: isize = 0;
+    let mut j: isize = 0;
     let mut s: *mut crate::src::libvorbis_1_3_6::lib::codebook::static_codebook =
         crate::stdlib::calloc(
             1 as i32 as libc::c_ulong,
@@ -311,7 +311,7 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
     if !(crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
         opb as *mut crate::ogg_h::oggpack_buffer,
         24 as i32,
-    ) != 0x564342 as i32 as libc::c_long)
+    ) != 0x564342 as i32 as isize)
     {
         /* first the basic parameters */
         (*s).dim = crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
@@ -322,7 +322,7 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
             opb as *mut crate::ogg_h::oggpack_buffer,
             24 as i32,
         );
-        if !((*s).entries == -(1 as i32) as libc::c_long) {
+        if !((*s).entries == -(1 as i32) as isize) {
             if !(crate::src::libvorbis_1_3_6::lib::sharedbook::ov_ilog(
                 (*s).dim as crate::config_types_h::ogg_uint32_t,
             ) + crate::src::libvorbis_1_3_6::lib::sharedbook::ov_ilog(
@@ -339,7 +339,7 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                         current_block = 14523784380283086299;
                         match current_block {
                             14523784380283086299 => {
-                                let mut unused: libc::c_long = 0;
+                                let mut unused: isize = 0;
                                 /* allocated but unused entries? */
                                 unused = crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
                                     opb as *mut crate::ogg_h::oggpack_buffer,
@@ -347,8 +347,8 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                 );
                                 if (*s).entries
                                     * (if unused != 0 { 1 as i32 } else { 5 as i32 })
-                                        as libc::c_long
-                                    + 7 as i32 as libc::c_long
+                                        as isize
+                                    + 7 as i32 as isize
                                     >> 3 as i32
                                     > (*opb).storage
                                         - crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(
@@ -366,7 +366,7 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                     /* allocated but unused entries? */
                                     if unused != 0 {
                                         /* yes, unused entries */
-                                        i = 0 as i32 as libc::c_long;
+                                        i = 0 as i32 as isize;
                                         loop {
                                             if !(i < (*s).entries) {
                                                 current_block = 15004371738079956865;
@@ -377,16 +377,16 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                                 1 as i32,
                                             ) != 0
                                             {
-                                                let mut num: libc::c_long =
+                                                let mut num: isize =
                                                     crate::src::libogg_1_3_3::src::bitwise::oggpack_read(opb as *mut crate::ogg_h::oggpack_buffer,
                                                                  5 as
                                                                      i32);
-                                                if num == -(1 as i32) as libc::c_long {
+                                                if num == -(1 as i32) as isize {
                                                     current_block = 15187751986642917127;
                                                     break;
                                                 }
                                                 *(*s).lengthlist.offset(i as isize) =
-                                                    (num + 1 as i32 as libc::c_long) as libc::c_char
+                                                    (num + 1 as i32 as isize) as libc::c_char
                                             } else {
                                                 *(*s).lengthlist.offset(i as isize) =
                                                     0 as i32 as libc::c_char
@@ -395,22 +395,22 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                         }
                                     } else {
                                         /* all entries used; no tagging */
-                                        i = 0 as i32 as libc::c_long;
+                                        i = 0 as i32 as isize;
                                         loop {
                                             if !(i < (*s).entries) {
                                                 current_block = 15004371738079956865;
                                                 break;
                                             }
-                                            let mut num_0: libc::c_long =
+                                            let mut num_0: isize =
                                                 crate::src::libogg_1_3_3::src::bitwise::oggpack_read(opb as *mut crate::ogg_h::oggpack_buffer,
                                                              5 as
                                                                  i32);
-                                            if num_0 == -(1 as i32) as libc::c_long {
+                                            if num_0 == -(1 as i32) as isize {
                                                 current_block = 15187751986642917127;
                                                 break;
                                             }
                                             *(*s).lengthlist.offset(i as isize) =
-                                                (num_0 + 1 as i32 as libc::c_long) as libc::c_char;
+                                                (num_0 + 1 as i32 as isize) as libc::c_char;
                                             i += 1
                                         }
                                     }
@@ -419,12 +419,12 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                             _ =>
                             /* ordered */
                             {
-                                let mut length: libc::c_long =
+                                let mut length: isize =
                                     crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
                                         opb as *mut crate::ogg_h::oggpack_buffer,
                                         5 as i32,
-                                    ) + 1 as i32 as libc::c_long;
-                                if length == 0 as i32 as libc::c_long {
+                                    ) + 1 as i32 as isize;
+                                if length == 0 as i32 as isize {
                                     current_block = 15187751986642917127;
                                 } else {
                                     (*s).lengthlist = crate::stdlib::malloc(
@@ -432,36 +432,36 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                             .wrapping_mul((*s).entries as libc::c_ulong),
                                     )
                                         as *mut libc::c_char;
-                                    i = 0 as i32 as libc::c_long;
+                                    i = 0 as i32 as isize;
                                     loop {
                                         if !(i < (*s).entries) {
                                             current_block = 15004371738079956865;
                                             break;
                                         }
-                                        let mut num_1: libc::c_long =
+                                        let mut num_1: isize =
                                             crate::src::libogg_1_3_3::src::bitwise::oggpack_read(opb as *mut crate::ogg_h::oggpack_buffer,
                                                          crate::src::libvorbis_1_3_6::lib::sharedbook::ov_ilog(((*s).entries
                                                                       - i) as
                                                                      crate::config_types_h::ogg_uint32_t));
-                                        if num_1 == -(1 as i32) as libc::c_long {
+                                        if num_1 == -(1 as i32) as isize {
                                             current_block = 15187751986642917127;
                                             break;
                                         }
-                                        if length > 32 as i32 as libc::c_long
+                                        if length > 32 as i32 as isize
                                             || num_1 > (*s).entries - i
-                                            || num_1 > 0 as i32 as libc::c_long
-                                                && num_1 - 1 as i32 as libc::c_long
-                                                    >> length - 1 as i32 as libc::c_long
-                                                    > 1 as i32 as libc::c_long
+                                            || num_1 > 0 as i32 as isize
+                                                && num_1 - 1 as i32 as isize
+                                                    >> length - 1 as i32 as isize
+                                                    > 1 as i32 as isize
                                         {
                                             current_block = 15187751986642917127;
                                             break;
                                         }
-                                        if length > 32 as i32 as libc::c_long {
+                                        if length > 32 as i32 as isize {
                                             current_block = 15187751986642917127;
                                             break;
                                         }
-                                        j = 0 as i32 as libc::c_long;
+                                        j = 0 as i32 as isize;
                                         while j < num_1 {
                                             *(*s).lengthlist.offset(i as isize) =
                                                 length as libc::c_char;
@@ -503,7 +503,7 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                                                       i32)
                                                          +
                                                          1 as i32 as
-                                                             libc::c_long) as
+                                                             isize) as
                                                         i32;
                                                 (*s).q_sequencep =
                                                     crate::src::libogg_1_3_3::src::bitwise::oggpack_read(opb as *mut crate::ogg_h::oggpack_buffer,
@@ -517,9 +517,9 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                                     match (*s).maptype {
                                                         1 => {
                                                             quantvals = if (*s).dim
-                                                                == 0 as i32 as libc::c_long
+                                                                == 0 as i32 as isize
                                                             {
-                                                                0 as i32 as libc::c_long
+                                                                0 as i32 as isize
                                                             } else {
                                                                 crate::src::libvorbis_1_3_6::lib::sharedbook::_book_maptype1_quantvals(s as *const crate::src::libvorbis_1_3_6::lib::codebook::static_codebook)
                                                             }
@@ -537,7 +537,7 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                                             7 as i32
                                                             >>
                                                             3 as i32)
-                                                           as libc::c_long >
+                                                           as isize >
                                                            (*opb).storage -
                                                                crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(opb as *mut crate::ogg_h::oggpack_buffer)
                                                        {
@@ -545,20 +545,20 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                                             15187751986642917127;
                                                     } else {
                                                         (*s).quantlist =
-                                                            crate::stdlib::malloc((::std::mem::size_of::<libc::c_long>()
+                                                            crate::stdlib::malloc((::std::mem::size_of::<isize>()
                                                                         as
                                                                         libc::c_ulong).wrapping_mul(quantvals
                                                                                                         as
                                                                                                         libc::c_ulong))
                                                                 as
-                                                                *mut libc::c_long;
+                                                                *mut isize;
                                                         i =
                                                             0 as i32
                                                                 as
-                                                                libc::c_long;
+                                                                isize;
                                                         while i <
                                                                   quantvals as
-                                                                      libc::c_long
+                                                                      isize
                                                               {
                                                             *(*s).quantlist.offset(i
                                                                                        as
@@ -580,7 +580,7 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                                                    -(1 as
                                                                          i32)
                                                                        as
-                                                                       libc::c_long
+                                                                       isize
                                                            {
                                                             current_block =
                                                                 15187751986642917127;
@@ -621,7 +621,7 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                                                       i32)
                                                          +
                                                          1 as i32 as
-                                                             libc::c_long) as
+                                                             isize) as
                                                         i32;
                                                 (*s).q_sequencep =
                                                     crate::src::libogg_1_3_3::src::bitwise::oggpack_read(opb as *mut crate::ogg_h::oggpack_buffer,
@@ -635,9 +635,9 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                                     match (*s).maptype {
                                                         1 => {
                                                             quantvals = if (*s).dim
-                                                                == 0 as i32 as libc::c_long
+                                                                == 0 as i32 as isize
                                                             {
-                                                                0 as i32 as libc::c_long
+                                                                0 as i32 as isize
                                                             } else {
                                                                 crate::src::libvorbis_1_3_6::lib::sharedbook::_book_maptype1_quantvals(s as *const crate::src::libvorbis_1_3_6::lib::codebook::static_codebook)
                                                             }
@@ -654,7 +654,7 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                                             7 as i32
                                                             >>
                                                             3 as i32)
-                                                           as libc::c_long >
+                                                           as isize >
                                                            (*opb).storage -
                                                                crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(opb as *mut crate::ogg_h::oggpack_buffer)
                                                        {
@@ -662,20 +662,20 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                                             15187751986642917127;
                                                     } else {
                                                         (*s).quantlist =
-                                                            crate::stdlib::malloc((::std::mem::size_of::<libc::c_long>()
+                                                            crate::stdlib::malloc((::std::mem::size_of::<isize>()
                                                                         as
                                                                         libc::c_ulong).wrapping_mul(quantvals
                                                                                                         as
                                                                                                         libc::c_ulong))
                                                                 as
-                                                                *mut libc::c_long;
+                                                                *mut isize;
                                                         i =
                                                             0 as i32
                                                                 as
-                                                                libc::c_long;
+                                                                isize;
                                                         while i <
                                                                   quantvals as
-                                                                      libc::c_long
+                                                                      isize
                                                               {
                                                             *(*s).quantlist.offset(i
                                                                                        as
@@ -697,7 +697,7 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                                                    -(1 as
                                                                          i32)
                                                                        as
-                                                                       libc::c_long
+                                                                       isize
                                                            {
                                                             current_block =
                                                                 15187751986642917127;
@@ -724,15 +724,15 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                         current_block = 3437258052017859086;
                         match current_block {
                             14523784380283086299 => {
-                                let mut unused: libc::c_long = 0;
+                                let mut unused: isize = 0;
                                 unused = crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
                                     opb as *mut crate::ogg_h::oggpack_buffer,
                                     1 as i32,
                                 );
                                 if (*s).entries
                                     * (if unused != 0 { 1 as i32 } else { 5 as i32 })
-                                        as libc::c_long
-                                    + 7 as i32 as libc::c_long
+                                        as isize
+                                    + 7 as i32 as isize
                                     >> 3 as i32
                                     > (*opb).storage
                                         - crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(
@@ -747,7 +747,7 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                     )
                                         as *mut libc::c_char;
                                     if unused != 0 {
-                                        i = 0 as i32 as libc::c_long;
+                                        i = 0 as i32 as isize;
                                         loop {
                                             if !(i < (*s).entries) {
                                                 current_block = 15004371738079956865;
@@ -758,16 +758,16 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                                 1 as i32,
                                             ) != 0
                                             {
-                                                let mut num: libc::c_long =
+                                                let mut num: isize =
                                                     crate::src::libogg_1_3_3::src::bitwise::oggpack_read(opb as *mut crate::ogg_h::oggpack_buffer,
                                                                  5 as
                                                                      i32);
-                                                if num == -(1 as i32) as libc::c_long {
+                                                if num == -(1 as i32) as isize {
                                                     current_block = 15187751986642917127;
                                                     break;
                                                 }
                                                 *(*s).lengthlist.offset(i as isize) =
-                                                    (num + 1 as i32 as libc::c_long) as libc::c_char
+                                                    (num + 1 as i32 as isize) as libc::c_char
                                             } else {
                                                 *(*s).lengthlist.offset(i as isize) =
                                                     0 as i32 as libc::c_char
@@ -775,34 +775,34 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                             i += 1
                                         }
                                     } else {
-                                        i = 0 as i32 as libc::c_long;
+                                        i = 0 as i32 as isize;
                                         loop {
                                             if !(i < (*s).entries) {
                                                 current_block = 15004371738079956865;
                                                 break;
                                             }
-                                            let mut num_0: libc::c_long =
+                                            let mut num_0: isize =
                                                 crate::src::libogg_1_3_3::src::bitwise::oggpack_read(opb as *mut crate::ogg_h::oggpack_buffer,
                                                              5 as
                                                                  i32);
-                                            if num_0 == -(1 as i32) as libc::c_long {
+                                            if num_0 == -(1 as i32) as isize {
                                                 current_block = 15187751986642917127;
                                                 break;
                                             }
                                             *(*s).lengthlist.offset(i as isize) =
-                                                (num_0 + 1 as i32 as libc::c_long) as libc::c_char;
+                                                (num_0 + 1 as i32 as isize) as libc::c_char;
                                             i += 1
                                         }
                                     }
                                 }
                             }
                             _ => {
-                                let mut length: libc::c_long =
+                                let mut length: isize =
                                     crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
                                         opb as *mut crate::ogg_h::oggpack_buffer,
                                         5 as i32,
-                                    ) + 1 as i32 as libc::c_long;
-                                if length == 0 as i32 as libc::c_long {
+                                    ) + 1 as i32 as isize;
+                                if length == 0 as i32 as isize {
                                     current_block = 15187751986642917127;
                                 } else {
                                     (*s).lengthlist = crate::stdlib::malloc(
@@ -810,36 +810,36 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                             .wrapping_mul((*s).entries as libc::c_ulong),
                                     )
                                         as *mut libc::c_char;
-                                    i = 0 as i32 as libc::c_long;
+                                    i = 0 as i32 as isize;
                                     loop {
                                         if !(i < (*s).entries) {
                                             current_block = 15004371738079956865;
                                             break;
                                         }
-                                        let mut num_1: libc::c_long =
+                                        let mut num_1: isize =
                                             crate::src::libogg_1_3_3::src::bitwise::oggpack_read(opb as *mut crate::ogg_h::oggpack_buffer,
                                                          crate::src::libvorbis_1_3_6::lib::sharedbook::ov_ilog(((*s).entries
                                                                       - i) as
                                                                      crate::config_types_h::ogg_uint32_t));
-                                        if num_1 == -(1 as i32) as libc::c_long {
+                                        if num_1 == -(1 as i32) as isize {
                                             current_block = 15187751986642917127;
                                             break;
                                         }
-                                        if length > 32 as i32 as libc::c_long
+                                        if length > 32 as i32 as isize
                                             || num_1 > (*s).entries - i
-                                            || num_1 > 0 as i32 as libc::c_long
-                                                && num_1 - 1 as i32 as libc::c_long
-                                                    >> length - 1 as i32 as libc::c_long
-                                                    > 1 as i32 as libc::c_long
+                                            || num_1 > 0 as i32 as isize
+                                                && num_1 - 1 as i32 as isize
+                                                    >> length - 1 as i32 as isize
+                                                    > 1 as i32 as isize
                                         {
                                             current_block = 15187751986642917127;
                                             break;
                                         }
-                                        if length > 32 as i32 as libc::c_long {
+                                        if length > 32 as i32 as isize {
                                             current_block = 15187751986642917127;
                                             break;
                                         }
-                                        j = 0 as i32 as libc::c_long;
+                                        j = 0 as i32 as isize;
                                         while j < num_1 {
                                             *(*s).lengthlist.offset(i as isize) =
                                                 length as libc::c_char;
@@ -877,7 +877,7 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                                                       i32)
                                                          +
                                                          1 as i32 as
-                                                             libc::c_long) as
+                                                             isize) as
                                                         i32;
                                                 (*s).q_sequencep =
                                                     crate::src::libogg_1_3_3::src::bitwise::oggpack_read(opb as *mut crate::ogg_h::oggpack_buffer,
@@ -891,9 +891,9 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                                     match (*s).maptype {
                                                         1 => {
                                                             quantvals = if (*s).dim
-                                                                == 0 as i32 as libc::c_long
+                                                                == 0 as i32 as isize
                                                             {
-                                                                0 as i32 as libc::c_long
+                                                                0 as i32 as isize
                                                             } else {
                                                                 crate::src::libvorbis_1_3_6::lib::sharedbook::_book_maptype1_quantvals(s as *const crate::src::libvorbis_1_3_6::lib::codebook::static_codebook)
                                                             }
@@ -910,7 +910,7 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                                             7 as i32
                                                             >>
                                                             3 as i32)
-                                                           as libc::c_long >
+                                                           as isize >
                                                            (*opb).storage -
                                                                crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(opb as *mut crate::ogg_h::oggpack_buffer)
                                                        {
@@ -918,20 +918,20 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                                             15187751986642917127;
                                                     } else {
                                                         (*s).quantlist =
-                                                            crate::stdlib::malloc((::std::mem::size_of::<libc::c_long>()
+                                                            crate::stdlib::malloc((::std::mem::size_of::<isize>()
                                                                         as
                                                                         libc::c_ulong).wrapping_mul(quantvals
                                                                                                         as
                                                                                                         libc::c_ulong))
                                                                 as
-                                                                *mut libc::c_long;
+                                                                *mut isize;
                                                         i =
                                                             0 as i32
                                                                 as
-                                                                libc::c_long;
+                                                                isize;
                                                         while i <
                                                                   quantvals as
-                                                                      libc::c_long
+                                                                      isize
                                                               {
                                                             *(*s).quantlist.offset(i
                                                                                        as
@@ -953,7 +953,7 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                                                    -(1 as
                                                                          i32)
                                                                        as
-                                                                       libc::c_long
+                                                                       isize
                                                            {
                                                             current_block =
                                                                 15187751986642917127;
@@ -989,7 +989,7 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                                                       i32)
                                                          +
                                                          1 as i32 as
-                                                             libc::c_long) as
+                                                             isize) as
                                                         i32;
                                                 (*s).q_sequencep =
                                                     crate::src::libogg_1_3_3::src::bitwise::oggpack_read(opb as *mut crate::ogg_h::oggpack_buffer,
@@ -1003,9 +1003,9 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                                     match (*s).maptype {
                                                         1 => {
                                                             quantvals = if (*s).dim
-                                                                == 0 as i32 as libc::c_long
+                                                                == 0 as i32 as isize
                                                             {
-                                                                0 as i32 as libc::c_long
+                                                                0 as i32 as isize
                                                             } else {
                                                                 crate::src::libvorbis_1_3_6::lib::sharedbook::_book_maptype1_quantvals(s as *const crate::src::libvorbis_1_3_6::lib::codebook::static_codebook)
                                                             }
@@ -1022,7 +1022,7 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                                             7 as i32
                                                             >>
                                                             3 as i32)
-                                                           as libc::c_long >
+                                                           as isize >
                                                            (*opb).storage -
                                                                crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(opb as *mut crate::ogg_h::oggpack_buffer)
                                                        {
@@ -1030,20 +1030,20 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                                             15187751986642917127;
                                                     } else {
                                                         (*s).quantlist =
-                                                            crate::stdlib::malloc((::std::mem::size_of::<libc::c_long>()
+                                                            crate::stdlib::malloc((::std::mem::size_of::<isize>()
                                                                         as
                                                                         libc::c_ulong).wrapping_mul(quantvals
                                                                                                         as
                                                                                                         libc::c_ulong))
                                                                 as
-                                                                *mut libc::c_long;
+                                                                *mut isize;
                                                         i =
                                                             0 as i32
                                                                 as
-                                                                libc::c_long;
+                                                                isize;
                                                         while i <
                                                                   quantvals as
-                                                                      libc::c_long
+                                                                      isize
                                                               {
                                                             *(*s).quantlist.offset(i
                                                                                        as
@@ -1065,7 +1065,7 @@ pub unsafe extern "C" fn vorbis_staticbook_unpack(
                                                                    -(1 as
                                                                          i32)
                                                                        as
-                                                                       libc::c_long
+                                                                       isize
                                                            {
                                                             current_block =
                                                                 15187751986642917127;
@@ -1107,7 +1107,7 @@ pub unsafe extern "C" fn vorbis_book_encode(
     mut a: i32,
     mut b: *mut crate::ogg_h::oggpack_buffer,
 ) -> i32 {
-    if a < 0 as i32 || a as libc::c_long >= (*(*book).c).entries {
+    if a < 0 as i32 || a as isize >= (*(*book).c).entries {
         return 0 as i32;
     }
     crate::src::libogg_1_3_3::src::bitwise::oggpack_write(
@@ -1139,30 +1139,30 @@ unsafe extern "C" fn bitreverse(
 unsafe extern "C" fn decode_packed_entry_number(
     mut book: *mut crate::src::libvorbis_1_3_6::lib::codebook::codebook,
     mut b: *mut crate::ogg_h::oggpack_buffer,
-) -> libc::c_long {
+) -> isize {
     let mut read: i32 = (*book).dec_maxlength;
-    let mut lo: libc::c_long = 0;
-    let mut hi: libc::c_long = 0;
-    let mut lok: libc::c_long = crate::src::libogg_1_3_3::src::bitwise::oggpack_look(
+    let mut lo: isize = 0;
+    let mut hi: isize = 0;
+    let mut lok: isize = crate::src::libogg_1_3_3::src::bitwise::oggpack_look(
         b as *mut crate::ogg_h::oggpack_buffer,
         (*book).dec_firsttablen,
     );
-    if lok >= 0 as i32 as libc::c_long {
-        let mut entry: libc::c_long = *(*book).dec_firsttable.offset(lok as isize) as libc::c_long;
+    if lok >= 0 as i32 as isize {
+        let mut entry: isize = *(*book).dec_firsttable.offset(lok as isize) as isize;
         if entry as libc::c_ulong & 0x80000000 as libc::c_ulong != 0 {
-            lo = entry >> 15 as i32 & 0x7fff as i32 as libc::c_long;
-            hi = (*book).used_entries - (entry & 0x7fff as i32 as libc::c_long)
+            lo = entry >> 15 as i32 & 0x7fff as i32 as isize;
+            hi = (*book).used_entries - (entry & 0x7fff as i32 as isize)
         } else {
             crate::src::libogg_1_3_3::src::bitwise::oggpack_adv(
                 b as *mut crate::ogg_h::oggpack_buffer,
                 *(*book)
                     .dec_codelengths
-                    .offset((entry - 1 as i32 as libc::c_long) as isize) as i32,
+                    .offset((entry - 1 as i32 as isize) as isize) as i32,
             );
-            return entry - 1 as i32 as libc::c_long;
+            return entry - 1 as i32 as isize;
         }
     } else {
-        lo = 0 as i32 as libc::c_long;
+        lo = 0 as i32 as isize;
         hi = (*book).used_entries
     }
     /* Single entry codebooks use a firsttablen of 1 and a
@@ -1174,24 +1174,24 @@ unsafe extern "C" fn decode_packed_entry_number(
         b as *mut crate::ogg_h::oggpack_buffer,
         read,
     );
-    while lok < 0 as i32 as libc::c_long && read > 1 as i32 {
+    while lok < 0 as i32 as isize && read > 1 as i32 {
         read -= 1;
         lok = crate::src::libogg_1_3_3::src::bitwise::oggpack_look(
             b as *mut crate::ogg_h::oggpack_buffer,
             read,
         )
     }
-    if lok < 0 as i32 as libc::c_long {
-        return -(1 as i32) as libc::c_long;
+    if lok < 0 as i32 as isize {
+        return -(1 as i32) as isize;
     }
     /* bisect search for the codeword in the ordered list */
     let mut testword: crate::config_types_h::ogg_uint32_t =
         bitreverse(lok as crate::config_types_h::ogg_uint32_t);
-    while hi - lo > 1 as i32 as libc::c_long {
-        let mut p: libc::c_long = hi - lo >> 1 as i32;
-        let mut test: libc::c_long =
-            (*(*book).codelist.offset((lo + p) as isize) > testword) as i32 as libc::c_long;
-        lo += p & test - 1 as i32 as libc::c_long;
+    while hi - lo > 1 as i32 as isize {
+        let mut p: isize = hi - lo >> 1 as i32;
+        let mut test: isize =
+            (*(*book).codelist.offset((lo + p) as isize) > testword) as i32 as isize;
+        lo += p & test - 1 as i32 as isize;
         hi -= p & -test
     }
     if *(*book).dec_codelengths.offset(lo as isize) as i32 <= read {
@@ -1205,7 +1205,7 @@ unsafe extern "C" fn decode_packed_entry_number(
         b as *mut crate::ogg_h::oggpack_buffer,
         read,
     );
-    return -(1 as i32) as libc::c_long;
+    return -(1 as i32) as isize;
 }
 /* Decode side is specced and easier, because we don't need to find
 matches using different criteria; we simply read and map.  There are
@@ -1226,15 +1226,15 @@ addmul==2 -> multiplicitive */
 pub unsafe extern "C" fn vorbis_book_decode(
     mut book: *mut crate::src::libvorbis_1_3_6::lib::codebook::codebook,
     mut b: *mut crate::ogg_h::oggpack_buffer,
-) -> libc::c_long {
-    if (*book).used_entries > 0 as i32 as libc::c_long {
-        let mut packed_entry: libc::c_long = decode_packed_entry_number(book, b);
-        if packed_entry >= 0 as i32 as libc::c_long {
-            return *(*book).dec_index.offset(packed_entry as isize) as libc::c_long;
+) -> isize {
+    if (*book).used_entries > 0 as i32 as isize {
+        let mut packed_entry: isize = decode_packed_entry_number(book, b);
+        if packed_entry >= 0 as i32 as isize {
+            return *(*book).dec_index.offset(packed_entry as isize) as isize;
         }
     }
     /* if there's no dec_index, the codebook unpacking isn't collapsed */
-    return -(1 as i32) as libc::c_long;
+    return -(1 as i32) as isize;
 }
 /* returns 0 on OK or -1 on eof *************************************/
 /* decode vector / dim granularity gaurding is done in the upper layer */
@@ -1245,15 +1245,15 @@ pub unsafe extern "C" fn vorbis_book_decodevs_add(
     mut a: *mut f32,
     mut b: *mut crate::ogg_h::oggpack_buffer,
     mut n: i32,
-) -> libc::c_long {
-    if (*book).used_entries > 0 as i32 as libc::c_long {
-        let mut step: i32 = (n as libc::c_long / (*book).dim) as i32;
+) -> isize {
+    if (*book).used_entries > 0 as i32 as isize {
+        let mut step: i32 = (n as isize / (*book).dim) as i32;
         let mut fresh0 = ::std::vec::from_elem(
             0,
-            (::std::mem::size_of::<libc::c_long>() as libc::c_ulong)
+            (::std::mem::size_of::<isize>() as libc::c_ulong)
                 .wrapping_mul(step as libc::c_ulong) as usize,
         );
-        let mut entry: *mut libc::c_long = fresh0.as_mut_ptr() as *mut libc::c_long;
+        let mut entry: *mut isize = fresh0.as_mut_ptr() as *mut isize;
         let mut fresh1 = ::std::vec::from_elem(
             0,
             (::std::mem::size_of::<*mut f32>() as libc::c_ulong).wrapping_mul(step as libc::c_ulong)
@@ -1266,8 +1266,8 @@ pub unsafe extern "C" fn vorbis_book_decodevs_add(
         i = 0 as i32;
         while i < step {
             *entry.offset(i as isize) = decode_packed_entry_number(book, b);
-            if *entry.offset(i as isize) == -(1 as i32) as libc::c_long {
-                return -(1 as i32) as libc::c_long;
+            if *entry.offset(i as isize) == -(1 as i32) as isize {
+                return -(1 as i32) as isize;
             }
             let ref mut fresh2 = *t.offset(i as isize);
             *fresh2 = (*book)
@@ -1277,7 +1277,7 @@ pub unsafe extern "C" fn vorbis_book_decodevs_add(
         }
         i = 0 as i32;
         o = 0 as i32;
-        while (i as libc::c_long) < (*book).dim {
+        while (i as isize) < (*book).dim {
             j = 0 as i32;
             while o + j < n && j < step {
                 *a.offset((o + j) as isize) += *(*t.offset(j as isize)).offset(i as isize);
@@ -1287,7 +1287,7 @@ pub unsafe extern "C" fn vorbis_book_decodevs_add(
             o += step
         }
     }
-    return 0 as i32 as libc::c_long;
+    return 0 as i32 as isize;
 }
 /* decode vector / dim granularity gaurding is done in the upper layer */
 #[no_mangle]
@@ -1297,8 +1297,8 @@ pub unsafe extern "C" fn vorbis_book_decodev_add(
     mut a: *mut f32,
     mut b: *mut crate::ogg_h::oggpack_buffer,
     mut n: i32,
-) -> libc::c_long {
-    if (*book).used_entries > 0 as i32 as libc::c_long {
+) -> isize {
+    if (*book).used_entries > 0 as i32 as isize {
         let mut i: i32 = 0;
         let mut j: i32 = 0;
         let mut entry: i32 = 0;
@@ -1307,13 +1307,13 @@ pub unsafe extern "C" fn vorbis_book_decodev_add(
         while i < n {
             entry = decode_packed_entry_number(book, b) as i32;
             if entry == -(1 as i32) {
-                return -(1 as i32) as libc::c_long;
+                return -(1 as i32) as isize;
             }
             t = (*book)
                 .valuelist
-                .offset((entry as libc::c_long * (*book).dim) as isize);
+                .offset((entry as isize * (*book).dim) as isize);
             j = 0 as i32;
-            while i < n && (j as libc::c_long) < (*book).dim {
+            while i < n && (j as isize) < (*book).dim {
                 let fresh3 = j;
                 j = j + 1;
                 let fresh4 = i;
@@ -1322,7 +1322,7 @@ pub unsafe extern "C" fn vorbis_book_decodev_add(
             }
         }
     }
-    return 0 as i32 as libc::c_long;
+    return 0 as i32 as isize;
 }
 /* unlike the others, we guard against n not being an integer number
 of <dim> internally rather than in the upper layer (called only by
@@ -1334,8 +1334,8 @@ pub unsafe extern "C" fn vorbis_book_decodev_set(
     mut a: *mut f32,
     mut b: *mut crate::ogg_h::oggpack_buffer,
     mut n: i32,
-) -> libc::c_long {
-    if (*book).used_entries > 0 as i32 as libc::c_long {
+) -> isize {
+    if (*book).used_entries > 0 as i32 as isize {
         let mut i: i32 = 0;
         let mut j: i32 = 0;
         let mut entry: i32 = 0;
@@ -1344,13 +1344,13 @@ pub unsafe extern "C" fn vorbis_book_decodev_set(
         while i < n {
             entry = decode_packed_entry_number(book, b) as i32;
             if entry == -(1 as i32) {
-                return -(1 as i32) as libc::c_long;
+                return -(1 as i32) as isize;
             }
             t = (*book)
                 .valuelist
-                .offset((entry as libc::c_long * (*book).dim) as isize);
+                .offset((entry as isize * (*book).dim) as isize);
             j = 0 as i32;
-            while i < n && (j as libc::c_long) < (*book).dim {
+            while i < n && (j as isize) < (*book).dim {
                 let fresh5 = j;
                 j = j + 1;
                 let fresh6 = i;
@@ -1367,33 +1367,33 @@ pub unsafe extern "C" fn vorbis_book_decodev_set(
             *a.offset(fresh7 as isize) = 0.0f32
         }
     }
-    return 0 as i32 as libc::c_long;
+    return 0 as i32 as isize;
 }
 #[no_mangle]
 
 pub unsafe extern "C" fn vorbis_book_decodevv_add(
     mut book: *mut crate::src::libvorbis_1_3_6::lib::codebook::codebook,
     mut a: *mut *mut f32,
-    mut offset: libc::c_long,
+    mut offset: isize,
     mut ch: i32,
     mut b: *mut crate::ogg_h::oggpack_buffer,
     mut n: i32,
-) -> libc::c_long {
-    let mut i: libc::c_long = 0;
-    let mut j: libc::c_long = 0;
-    let mut entry: libc::c_long = 0;
+) -> isize {
+    let mut i: isize = 0;
+    let mut j: isize = 0;
+    let mut entry: isize = 0;
     let mut chptr: i32 = 0 as i32;
-    if (*book).used_entries > 0 as i32 as libc::c_long {
-        let mut m: i32 = ((offset + n as libc::c_long) / ch as libc::c_long) as i32;
-        i = offset / ch as libc::c_long;
-        while i < m as libc::c_long {
+    if (*book).used_entries > 0 as i32 as isize {
+        let mut m: i32 = ((offset + n as isize) / ch as isize) as i32;
+        i = offset / ch as isize;
+        while i < m as isize {
             entry = decode_packed_entry_number(book, b);
-            if entry == -(1 as i32) as libc::c_long {
-                return -(1 as i32) as libc::c_long;
+            if entry == -(1 as i32) as isize {
+                return -(1 as i32) as isize;
             }
             let mut t: *const f32 = (*book).valuelist.offset((entry * (*book).dim) as isize);
-            j = 0 as i32 as libc::c_long;
-            while i < m as libc::c_long && j < (*book).dim {
+            j = 0 as i32 as isize;
+            while i < m as isize && j < (*book).dim {
                 let fresh8 = chptr;
                 chptr = chptr + 1;
                 *(*a.offset(fresh8 as isize)).offset(i as isize) += *t.offset(j as isize);
@@ -1405,5 +1405,5 @@ pub unsafe extern "C" fn vorbis_book_decodevv_add(
             }
         }
     }
-    return 0 as i32 as libc::c_long;
+    return 0 as i32 as isize;
 }

--- a/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/envelope.rs
+++ b/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/envelope.rs
@@ -32,10 +32,10 @@ pub struct envelope_lookup {
     pub filter: *mut crate::src::libvorbis_1_3_6::lib::envelope::envelope_filter_state,
     pub stretch: i32,
     pub mark: *mut i32,
-    pub storage: libc::c_long,
-    pub current: libc::c_long,
-    pub curmark: libc::c_long,
-    pub cursor: libc::c_long,
+    pub storage: isize,
+    pub current: isize,
+    pub curmark: isize,
+    pub cursor: isize,
 }
 use ::libc;
 
@@ -136,8 +136,8 @@ pub unsafe extern "C" fn _ve_envelope_init(
     (*e).searchstep = 64 as i32;
     (*e).minenergy = (*gi).preecho_minenergy;
     (*e).ch = ch;
-    (*e).storage = 128 as i32 as libc::c_long;
-    (*e).cursor = (*ci).blocksizes[1 as i32 as usize] / 2 as i32 as libc::c_long;
+    (*e).storage = 128 as i32 as isize;
+    (*e).cursor = (*ci).blocksizes[1 as i32 as usize] / 2 as i32 as isize;
     (*e).mdct_win = crate::stdlib::calloc(
         n as libc::c_ulong,
         ::std::mem::size_of::<f32>() as libc::c_ulong,
@@ -229,10 +229,10 @@ unsafe extern "C" fn _ve_amp(
     mut bands: *mut crate::src::libvorbis_1_3_6::lib::envelope::envelope_band,
     mut filters: *mut crate::src::libvorbis_1_3_6::lib::envelope::envelope_filter_state,
 ) -> i32 {
-    let mut n: libc::c_long = (*ve).winlength as libc::c_long;
+    let mut n: isize = (*ve).winlength as isize;
     let mut ret: i32 = 0 as i32;
-    let mut i: libc::c_long = 0;
-    let mut j: libc::c_long = 0;
+    let mut i: isize = 0;
+    let mut j: isize = 0;
     let mut decay: f32 = 0.;
     /* we want to have a 'minimum bar' for energy, else we're just
     basing blocks on quantization noise that outweighs the signal
@@ -260,7 +260,7 @@ unsafe extern "C" fn _ve_amp(
     /*_analysis_output_always("lpcm",seq2,data,n,0,0,
     totalshift+pos*ve->searchstep);*/
     /* window and transform */
-    i = 0 as i32 as libc::c_long;
+    i = 0 as i32 as isize;
     while i < n {
         *vec.offset(i as isize) = *data.offset(i as isize) * *(*ve).mdct_win.offset(i as isize);
         i += 1
@@ -300,11 +300,11 @@ unsafe extern "C" fn _ve_amp(
     /* perform spreading and limiting, also smooth the spectrum.  yes,
     the MDCT results in all real coefficients, but it still *behaves*
     like real/imaginary pairs */
-    i = 0 as i32 as libc::c_long;
-    while i < n / 2 as i32 as libc::c_long {
+    i = 0 as i32 as isize;
+    while i < n / 2 as i32 as isize {
         let mut val: f32 = *vec.offset(i as isize) * *vec.offset(i as isize)
-            + *vec.offset((i + 1 as i32 as libc::c_long) as isize)
-                * *vec.offset((i + 1 as i32 as libc::c_long) as isize);
+            + *vec.offset((i + 1 as i32 as isize) as isize)
+                * *vec.offset((i + 1 as i32 as isize) as isize);
         val = todB(&mut val) * 0.5f32;
         if val < decay {
             val = decay
@@ -314,19 +314,19 @@ unsafe extern "C" fn _ve_amp(
         }
         *vec.offset((i >> 1 as i32) as isize) = val;
         decay = (decay as f64 - 8.0f64) as f32;
-        i += 2 as i32 as libc::c_long
+        i += 2 as i32 as isize
     }
     /*_analysis_output_always("spread",seq2++,vec,n/4,0,0,0);*/
     /* perform preecho/postecho triggering by band */
-    j = 0 as i32 as libc::c_long;
-    while j < 7 as i32 as libc::c_long {
+    j = 0 as i32 as isize;
+    while j < 7 as i32 as isize {
         let mut acc: f32 = 0.0f64 as f32;
         let mut valmax: f32 = 0.;
         let mut valmin: f32 = 0.;
         /* accumulate amplitude */
-        i = 0 as i32 as libc::c_long;
-        while i < (*bands.offset(j as isize)).end as libc::c_long {
-            acc += *vec.offset((i + (*bands.offset(j as isize)).begin as libc::c_long) as isize)
+        i = 0 as i32 as isize;
+        while i < (*bands.offset(j as isize)).end as isize {
+            acc += *vec.offset((i + (*bands.offset(j as isize)).begin as isize) as isize)
                 * *(*bands.offset(j as isize)).window.offset(i as isize);
             i += 1
         }
@@ -353,8 +353,8 @@ unsafe extern "C" fn _ve_amp(
         } else {
             acc
         };
-        i = 0 as i32 as libc::c_long;
-        while i < stretch as libc::c_long {
+        i = 0 as i32 as isize;
+        while i < stretch as isize {
             p -= 1;
             if p < 0 as i32 {
                 p += 16 as i32 + 2 as i32 - 1 as i32
@@ -396,7 +396,7 @@ unsafe extern "C" fn _ve_amp(
 
 pub unsafe extern "C" fn _ve_envelope_search(
     mut v: *mut crate::codec_h::vorbis_dsp_state,
-) -> libc::c_long {
+) -> isize {
     let mut vi: *mut crate::codec_h::vorbis_info = (*v).vi;
     let mut ci: *mut crate::codec_internal_h::codec_setup_info =
         (*vi).codec_setup as *mut crate::codec_internal_h::codec_setup_info;
@@ -404,51 +404,51 @@ pub unsafe extern "C" fn _ve_envelope_search(
         &mut (*ci).psy_g_param;
     let mut ve: *mut crate::src::libvorbis_1_3_6::lib::envelope::envelope_lookup =
         (*((*v).backend_state as *mut crate::codec_internal_h::private_state)).ve;
-    let mut i: libc::c_long = 0;
-    let mut j: libc::c_long = 0;
-    let mut first: i32 = ((*ve).current / (*ve).searchstep as libc::c_long) as i32;
+    let mut i: isize = 0;
+    let mut j: isize = 0;
+    let mut first: i32 = ((*ve).current / (*ve).searchstep as isize) as i32;
     let mut last: i32 = (*v).pcm_current / (*ve).searchstep - 4 as i32;
     if first < 0 as i32 {
         first = 0 as i32
     }
     /* make sure we have enough storage to match the PCM */
-    if (last + 4 as i32 + 2 as i32) as libc::c_long > (*ve).storage {
-        (*ve).storage = (last + 4 as i32 + 2 as i32) as libc::c_long; /* be sure */
+    if (last + 4 as i32 + 2 as i32) as isize > (*ve).storage {
+        (*ve).storage = (last + 4 as i32 + 2 as i32) as isize; /* be sure */
         (*ve).mark = crate::stdlib::realloc(
             (*ve).mark as *mut libc::c_void,
             ((*ve).storage as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<i32>() as libc::c_ulong),
         ) as *mut i32
     }
-    j = first as libc::c_long;
-    while j < last as libc::c_long {
+    j = first as isize;
+    while j < last as isize {
         let mut ret: i32 = 0 as i32;
         (*ve).stretch += 1;
         if (*ve).stretch > 12 as i32 * 2 as i32 {
             (*ve).stretch = 12 as i32 * 2 as i32
         }
-        i = 0 as i32 as libc::c_long;
-        while i < (*ve).ch as libc::c_long {
+        i = 0 as i32 as isize;
+        while i < (*ve).ch as isize {
             let mut pcm: *mut f32 = (*(*v).pcm.offset(i as isize))
-                .offset(((*ve).searchstep as libc::c_long * j) as isize);
+                .offset(((*ve).searchstep as isize * j) as isize);
             ret |= _ve_amp(
                 ve,
                 gi,
                 pcm,
                 (*ve).band.as_mut_ptr(),
-                (*ve).filter.offset((i * 7 as i32 as libc::c_long) as isize),
+                (*ve).filter.offset((i * 7 as i32 as isize) as isize),
             );
             i += 1
         }
-        *(*ve).mark.offset((j + 2 as i32 as libc::c_long) as isize) = 0 as i32;
+        *(*ve).mark.offset((j + 2 as i32 as isize) as isize) = 0 as i32;
         if ret & 1 as i32 != 0 {
             *(*ve).mark.offset(j as isize) = 1 as i32;
-            *(*ve).mark.offset((j + 1 as i32 as libc::c_long) as isize) = 1 as i32
+            *(*ve).mark.offset((j + 1 as i32 as isize) as isize) = 1 as i32
         }
         if ret & 2 as i32 != 0 {
             *(*ve).mark.offset(j as isize) = 1 as i32;
-            if j > 0 as i32 as libc::c_long {
-                *(*ve).mark.offset((j - 1 as i32 as libc::c_long) as isize) = 1 as i32
+            if j > 0 as i32 as isize {
+                *(*ve).mark.offset((j - 1 as i32 as isize) as isize) = 1 as i32
             }
         }
         if ret & 4 as i32 != 0 {
@@ -456,36 +456,36 @@ pub unsafe extern "C" fn _ve_envelope_search(
         }
         j += 1
     }
-    (*ve).current = (last * (*ve).searchstep) as libc::c_long;
-    let mut centerW: libc::c_long = (*v).centerW;
-    let mut testW: libc::c_long = centerW
-        + (*ci).blocksizes[(*v).W as usize] / 4 as i32 as libc::c_long
-        + (*ci).blocksizes[1 as i32 as usize] / 2 as i32 as libc::c_long
-        + (*ci).blocksizes[0 as i32 as usize] / 4 as i32 as libc::c_long;
+    (*ve).current = (last * (*ve).searchstep) as isize;
+    let mut centerW: isize = (*v).centerW;
+    let mut testW: isize = centerW
+        + (*ci).blocksizes[(*v).W as usize] / 4 as i32 as isize
+        + (*ci).blocksizes[1 as i32 as usize] / 2 as i32 as isize
+        + (*ci).blocksizes[0 as i32 as usize] / 4 as i32 as isize;
     j = (*ve).cursor;
-    while j < (*ve).current - (*ve).searchstep as libc::c_long {
+    while j < (*ve).current - (*ve).searchstep as isize {
         /* account for postecho
         working back one window */
         if j >= testW {
-            return 1 as i32 as libc::c_long;
+            return 1 as i32 as isize;
         }
         (*ve).cursor = j;
         if *(*ve)
             .mark
-            .offset((j / (*ve).searchstep as libc::c_long) as isize)
+            .offset((j / (*ve).searchstep as isize) as isize)
             != 0
         {
             if j > centerW {
                 (*ve).curmark = j;
                 if j >= testW {
-                    return 1 as i32 as libc::c_long;
+                    return 1 as i32 as isize;
                 }
-                return 0 as i32 as libc::c_long;
+                return 0 as i32 as isize;
             }
         }
-        j += (*ve).searchstep as libc::c_long
+        j += (*ve).searchstep as isize
     }
-    return -(1 as i32) as libc::c_long;
+    return -(1 as i32) as isize;
 }
 #[no_mangle]
 
@@ -495,24 +495,24 @@ pub unsafe extern "C" fn _ve_envelope_mark(mut v: *mut crate::codec_h::vorbis_ds
     let mut vi: *mut crate::codec_h::vorbis_info = (*v).vi;
     let mut ci: *mut crate::codec_internal_h::codec_setup_info =
         (*vi).codec_setup as *mut crate::codec_internal_h::codec_setup_info;
-    let mut centerW: libc::c_long = (*v).centerW;
-    let mut beginW: libc::c_long =
-        centerW - (*ci).blocksizes[(*v).W as usize] / 4 as i32 as libc::c_long;
-    let mut endW: libc::c_long =
-        centerW + (*ci).blocksizes[(*v).W as usize] / 4 as i32 as libc::c_long;
+    let mut centerW: isize = (*v).centerW;
+    let mut beginW: isize =
+        centerW - (*ci).blocksizes[(*v).W as usize] / 4 as i32 as isize;
+    let mut endW: isize =
+        centerW + (*ci).blocksizes[(*v).W as usize] / 4 as i32 as isize;
     if (*v).W != 0 {
-        beginW -= (*ci).blocksizes[(*v).lW as usize] / 4 as i32 as libc::c_long;
-        endW += (*ci).blocksizes[(*v).nW as usize] / 4 as i32 as libc::c_long
+        beginW -= (*ci).blocksizes[(*v).lW as usize] / 4 as i32 as isize;
+        endW += (*ci).blocksizes[(*v).nW as usize] / 4 as i32 as isize
     } else {
-        beginW -= (*ci).blocksizes[0 as i32 as usize] / 4 as i32 as libc::c_long;
-        endW += (*ci).blocksizes[0 as i32 as usize] / 4 as i32 as libc::c_long
+        beginW -= (*ci).blocksizes[0 as i32 as usize] / 4 as i32 as isize;
+        endW += (*ci).blocksizes[0 as i32 as usize] / 4 as i32 as isize
     }
     if (*ve).curmark >= beginW && (*ve).curmark < endW {
         return 1 as i32;
     }
-    let mut first: libc::c_long = beginW / (*ve).searchstep as libc::c_long;
-    let mut last: libc::c_long = endW / (*ve).searchstep as libc::c_long;
-    let mut i: libc::c_long = 0;
+    let mut first: isize = beginW / (*ve).searchstep as isize;
+    let mut last: isize = endW / (*ve).searchstep as isize;
+    let mut i: isize = 0;
     i = first;
     while i < last {
         if *(*ve).mark.offset(i as isize) != 0 {
@@ -543,12 +543,12 @@ function: PCM data envelope analysis and manipulation
 
 pub unsafe extern "C" fn _ve_envelope_shift(
     mut e: *mut crate::src::libvorbis_1_3_6::lib::envelope::envelope_lookup,
-    mut shift: libc::c_long,
+    mut shift: isize,
 ) {
     let mut smallsize: i32 =
-        ((*e).current / (*e).searchstep as libc::c_long + 2 as i32 as libc::c_long) as i32; /* adjust for placing marks
+        ((*e).current / (*e).searchstep as isize + 2 as i32 as isize) as i32; /* adjust for placing marks
                                                                                             ahead of ve->current */
-    let mut smallshift: i32 = (shift / (*e).searchstep as libc::c_long) as i32;
+    let mut smallshift: i32 = (shift / (*e).searchstep as isize) as i32;
     crate::stdlib::memmove(
         (*e).mark as *mut libc::c_void,
         (*e).mark.offset(smallshift as isize) as *const libc::c_void,
@@ -556,7 +556,7 @@ pub unsafe extern "C" fn _ve_envelope_shift(
             .wrapping_mul(::std::mem::size_of::<i32>() as libc::c_ulong),
     );
     (*e).current -= shift;
-    if (*e).curmark >= 0 as i32 as libc::c_long {
+    if (*e).curmark >= 0 as i32 as isize {
         (*e).curmark -= shift
     }
     (*e).cursor -= shift;

--- a/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/floor0.rs
+++ b/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/floor0.rs
@@ -39,8 +39,8 @@ pub struct vorbis_look_floor0 {
     pub linearmap: *mut *mut i32,
     pub n: [i32; 2],
     pub vi: *mut crate::backends_h::vorbis_info_floor0,
-    pub bits: libc::c_long,
-    pub frames: libc::c_long,
+    pub bits: isize,
+    pub frames: isize,
 }
 /* **********************************************/
 
@@ -113,10 +113,10 @@ unsafe extern "C" fn floor0_unpack(
     (*info).numbooks = (crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
         opb as *mut crate::ogg_h::oggpack_buffer,
         4 as i32,
-    ) + 1 as i32 as libc::c_long) as i32;
+    ) + 1 as i32 as isize) as i32;
     if !((*info).order < 1 as i32) {
-        if !((*info).rate < 1 as i32 as libc::c_long) {
-            if !((*info).barkmap < 1 as i32 as libc::c_long) {
+        if !((*info).rate < 1 as i32 as isize) {
+            if !((*info).barkmap < 1 as i32 as isize) {
                 if !((*info).numbooks < 1 as i32) {
                     j = 0 as i32;
                     loop {
@@ -142,7 +142,7 @@ unsafe extern "C" fn floor0_unpack(
                             break;
                         }
                         if (*(*ci).book_param[(*info).books[j as usize] as usize]).dim
-                            < 1 as i32 as libc::c_long
+                            < 1 as i32 as isize
                         {
                             current_block = 8027669132317143458;
                             break;
@@ -181,7 +181,7 @@ unsafe extern "C" fn floor0_map_lazy_init(
         let mut info: *mut crate::backends_h::vorbis_info_floor0 =
             infoX as *mut crate::backends_h::vorbis_info_floor0;
         let mut W: i32 = (*vb).W as i32;
-        let mut n: i32 = ((*ci).blocksizes[W as usize] / 2 as i32 as libc::c_long) as i32;
+        let mut n: i32 = ((*ci).blocksizes[W as usize] / 2 as i32 as isize) as i32;
         let mut j: i32 = 0;
         /* we choose a scaling constant so that:
           floor(bark(rate/2-1)*C)=mapped-1
@@ -269,7 +269,7 @@ unsafe extern "C" fn floor0_inverse1(
     ) as i32;
     if ampraw > 0 as i32 {
         /* also handles the -1 out of data case */
-        let mut maxval: libc::c_long = (((1 as i32) << (*info).ampbits) - 1 as i32) as libc::c_long;
+        let mut maxval: isize = (((1 as i32) << (*info).ampbits) - 1 as i32) as isize;
         let mut amp: f32 = ampraw as f32 / maxval as f32 * (*info).ampdB as f32;
         let mut booknum: i32 = crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
             &mut (*vb).opb as *mut _ as *mut crate::ogg_h::oggpack_buffer,
@@ -291,21 +291,21 @@ unsafe extern "C" fn floor0_inverse1(
             let mut lsp: *mut f32 = crate::src::libvorbis_1_3_6::lib::block::_vorbis_block_alloc(
                 vb as *mut crate::codec_h::vorbis_block,
                 (::std::mem::size_of::<f32>() as libc::c_ulong).wrapping_mul(
-                    ((*look).m as libc::c_long + (*b).dim + 1 as i32 as libc::c_long)
+                    ((*look).m as isize + (*b).dim + 1 as i32 as isize)
                         as libc::c_ulong,
-                ) as libc::c_long,
+                ) as isize,
             ) as *mut f32;
             if !(crate::src::libvorbis_1_3_6::lib::codebook::vorbis_book_decodev_set(
                 b as *mut crate::src::libvorbis_1_3_6::lib::codebook::codebook,
                 lsp,
                 &mut (*vb).opb as *mut _ as *mut crate::ogg_h::oggpack_buffer,
                 (*look).m,
-            ) == -(1 as i32) as libc::c_long)
+            ) == -(1 as i32) as isize)
             {
                 j = 0 as i32;
                 while j < (*look).m {
                     k = 0 as i32;
-                    while j < (*look).m && (k as libc::c_long) < (*b).dim {
+                    while j < (*look).m && (k as isize) < (*b).dim {
                         *lsp.offset(j as isize) += last;
                         k += 1;
                         j += 1

--- a/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/floor1.rs
+++ b/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/floor1.rs
@@ -245,7 +245,7 @@ unsafe extern "C" fn floor1_unpack(
                     (crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
                         opb as *mut crate::ogg_h::oggpack_buffer,
                         3 as i32,
-                    ) + 1 as i32 as libc::c_long) as i32;
+                    ) + 1 as i32 as isize) as i32;
                 (*info).class_subs[j as usize] =
                     crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
                         opb as *mut crate::ogg_h::oggpack_buffer,
@@ -274,7 +274,7 @@ unsafe extern "C" fn floor1_unpack(
                         (crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
                             opb as *mut crate::ogg_h::oggpack_buffer,
                             8 as i32,
-                        ) - 1 as i32 as libc::c_long) as i32;
+                        ) - 1 as i32 as isize) as i32;
                     if (*info).class_subbook[j as usize][k as usize] < -(1 as i32)
                         || (*info).class_subbook[j as usize][k as usize] >= (*ci).books
                     {
@@ -292,7 +292,7 @@ unsafe extern "C" fn floor1_unpack(
                     (*info).mult = (crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
                         opb as *mut crate::ogg_h::oggpack_buffer,
                         2 as i32,
-                    ) + 1 as i32 as libc::c_long) as i32; /* only 1,2,3,4 legal now */
+                    ) + 1 as i32 as isize) as i32; /* only 1,2,3,4 legal now */
                     rangebits = crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
                         opb as *mut crate::ogg_h::oggpack_buffer,
                         4 as i32,
@@ -429,7 +429,7 @@ unsafe extern "C" fn floor1_look(
     while i < n {
         (*look).forward_index[i as usize] = sortpointer[i as usize]
             .offset_from((*info).postlist.as_mut_ptr())
-            as libc::c_long as i32;
+            as isize as i32;
         i += 1
     }
     /* points from range order to sorted position */
@@ -880,7 +880,7 @@ unsafe extern "C" fn accumulate_fit(
     mut n: i32,
     mut info: *mut crate::backends_h::vorbis_info_floor1,
 ) -> i32 {
-    let mut i: libc::c_long = 0;
+    let mut i: isize = 0;
     let mut xa: i32 = 0 as i32;
     let mut ya: i32 = 0 as i32;
     let mut x2a: i32 = 0 as i32;
@@ -903,23 +903,23 @@ unsafe extern "C" fn accumulate_fit(
     if x1 >= n {
         x1 = n - 1 as i32
     }
-    i = x0 as libc::c_long;
-    while i <= x1 as libc::c_long {
+    i = x0 as isize;
+    while i <= x1 as isize {
         let mut quantized: i32 = vorbis_dBquant(flr.offset(i as isize));
         if quantized != 0 {
             if *mdct.offset(i as isize) + (*info).twofitatten >= *flr.offset(i as isize) {
-                xa = (xa as libc::c_long + i) as i32;
+                xa = (xa as isize + i) as i32;
                 ya += quantized;
-                x2a = (x2a as libc::c_long + i * i) as i32;
+                x2a = (x2a as isize + i * i) as i32;
                 y2a += quantized * quantized;
-                xya = (xya as libc::c_long + i * quantized as libc::c_long) as i32;
+                xya = (xya as isize + i * quantized as isize) as i32;
                 na += 1
             } else {
-                xb = (xb as libc::c_long + i) as i32;
+                xb = (xb as isize + i) as i32;
                 yb += quantized;
-                x2b = (x2b as libc::c_long + i * i) as i32;
+                x2b = (x2b as isize + i * i) as i32;
                 y2b += quantized * quantized;
-                xyb = (xyb as libc::c_long + i * quantized as libc::c_long) as i32;
+                xyb = (xyb as isize + i * quantized as isize) as i32;
                 nb += 1
             }
         }
@@ -1104,12 +1104,12 @@ pub unsafe extern "C" fn floor1_fit(
     mut logmdct: *const f32,
     mut logmask: *const f32,
 ) -> *mut i32 {
-    let mut i: libc::c_long = 0;
-    let mut j: libc::c_long = 0;
+    let mut i: isize = 0;
+    let mut j: isize = 0;
     let mut info: *mut crate::backends_h::vorbis_info_floor1 = (*look).vi;
-    let mut n: libc::c_long = (*look).n as libc::c_long;
-    let mut posts: libc::c_long = (*look).posts as libc::c_long;
-    let mut nonzero: libc::c_long = 0 as i32 as libc::c_long;
+    let mut n: isize = (*look).n as isize;
+    let mut posts: isize = (*look).posts as isize;
+    let mut nonzero: isize = 0 as i32 as isize;
     let mut fits: [lsfit_acc; 64] = [lsfit_acc {
         x0: 0,
         x1: 0,
@@ -1132,34 +1132,34 @@ pub unsafe extern "C" fn floor1_fit(
     let mut hineighbor: [i32; 65] = [0; 65];
     let mut output: *mut i32 = 0 as *mut i32;
     let mut memo: [i32; 65] = [0; 65];
-    i = 0 as i32 as libc::c_long;
+    i = 0 as i32 as isize;
     while i < posts {
         fit_valueA[i as usize] = -(200 as i32);
         i += 1
     }
-    i = 0 as i32 as libc::c_long;
+    i = 0 as i32 as isize;
     while i < posts {
         fit_valueB[i as usize] = -(200 as i32);
         i += 1
     }
-    i = 0 as i32 as libc::c_long;
+    i = 0 as i32 as isize;
     while i < posts {
         loneighbor[i as usize] = 0 as i32;
         i += 1
     }
-    i = 0 as i32 as libc::c_long;
+    i = 0 as i32 as isize;
     while i < posts {
         hineighbor[i as usize] = 1 as i32;
         i += 1
     }
-    i = 0 as i32 as libc::c_long;
+    i = 0 as i32 as isize;
     while i < posts {
         memo[i as usize] = -(1 as i32);
         i += 1
     }
     /* quantize the relevant floor points and collect them into line fit
     structures (one per minimal division) at the same time */
-    if posts == 0 as i32 as libc::c_long {
+    if posts == 0 as i32 as isize {
         nonzero += accumulate_fit(
             logmask,
             logmdct,
@@ -1168,19 +1168,19 @@ pub unsafe extern "C" fn floor1_fit(
             fits.as_mut_ptr(),
             n as i32,
             info,
-        ) as libc::c_long
+        ) as isize
     } else {
-        i = 0 as i32 as libc::c_long;
-        while i < posts - 1 as i32 as libc::c_long {
+        i = 0 as i32 as isize;
+        while i < posts - 1 as i32 as isize {
             nonzero += accumulate_fit(
                 logmask,
                 logmdct,
                 (*look).sorted_index[i as usize],
-                (*look).sorted_index[(i + 1 as i32 as libc::c_long) as usize],
+                (*look).sorted_index[(i + 1 as i32 as isize) as usize],
                 fits.as_mut_ptr().offset(i as isize),
                 n as i32,
                 info,
-            ) as libc::c_long;
+            ) as isize;
             i += 1
         }
     }
@@ -1190,7 +1190,7 @@ pub unsafe extern "C" fn floor1_fit(
         let mut y1: i32 = -(200 as i32);
         fit_line(
             fits.as_mut_ptr(),
-            (posts - 1 as i32 as libc::c_long) as i32,
+            (posts - 1 as i32 as isize) as i32,
             &mut y0,
             &mut y1,
             info,
@@ -1203,7 +1203,7 @@ pub unsafe extern "C" fn floor1_fit(
         /* start progressive splitting.  This is a greedy, non-optimal
         algorithm, but simple and close enough to the best
         answer. */
-        i = 2 as i32 as libc::c_long;
+        i = 2 as i32 as isize;
         while i < posts {
             let mut sortpos: i32 = (*look).reverse_index[i as usize];
             let mut ln: i32 = loneighbor[sortpos as usize];
@@ -1267,15 +1267,15 @@ pub unsafe extern "C" fn floor1_fit(
                         }
                         if ly1 >= 0 as i32 || hy0 >= 0 as i32 {
                             /* store new neighbor values */
-                            j = (sortpos - 1 as i32) as libc::c_long;
-                            while j >= 0 as i32 as libc::c_long {
+                            j = (sortpos - 1 as i32) as isize;
+                            while j >= 0 as i32 as isize {
                                 if !(hineighbor[j as usize] == hn) {
                                     break;
                                 }
                                 hineighbor[j as usize] = i as i32;
                                 j -= 1
                             }
-                            j = (sortpos + 1 as i32) as libc::c_long;
+                            j = (sortpos + 1 as i32) as isize;
                             while j < posts {
                                 if !(loneighbor[j as usize] == ln) {
                                     break;
@@ -1295,7 +1295,7 @@ pub unsafe extern "C" fn floor1_fit(
         output = crate::src::libvorbis_1_3_6::lib::block::_vorbis_block_alloc(
             vb as *mut crate::codec_h::vorbis_block,
             (::std::mem::size_of::<i32>() as libc::c_ulong).wrapping_mul(posts as libc::c_ulong)
-                as libc::c_long,
+                as isize,
         ) as *mut i32;
         *output.offset(0 as i32 as isize) =
             post_Y(fit_valueA.as_mut_ptr(), fit_valueB.as_mut_ptr(), 0 as i32);
@@ -1304,10 +1304,10 @@ pub unsafe extern "C" fn floor1_fit(
         /* fill in posts marked as not using a fit; we will zero
         back out to 'unused' when encoding them so long as curve
         interpolation doesn't force them into use */
-        i = 2 as i32 as libc::c_long;
+        i = 2 as i32 as isize;
         while i < posts {
-            let mut ln_0: i32 = (*look).loneighbor[(i - 2 as i32 as libc::c_long) as usize];
-            let mut hn_0: i32 = (*look).hineighbor[(i - 2 as i32 as libc::c_long) as usize];
+            let mut ln_0: i32 = (*look).loneighbor[(i - 2 as i32 as isize) as usize];
+            let mut hn_0: i32 = (*look).hineighbor[(i - 2 as i32 as isize) as usize];
             let mut x0: i32 = (*info).postlist[ln_0 as usize];
             let mut x1: i32 = (*info).postlist[hn_0 as usize];
             let mut y0_0: i32 = *output.offset(ln_0 as isize);
@@ -1333,17 +1333,17 @@ pub unsafe extern "C" fn floor1_interpolate_fit(
     mut B: *mut i32,
     mut del: i32,
 ) -> *mut i32 {
-    let mut i: libc::c_long = 0;
-    let mut posts: libc::c_long = (*look).posts as libc::c_long;
+    let mut i: isize = 0;
+    let mut posts: isize = (*look).posts as isize;
     let mut output: *mut i32 = 0 as *mut i32;
     if !A.is_null() && !B.is_null() {
         output = crate::src::libvorbis_1_3_6::lib::block::_vorbis_block_alloc(
             vb as *mut crate::codec_h::vorbis_block,
             (::std::mem::size_of::<i32>() as libc::c_ulong).wrapping_mul(posts as libc::c_ulong)
-                as libc::c_long,
+                as isize,
         ) as *mut i32;
         /* overly simpleminded--- look again post 1.2 */
-        i = 0 as i32 as libc::c_long;
+        i = 0 as i32 as isize;
         while i < posts {
             *output.offset(i as isize) = (65536 as i32 - del)
                 * (*A.offset(i as isize) & 0x7fff as i32)
@@ -1394,10 +1394,10 @@ pub unsafe extern "C" fn floor1_encode(
     mut post: *mut i32,
     mut ilogmask: *mut i32,
 ) -> i32 {
-    let mut i: libc::c_long = 0;
-    let mut j: libc::c_long = 0;
+    let mut i: isize = 0;
+    let mut j: isize = 0;
     let mut info: *mut crate::backends_h::vorbis_info_floor1 = (*look).vi;
-    let mut posts: libc::c_long = (*look).posts as libc::c_long;
+    let mut posts: isize = (*look).posts as isize;
     let mut ci: *mut crate::codec_internal_h::codec_setup_info =
         (*(*(*vb).vd).vi).codec_setup as *mut crate::codec_internal_h::codec_setup_info;
     let mut out: [i32; 65] = [0; 65];
@@ -1406,7 +1406,7 @@ pub unsafe extern "C" fn floor1_encode(
     let mut books: *mut crate::src::libvorbis_1_3_6::lib::codebook::codebook = (*ci).fullbooks;
     /* quantize values to multiplier spec */
     if !post.is_null() {
-        i = 0 as i32 as libc::c_long;
+        i = 0 as i32 as isize;
         while i < posts {
             let mut val: i32 = *post.offset(i as isize) & 0x7fff as i32;
             match (*info).mult {
@@ -1434,11 +1434,11 @@ pub unsafe extern "C" fn floor1_encode(
         out[0 as i32 as usize] = *post.offset(0 as i32 as isize);
         out[1 as i32 as usize] = *post.offset(1 as i32 as isize);
         /* find prediction values for each post and subtract them */
-        i = 2 as i32 as libc::c_long; /* in case there was roundoff jitter
+        i = 2 as i32 as isize; /* in case there was roundoff jitter
                                       in interpolation */
         while i < posts {
-            let mut ln: i32 = (*look).loneighbor[(i - 2 as i32 as libc::c_long) as usize];
-            let mut hn: i32 = (*look).hineighbor[(i - 2 as i32 as libc::c_long) as usize];
+            let mut ln: i32 = (*look).loneighbor[(i - 2 as i32 as isize) as usize];
+            let mut hn: i32 = (*look).hineighbor[(i - 2 as i32 as isize) as usize];
             let mut x0: i32 = (*info).postlist[ln as usize];
             let mut x1: i32 = (*info).postlist[hn as usize];
             let mut y0: i32 = *post.offset(ln as isize);
@@ -1489,7 +1489,7 @@ pub unsafe extern "C" fn floor1_encode(
         (*look).frames += 1;
         (*look).postbits += (crate::src::libvorbis_1_3_6::lib::sharedbook::ov_ilog(
             ((*look).quant_q - 1 as i32) as crate::config_types_h::ogg_uint32_t,
-        ) * 2 as i32) as libc::c_long;
+        ) * 2 as i32) as isize;
         crate::src::libogg_1_3_3::src::bitwise::oggpack_write(
             opb as *mut crate::ogg_h::oggpack_buffer,
             out[0 as i32 as usize] as libc::c_ulong,
@@ -1505,9 +1505,9 @@ pub unsafe extern "C" fn floor1_encode(
             ),
         );
         /* partition by partition */
-        i = 0 as i32 as libc::c_long;
-        j = 2 as i32 as libc::c_long;
-        while i < (*info).partitions as libc::c_long {
+        i = 0 as i32 as isize;
+        j = 2 as i32 as isize;
+        while i < (*info).partitions as isize {
             let mut class: i32 = (*info).partitionclass[i as usize];
             let mut cdim: i32 = (*info).class_dim[class as usize];
             let mut csubbits: i32 = (*info).class_subs[class as usize];
@@ -1542,7 +1542,7 @@ pub unsafe extern "C" fn floor1_encode(
                 while k < cdim {
                     l = 0 as i32;
                     while l < csub {
-                        let mut val_1: i32 = out[(j + k as libc::c_long) as usize];
+                        let mut val_1: i32 = out[(j + k as isize) as usize];
                         if val_1 < maxval[l as usize] {
                             bookas[k as usize] = l;
                             break;
@@ -1560,7 +1560,7 @@ pub unsafe extern "C" fn floor1_encode(
                         as *mut crate::src::libvorbis_1_3_6::lib::codebook::codebook,
                     cval,
                     opb as *mut crate::ogg_h::oggpack_buffer,
-                ) as libc::c_long
+                ) as isize
             }
             /* write post values */
             k = 0 as i32;
@@ -1569,23 +1569,23 @@ pub unsafe extern "C" fn floor1_encode(
                     (*info).class_subbook[class as usize][bookas[k as usize] as usize];
                 if book >= 0 as i32 {
                     /* hack to allow training with 'bad' books */
-                    if (out[(j + k as libc::c_long) as usize] as libc::c_long)
+                    if (out[(j + k as isize) as usize] as isize)
                         < (*books.offset(book as isize)).entries
                     {
                         (*look).postbits +=
                             crate::src::libvorbis_1_3_6::lib::codebook::vorbis_book_encode(
                                 books.offset(book as isize)
                                     as *mut crate::src::libvorbis_1_3_6::lib::codebook::codebook,
-                                out[(j + k as libc::c_long) as usize],
+                                out[(j + k as isize) as usize],
                                 opb as *mut crate::ogg_h::oggpack_buffer,
-                            ) as libc::c_long
+                            ) as isize
                     }
                     /*else
                     fprintf(stderr,"+!");*/
                 }
                 k += 1
             }
-            j += cdim as libc::c_long;
+            j += cdim as isize;
             i += 1
         }
         /* generate quantized floor equivalent to what we'd unpack in decode */
@@ -1593,9 +1593,9 @@ pub unsafe extern "C" fn floor1_encode(
         let mut hx: i32 = 0 as i32; /* be certain */
         let mut lx: i32 = 0 as i32;
         let mut ly: i32 = *post.offset(0 as i32 as isize) * (*info).mult;
-        let mut n: i32 = ((*ci).blocksizes[(*vb).W as usize] / 2 as i32 as libc::c_long) as i32;
-        j = 1 as i32 as libc::c_long;
-        while j < (*look).posts as libc::c_long {
+        let mut n: i32 = ((*ci).blocksizes[(*vb).W as usize] / 2 as i32 as isize) as i32;
+        j = 1 as i32 as isize;
+        while j < (*look).posts as isize {
             let mut current: i32 = (*look).forward_index[j as usize];
             let mut hy: i32 = *post.offset(current as isize) & 0x7fff as i32;
             if hy == *post.offset(current as isize) {
@@ -1607,8 +1607,8 @@ pub unsafe extern "C" fn floor1_encode(
             }
             j += 1
         }
-        j = hx as libc::c_long;
-        while j < ((*vb).pcmend / 2 as i32) as libc::c_long {
+        j = hx as isize;
+        while j < ((*vb).pcmend / 2 as i32) as isize {
             *ilogmask.offset(j as isize) = ly;
             j += 1
         }
@@ -1647,13 +1647,13 @@ unsafe extern "C" fn floor1_inverse1(
     if crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
         &mut (*vb).opb as *mut _ as *mut crate::ogg_h::oggpack_buffer,
         1 as i32,
-    ) == 1 as i32 as libc::c_long
+    ) == 1 as i32 as isize
     {
         let mut fit_value: *mut i32 = crate::src::libvorbis_1_3_6::lib::block::_vorbis_block_alloc(
             vb as *mut crate::codec_h::vorbis_block,
             ((*look).posts as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<i32>() as libc::c_ulong)
-                as libc::c_long,
+                as isize,
         ) as *mut i32;
         *fit_value.offset(0 as i32 as isize) = crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
             &mut (*vb).opb as *mut _ as *mut crate::ogg_h::oggpack_buffer,
@@ -1773,7 +1773,7 @@ unsafe extern "C" fn floor1_inverse2(
     let mut info: *mut crate::backends_h::vorbis_info_floor1 = (*look).vi;
     let mut ci: *mut crate::codec_internal_h::codec_setup_info =
         (*(*(*vb).vd).vi).codec_setup as *mut crate::codec_internal_h::codec_setup_info;
-    let mut n: i32 = ((*ci).blocksizes[(*vb).W as usize] / 2 as i32 as libc::c_long) as i32;
+    let mut n: i32 = ((*ci).blocksizes[(*vb).W as usize] / 2 as i32 as isize) as i32;
     let mut j: i32 = 0;
     if !memo.is_null() {
         /* render the lines */

--- a/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/info.rs
+++ b/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/info.rs
@@ -232,15 +232,15 @@ pub unsafe extern "C" fn vorbis_comment_query(
     mut tag: *const libc::c_char,
     mut count: i32,
 ) -> *mut libc::c_char {
-    let mut i: libc::c_long = 0;
+    let mut i: isize = 0;
     let mut found: i32 = 0 as i32;
     let mut taglen: i32 = crate::stdlib::strlen(tag).wrapping_add(1 as i32 as libc::c_ulong) as i32;
     let mut fulltag: *mut libc::c_char =
         crate::stdlib::malloc((taglen + 1 as i32) as libc::c_ulong) as *mut libc::c_char;
     ::libc::strcpy(fulltag, tag);
     ::libc::strcat(fulltag, b"=\x00" as *const u8 as *const libc::c_char);
-    i = 0 as i32 as libc::c_long;
-    while i < (*vc).comments as libc::c_long {
+    i = 0 as i32 as isize;
+    while i < (*vc).comments as isize {
         if tagcompare(*(*vc).user_comments.offset(i as isize), fulltag, taglen) == 0 {
             if count == found {
                 /* We return a pointer to the data, not a copy */
@@ -283,10 +283,10 @@ pub unsafe extern "C" fn vorbis_comment_query_count(
 
 pub unsafe extern "C" fn vorbis_comment_clear(mut vc: *mut crate::codec_h::vorbis_comment) {
     if !vc.is_null() {
-        let mut i: libc::c_long = 0;
+        let mut i: isize = 0;
         if !(*vc).user_comments.is_null() {
-            i = 0 as i32 as libc::c_long;
-            while i < (*vc).comments as libc::c_long {
+            i = 0 as i32 as isize;
+            while i < (*vc).comments as isize {
                 if !(*(*vc).user_comments.offset(i as isize)).is_null() {
                     ::libc::free(*(*vc).user_comments.offset(i as isize) as *mut libc::c_void);
                 }
@@ -320,7 +320,7 @@ pub unsafe extern "C" fn vorbis_info_blocksize(
     return if !ci.is_null() {
         (*ci).blocksizes[zo as usize]
     } else {
-        -(1 as i32) as libc::c_long
+        -(1 as i32) as isize
     } as i32;
 }
 /* libvorbis encodes in two abstraction layers; first we perform DSP
@@ -475,34 +475,34 @@ unsafe extern "C" fn _vorbis_unpack_info(
     (*vi).bitrate_upper = crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
         opb as *mut crate::ogg_h::oggpack_buffer,
         32 as i32,
-    ) as crate::config_types_h::ogg_int32_t as libc::c_long;
+    ) as crate::config_types_h::ogg_int32_t as isize;
     (*vi).bitrate_nominal = crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
         opb as *mut crate::ogg_h::oggpack_buffer,
         32 as i32,
-    ) as crate::config_types_h::ogg_int32_t as libc::c_long;
+    ) as crate::config_types_h::ogg_int32_t as isize;
     (*vi).bitrate_lower = crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
         opb as *mut crate::ogg_h::oggpack_buffer,
         32 as i32,
-    ) as crate::config_types_h::ogg_int32_t as libc::c_long;
+    ) as crate::config_types_h::ogg_int32_t as isize;
     (*ci).blocksizes[0 as i32 as usize] = ((1 as i32)
         << crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
             opb as *mut crate::ogg_h::oggpack_buffer,
             4 as i32,
-        )) as libc::c_long;
+        )) as isize;
     (*ci).blocksizes[1 as i32 as usize] = ((1 as i32)
         << crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
             opb as *mut crate::ogg_h::oggpack_buffer,
             4 as i32,
-        )) as libc::c_long;
-    if !((*vi).rate < 1 as i32 as libc::c_long) {
+        )) as isize;
+    if !((*vi).rate < 1 as i32 as isize) {
         if !((*vi).channels < 1 as i32) {
-            if !((*ci).blocksizes[0 as i32 as usize] < 64 as i32 as libc::c_long) {
+            if !((*ci).blocksizes[0 as i32 as usize] < 64 as i32 as isize) {
                 if !((*ci).blocksizes[1 as i32 as usize] < (*ci).blocksizes[0 as i32 as usize]) {
-                    if !((*ci).blocksizes[1 as i32 as usize] > 8192 as i32 as libc::c_long) {
+                    if !((*ci).blocksizes[1 as i32 as usize] > 8192 as i32 as isize) {
                         if !(crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
                             opb as *mut crate::ogg_h::oggpack_buffer,
                             1 as i32,
-                        ) != 1 as i32 as libc::c_long)
+                        ) != 1 as i32 as isize)
                         {
                             return 0 as i32;
                         }
@@ -526,7 +526,7 @@ unsafe extern "C" fn _vorbis_unpack_comment(
         32 as i32,
     ) as i32;
     if !(vendorlen < 0 as i32) {
-        if !(vendorlen as libc::c_long > (*opb).storage - 8 as i32 as libc::c_long) {
+        if !(vendorlen as isize > (*opb).storage - 8 as i32 as isize) {
             (*vc).vendor = crate::stdlib::calloc(
                 (vendorlen + 1 as i32) as libc::c_ulong,
                 1 as i32 as libc::c_ulong,
@@ -537,7 +537,7 @@ unsafe extern "C" fn _vorbis_unpack_comment(
                 32 as i32,
             ) as i32;
             if !(i < 0 as i32) {
-                if !(i as libc::c_long
+                if !(i as isize
                     > (*opb).storage
                         - crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(
                             opb as *mut crate::ogg_h::oggpack_buffer,
@@ -567,7 +567,7 @@ unsafe extern "C" fn _vorbis_unpack_comment(
                             current_block = 16389255375241467587;
                             break;
                         }
-                        if len as libc::c_long
+                        if len as isize
                             > (*opb).storage
                                 - crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(
                                     opb as *mut crate::ogg_h::oggpack_buffer,
@@ -591,7 +591,7 @@ unsafe extern "C" fn _vorbis_unpack_comment(
                             if !(crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
                                 opb as *mut crate::ogg_h::oggpack_buffer,
                                 1 as i32,
-                            ) != 1 as i32 as libc::c_long)
+                            ) != 1 as i32 as isize)
                             {
                                 return 0 as i32;
                             }
@@ -619,7 +619,7 @@ unsafe extern "C" fn _vorbis_unpack_books(
     (*ci).books = (crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
         opb as *mut crate::ogg_h::oggpack_buffer,
         8 as i32,
-    ) + 1 as i32 as libc::c_long) as i32;
+    ) + 1 as i32 as isize) as i32;
     if !((*ci).books <= 0 as i32) {
         i = 0 as i32;
         loop {
@@ -646,7 +646,7 @@ unsafe extern "C" fn _vorbis_unpack_books(
                 let mut times: i32 = (crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
                     opb as *mut crate::ogg_h::oggpack_buffer,
                     6 as i32,
-                ) + 1 as i32 as libc::c_long) as i32;
+                ) + 1 as i32 as isize) as i32;
                 if !(times <= 0 as i32) {
                     i = 0 as i32;
                     loop {
@@ -671,7 +671,7 @@ unsafe extern "C" fn _vorbis_unpack_books(
                             (*ci).floors = (crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
                                 opb as *mut crate::ogg_h::oggpack_buffer,
                                 6 as i32,
-                            ) + 1 as i32 as libc::c_long)
+                            ) + 1 as i32 as isize)
                                 as i32;
                             if !((*ci).floors <= 0 as i32) {
                                 i = 0 as i32;
@@ -713,7 +713,7 @@ unsafe extern "C" fn _vorbis_unpack_books(
                                             (crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
                                                 opb as *mut crate::ogg_h::oggpack_buffer,
                                                 6 as i32,
-                                            ) + 1 as i32 as libc::c_long)
+                                            ) + 1 as i32 as isize)
                                                 as i32;
                                         if !((*ci).residues <= 0 as i32) {
                                             i = 0 as i32;
@@ -760,7 +760,7 @@ unsafe extern "C" fn _vorbis_unpack_books(
                                                              +
                                                              1 as i32
                                                                  as
-                                                                 libc::c_long)
+                                                                 isize)
                                                             as i32;
                                                     if !((*ci).maps <= 0 as i32) {
                                                         i = 0 as i32;
@@ -817,7 +817,7 @@ unsafe extern "C" fn _vorbis_unpack_books(
                                                                          1 as
                                                                              i32
                                                                              as
-                                                                             libc::c_long)
+                                                                             isize)
                                                                         as
                                                                         i32; /* top level EOP check */
                                                                 if !((*ci).modes <= 0 as i32) {
@@ -935,7 +935,7 @@ unsafe extern "C" fn _vorbis_unpack_books(
                                                                                          as
                                                                                          i32
                                                                                          as
-                                                                                         libc::c_long)
+                                                                                         isize)
                                                                                {
                                                                                 return 0
                                                                                            as
@@ -987,7 +987,7 @@ pub unsafe extern "C" fn vorbis_synthesis_idheader(mut op: *mut crate::ogg_h::og
         if crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
             &mut opb as *mut _ as *mut crate::ogg_h::oggpack_buffer,
             8 as i32,
-        ) != 1 as i32 as libc::c_long
+        ) != 1 as i32 as isize
         {
             return 0 as i32;
         }
@@ -1062,7 +1062,7 @@ pub unsafe extern "C" fn vorbis_synthesis_headerin(
                     /* Not the initial packet */
                     return -(133 as i32);
                 }
-                if (*vi).rate != 0 as i32 as libc::c_long {
+                if (*vi).rate != 0 as i32 as isize {
                     /* previously initialized info header */
                     return -(133 as i32);
                 }
@@ -1070,7 +1070,7 @@ pub unsafe extern "C" fn vorbis_synthesis_headerin(
             }
             3 => {
                 /* least significant *bit* is read first */
-                if (*vi).rate == 0 as i32 as libc::c_long {
+                if (*vi).rate == 0 as i32 as isize {
                     /* um... we didn't get the initial header */
                     return -(133 as i32);
                 }
@@ -1082,7 +1082,7 @@ pub unsafe extern "C" fn vorbis_synthesis_headerin(
             }
             5 => {
                 /* least significant *bit* is read first */
-                if (*vi).rate == 0 as i32 as libc::c_long || (*vc).vendor.is_null() {
+                if (*vi).rate == 0 as i32 as isize || (*vc).vendor.is_null() {
                     /* um... we didn;t get the initial header or comments yet */
                     return -(133 as i32);
                 }
@@ -1115,7 +1115,7 @@ unsafe extern "C" fn _vorbis_pack_info(
     let mut ci: *mut crate::codec_internal_h::codec_setup_info =
         (*vi).codec_setup as *mut crate::codec_internal_h::codec_setup_info;
     if ci.is_null()
-        || (*ci).blocksizes[0 as i32 as usize] < 64 as i32 as libc::c_long
+        || (*ci).blocksizes[0 as i32 as usize] < 64 as i32 as isize
         || (*ci).blocksizes[1 as i32 as usize] < (*ci).blocksizes[0 as i32 as usize]
     {
         return -(129 as i32);
@@ -1165,7 +1165,7 @@ unsafe extern "C" fn _vorbis_pack_info(
     crate::src::libogg_1_3_3::src::bitwise::oggpack_write(
         opb as *mut crate::ogg_h::oggpack_buffer,
         crate::src::libvorbis_1_3_6::lib::sharedbook::ov_ilog(
-            ((*ci).blocksizes[0 as i32 as usize] - 1 as i32 as libc::c_long)
+            ((*ci).blocksizes[0 as i32 as usize] - 1 as i32 as isize)
                 as crate::config_types_h::ogg_uint32_t,
         ) as libc::c_ulong,
         4 as i32,
@@ -1173,7 +1173,7 @@ unsafe extern "C" fn _vorbis_pack_info(
     crate::src::libogg_1_3_3::src::bitwise::oggpack_write(
         opb as *mut crate::ogg_h::oggpack_buffer,
         crate::src::libvorbis_1_3_6::lib::sharedbook::ov_ilog(
-            ((*ci).blocksizes[1 as i32 as usize] - 1 as i32 as libc::c_long)
+            ((*ci).blocksizes[1 as i32 as usize] - 1 as i32 as isize)
                 as crate::config_types_h::ogg_uint32_t,
         ) as libc::c_ulong,
         4 as i32,
@@ -1473,8 +1473,8 @@ pub unsafe extern "C" fn vorbis_commentheader_out(
     (*op).bytes = crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(
         &mut opb as *mut _ as *mut crate::ogg_h::oggpack_buffer,
     );
-    (*op).b_o_s = 0 as i32 as libc::c_long;
-    (*op).e_o_s = 0 as i32 as libc::c_long;
+    (*op).b_o_s = 0 as i32 as isize;
+    (*op).e_o_s = 0 as i32 as isize;
     (*op).granulepos = 0 as i32 as crate::config_types_h::ogg_int64_t;
     (*op).packetno = 1 as i32 as crate::config_types_h::ogg_int64_t;
     crate::src::libogg_1_3_3::src::bitwise::oggpack_writeclear(
@@ -1530,8 +1530,8 @@ pub unsafe extern "C" fn vorbis_analysis_headerout(
             (*op).bytes = crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(
                 &mut opb as *mut _ as *mut crate::ogg_h::oggpack_buffer,
             );
-            (*op).b_o_s = 1 as i32 as libc::c_long;
-            (*op).e_o_s = 0 as i32 as libc::c_long;
+            (*op).b_o_s = 1 as i32 as isize;
+            (*op).e_o_s = 0 as i32 as isize;
             (*op).granulepos = 0 as i32 as crate::config_types_h::ogg_int64_t;
             (*op).packetno = 0 as i32 as crate::config_types_h::ogg_int64_t;
             /* second header packet (comments) **********************************/
@@ -1557,8 +1557,8 @@ pub unsafe extern "C" fn vorbis_analysis_headerout(
                 (*op_comm).bytes = crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(
                     &mut opb as *mut _ as *mut crate::ogg_h::oggpack_buffer,
                 );
-                (*op_comm).b_o_s = 0 as i32 as libc::c_long;
-                (*op_comm).e_o_s = 0 as i32 as libc::c_long;
+                (*op_comm).b_o_s = 0 as i32 as isize;
+                (*op_comm).e_o_s = 0 as i32 as isize;
                 (*op_comm).granulepos = 0 as i32 as crate::config_types_h::ogg_int64_t;
                 (*op_comm).packetno = 1 as i32 as crate::config_types_h::ogg_int64_t;
                 /* third header packet (modes/codebooks) ****************************/
@@ -1585,8 +1585,8 @@ pub unsafe extern "C" fn vorbis_analysis_headerout(
                     (*op_code).bytes = crate::src::libogg_1_3_3::src::bitwise::oggpack_bytes(
                         &mut opb as *mut _ as *mut crate::ogg_h::oggpack_buffer,
                     );
-                    (*op_code).b_o_s = 0 as i32 as libc::c_long;
-                    (*op_code).e_o_s = 0 as i32 as libc::c_long;
+                    (*op_code).b_o_s = 0 as i32 as isize;
+                    (*op_code).e_o_s = 0 as i32 as isize;
                     (*op_code).granulepos = 0 as i32 as crate::config_types_h::ogg_int64_t;
                     (*op_code).packetno = 2 as i32 as crate::config_types_h::ogg_int64_t;
                     crate::src::libogg_1_3_3::src::bitwise::oggpack_writeclear(
@@ -1639,18 +1639,18 @@ pub unsafe extern "C" fn vorbis_granule_time(
     mut v: *mut crate::codec_h::vorbis_dsp_state,
     mut granulepos: crate::config_types_h::ogg_int64_t,
 ) -> f64 {
-    if granulepos == -(1 as i32) as libc::c_long {
+    if granulepos == -(1 as i32) as isize {
         return -(1 as i32) as f64;
     }
     /* We're not guaranteed a 64 bit unsigned type everywhere, so we
     have to put the unsigned granpo in a signed type. */
-    if granulepos >= 0 as i32 as libc::c_long {
+    if granulepos >= 0 as i32 as isize {
         return granulepos as f64 / (*(*v).vi).rate as f64;
     } else {
         let mut granuleoff: crate::config_types_h::ogg_int64_t =
             0xffffffff as u32 as crate::config_types_h::ogg_int64_t;
         granuleoff <<= 31 as i32;
-        granuleoff |= 0x7ffffffff as libc::c_long;
+        granuleoff |= 0x7ffffffff as isize;
         return (granulepos as f64 + 2 as i32 as f64 + granuleoff as f64 + granuleoff as f64)
             / (*(*v).vi).rate as f64;
     };

--- a/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/lpc.rs
+++ b/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/lpc.rs
@@ -166,42 +166,42 @@ pub unsafe extern "C" fn vorbis_lpc_predict(
     mut prime: *mut f32,
     mut m: i32,
     mut data: *mut f32,
-    mut n: libc::c_long,
+    mut n: isize,
 ) {
     /* in: coeff[0...m-1] LPC coefficients
          prime[0...m-1] initial values (allocated size of n+m-1)
     out: data[0...n-1] data samples */
-    let mut i: libc::c_long = 0;
-    let mut j: libc::c_long = 0;
-    let mut o: libc::c_long = 0;
-    let mut p: libc::c_long = 0;
+    let mut i: isize = 0;
+    let mut j: isize = 0;
+    let mut o: isize = 0;
+    let mut p: isize = 0;
     let mut y: f32 = 0.;
     let mut fresh3 = ::std::vec::from_elem(
         0,
         (::std::mem::size_of::<f32>() as libc::c_ulong)
-            .wrapping_mul((m as libc::c_long + n) as libc::c_ulong) as usize,
+            .wrapping_mul((m as isize + n) as libc::c_ulong) as usize,
     );
     let mut work: *mut f32 = fresh3.as_mut_ptr() as *mut f32;
     if prime.is_null() {
-        i = 0 as i32 as libc::c_long;
-        while i < m as libc::c_long {
+        i = 0 as i32 as isize;
+        while i < m as isize {
             *work.offset(i as isize) = 0.0f32;
             i += 1
         }
     } else {
-        i = 0 as i32 as libc::c_long;
-        while i < m as libc::c_long {
+        i = 0 as i32 as isize;
+        while i < m as isize {
             *work.offset(i as isize) = *prime.offset(i as isize);
             i += 1
         }
     }
-    i = 0 as i32 as libc::c_long;
+    i = 0 as i32 as isize;
     while i < n {
         y = 0 as i32 as f32;
         o = i;
-        p = m as libc::c_long;
-        j = 0 as i32 as libc::c_long;
-        while j < m as libc::c_long {
+        p = m as isize;
+        j = 0 as i32 as isize;
+        while j < m as isize {
             let fresh4 = o;
             o = o + 1;
             p -= 1;

--- a/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/mapping0.rs
+++ b/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/mapping0.rs
@@ -253,7 +253,7 @@ unsafe extern "C" fn mapping0_unpack(
                 (*info).submaps = (crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
                     opb as *mut crate::ogg_h::oggpack_buffer,
                     4 as i32,
-                ) + 1 as i32 as libc::c_long) as i32;
+                ) + 1 as i32 as isize) as i32;
                 if (*info).submaps <= 0 as i32 {
                     current_block = 1977384903651761240;
                 } else {
@@ -276,7 +276,7 @@ unsafe extern "C" fn mapping0_unpack(
                                 (crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
                                     opb as *mut crate::ogg_h::oggpack_buffer,
                                     8 as i32,
-                                ) + 1 as i32 as libc::c_long)
+                                ) + 1 as i32 as isize)
                                     as i32;
                             if (*info).coupling_steps <= 0 as i32 {
                                 current_block = 1977384903651761240;
@@ -340,7 +340,7 @@ unsafe extern "C" fn mapping0_unpack(
                                 if !(crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
                                     opb as *mut crate::ogg_h::oggpack_buffer,
                                     2 as i32,
-                                ) != 0 as i32 as libc::c_long)
+                                ) != 0 as i32 as isize)
                                 {
                                     if (*info).submaps > 1 as i32 {
                                         i = 0 as i32;
@@ -448,20 +448,20 @@ unsafe extern "C" fn mapping0_forward(mut vb: *mut crate::codec_h::vorbis_block)
         vb as *mut crate::codec_h::vorbis_block,
         ((*vi).channels as libc::c_ulong)
             .wrapping_mul(::std::mem::size_of::<*mut f32>() as libc::c_ulong)
-            as libc::c_long,
+            as isize,
     ) as *mut *mut f32;
     let mut iwork: *mut *mut i32 = crate::src::libvorbis_1_3_6::lib::block::_vorbis_block_alloc(
         vb as *mut crate::codec_h::vorbis_block,
         ((*vi).channels as libc::c_ulong)
             .wrapping_mul(::std::mem::size_of::<*mut i32>() as libc::c_ulong)
-            as libc::c_long,
+            as isize,
     ) as *mut *mut i32;
     let mut floor_posts: *mut *mut *mut i32 =
         crate::src::libvorbis_1_3_6::lib::block::_vorbis_block_alloc(
             vb as *mut crate::codec_h::vorbis_block,
             ((*vi).channels as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<*mut *mut i32>() as libc::c_ulong)
-                as libc::c_long,
+                as isize,
         ) as *mut *mut *mut i32;
     let mut global_ampmax: f32 = (*vbi).ampmax;
     let mut fresh1 = ::std::vec::from_elem(
@@ -490,14 +490,14 @@ unsafe extern "C" fn mapping0_forward(mut vb: *mut crate::codec_h::vorbis_block)
             vb as *mut crate::codec_h::vorbis_block,
             ((n / 2 as i32) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<i32>() as libc::c_ulong)
-                as libc::c_long,
+                as isize,
         ) as *mut i32;
         let ref mut fresh3 = *gmdct.offset(i as isize);
         *fresh3 = crate::src::libvorbis_1_3_6::lib::block::_vorbis_block_alloc(
             vb as *mut crate::codec_h::vorbis_block,
             ((n / 2 as i32) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<f32>() as libc::c_ulong)
-                as libc::c_long,
+                as isize,
         ) as *mut f32;
         scale_dB = (todB(&mut scale) as f64 + 0.345f64) as f32;
         /* window the PCM data */
@@ -576,12 +576,12 @@ unsafe extern "C" fn mapping0_forward(mut vb: *mut crate::codec_h::vorbis_block)
     let mut noise: *mut f32 = crate::src::libvorbis_1_3_6::lib::block::_vorbis_block_alloc(
         vb as *mut crate::codec_h::vorbis_block,
         ((n / 2 as i32) as libc::c_ulong)
-            .wrapping_mul(::std::mem::size_of::<f32>() as libc::c_ulong) as libc::c_long,
+            .wrapping_mul(::std::mem::size_of::<f32>() as libc::c_ulong) as isize,
     ) as *mut f32;
     let mut tone: *mut f32 = crate::src::libvorbis_1_3_6::lib::block::_vorbis_block_alloc(
         vb as *mut crate::codec_h::vorbis_block,
         ((n / 2 as i32) as libc::c_ulong)
-            .wrapping_mul(::std::mem::size_of::<f32>() as libc::c_ulong) as libc::c_long,
+            .wrapping_mul(::std::mem::size_of::<f32>() as libc::c_ulong) as isize,
     ) as *mut f32;
     i = 0 as i32;
     while i < (*vi).channels {
@@ -612,7 +612,7 @@ unsafe extern "C" fn mapping0_forward(mut vb: *mut crate::codec_h::vorbis_block)
             vb as *mut crate::codec_h::vorbis_block,
             (15 as i32 as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<*mut i32>() as libc::c_ulong)
-                as libc::c_long,
+                as isize,
         ) as *mut *mut i32;
         crate::stdlib::memset(
             *floor_posts.offset(i as isize) as *mut libc::c_void,
@@ -864,7 +864,7 @@ unsafe extern "C" fn mapping0_forward(mut vb: *mut crate::codec_h::vorbis_block)
         i = 0 as i32;
         while i < (*info).submaps {
             let mut ch_in_bundle: i32 = 0 as i32;
-            let mut classifications: *mut *mut libc::c_long = 0 as *mut *mut libc::c_long;
+            let mut classifications: *mut *mut isize = 0 as *mut *mut isize;
             let mut resnum: i32 = (*info).residuesubmap[i as usize];
             j = 0 as i32;
             while j < (*vi).channels {
@@ -938,7 +938,7 @@ unsafe extern "C" fn mapping0_inverse(
     let mut i: i32 = 0;
     let mut j: i32 = 0;
     (*vb).pcmend = (*ci).blocksizes[(*vb).W as usize] as i32;
-    let mut n: libc::c_long = (*vb).pcmend as libc::c_long;
+    let mut n: isize = (*vb).pcmend as isize;
     let mut fresh17 = ::std::vec::from_elem(
         0,
         (::std::mem::size_of::<*mut f32>() as libc::c_ulong)
@@ -1054,7 +1054,7 @@ unsafe extern "C" fn mapping0_inverse(
         let mut pcmM: *mut f32 = *(*vb).pcm.offset((*info).coupling_mag[i as usize] as isize);
         let mut pcmA: *mut f32 = *(*vb).pcm.offset((*info).coupling_ang[i as usize] as isize);
         j = 0 as i32;
-        while (j as libc::c_long) < n / 2 as i32 as libc::c_long {
+        while (j as isize) < n / 2 as i32 as isize {
             let mut mag: f32 = *pcmM.offset(j as isize);
             let mut ang: f32 = *pcmA.offset(j as isize);
             if mag > 0 as i32 as f32 {

--- a/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/psy.rs
+++ b/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/psy.rs
@@ -59,13 +59,13 @@ pub struct vorbis_look_psy {
     pub tonecurves: *mut *mut *mut f32,
     pub noiseoffset: *mut *mut f32,
     pub ath: *mut f32,
-    pub octave: *mut libc::c_long,
-    pub bark: *mut libc::c_long,
-    pub firstoc: libc::c_long,
-    pub shiftoc: libc::c_long,
+    pub octave: *mut isize,
+    pub bark: *mut isize,
+    pub firstoc: isize,
+    pub shiftoc: isize,
     pub eighth_octave_lines: i32,
     pub total_octave_lines: i32,
-    pub rate: libc::c_long,
+    pub rate: isize,
     pub m_val: f32,
 }
 use ::libc;
@@ -6653,13 +6653,13 @@ pub unsafe extern "C" fn _vp_psy_init(
     mut vi: *mut crate::src::libvorbis_1_3_6::lib::psy::vorbis_info_psy,
     mut gi: *mut crate::src::libvorbis_1_3_6::lib::psy::vorbis_info_psy_global,
     mut n: i32,
-    mut rate: libc::c_long,
+    mut rate: isize,
 ) {
-    let mut i: libc::c_long = 0;
-    let mut j: libc::c_long = 0;
-    let mut lo: libc::c_long = -(99 as i32) as libc::c_long;
-    let mut hi: libc::c_long = 1 as i32 as libc::c_long;
-    let mut maxoc: libc::c_long = 0;
+    let mut i: isize = 0;
+    let mut j: isize = 0;
+    let mut lo: isize = -(99 as i32) as isize;
+    let mut hi: isize = 1 as i32 as isize;
+    let mut maxoc: isize = 0;
     crate::stdlib::memset(
         p as *mut libc::c_void,
         0 as i32,
@@ -6670,56 +6670,56 @@ pub unsafe extern "C" fn _vp_psy_init(
     (*p).shiftoc = (crate::stdlib::rint(
         crate::stdlib::log(((*gi).eighth_octave_lines as f32 * 8.0f32) as f64)
             / crate::stdlib::log(2.0f32 as f64),
-    ) - 1 as i32 as f64) as libc::c_long;
+    ) - 1 as i32 as f64) as isize;
     (*p).firstoc = ((crate::stdlib::log((0.25f32 * rate as f32) as f64 * 0.5f64 / n as f64)
         * 1.442695f32 as f64
         - 5.965784f32 as f64)
-        * ((1 as i32) << (*p).shiftoc + 1 as i32 as libc::c_long) as f64
-        - (*gi).eighth_octave_lines as f64) as libc::c_long;
+        * ((1 as i32) << (*p).shiftoc + 1 as i32 as isize) as f64
+        - (*gi).eighth_octave_lines as f64) as isize;
     maxoc = ((crate::stdlib::log(((n as f32 + 0.25f32) * rate as f32) as f64 * 0.5f64 / n as f64)
         * 1.442695f32 as f64
         - 5.965784f32 as f64)
-        * ((1 as i32) << (*p).shiftoc + 1 as i32 as libc::c_long) as f64
-        + 0.5f32 as f64) as libc::c_long;
-    (*p).total_octave_lines = (maxoc - (*p).firstoc + 1 as i32 as libc::c_long) as i32;
+        * ((1 as i32) << (*p).shiftoc + 1 as i32 as isize) as f64
+        + 0.5f32 as f64) as isize;
+    (*p).total_octave_lines = (maxoc - (*p).firstoc + 1 as i32 as isize) as i32;
     (*p).ath = crate::stdlib::malloc(
         (n as libc::c_ulong).wrapping_mul(::std::mem::size_of::<f32>() as libc::c_ulong),
     ) as *mut f32;
     (*p).octave = crate::stdlib::malloc(
-        (n as libc::c_ulong).wrapping_mul(::std::mem::size_of::<libc::c_long>() as libc::c_ulong),
-    ) as *mut libc::c_long;
+        (n as libc::c_ulong).wrapping_mul(::std::mem::size_of::<isize>() as libc::c_ulong),
+    ) as *mut isize;
     (*p).bark = crate::stdlib::malloc(
-        (n as libc::c_ulong).wrapping_mul(::std::mem::size_of::<libc::c_long>() as libc::c_ulong),
-    ) as *mut libc::c_long;
+        (n as libc::c_ulong).wrapping_mul(::std::mem::size_of::<isize>() as libc::c_ulong),
+    ) as *mut isize;
     (*p).vi = vi;
     (*p).n = n;
     (*p).rate = rate;
     /* AoTuV HF weighting */
     (*p).m_val = 1.0f64 as f32; /* 48kHz */
-    if rate < 26000 as i32 as libc::c_long {
+    if rate < 26000 as i32 as isize {
         (*p).m_val = 0 as i32 as f32
-    } else if rate < 38000 as i32 as libc::c_long {
+    } else if rate < 38000 as i32 as isize {
         (*p).m_val = 0.94f64 as f32
-    } else if rate > 46000 as i32 as libc::c_long {
+    } else if rate > 46000 as i32 as isize {
         (*p).m_val = 1.275f64 as f32
     } /* 32kHz */
     /* set up the lookups for a given blocksize and sample rate */
-    i = 0 as i32 as libc::c_long;
-    j = 0 as i32 as libc::c_long;
-    while i < (88 as i32 - 1 as i32) as libc::c_long {
+    i = 0 as i32 as isize;
+    j = 0 as i32 as isize;
+    while i < (88 as i32 - 1 as i32) as isize {
         let mut endpos: i32 = crate::stdlib::rint(
             crate::stdlib::exp(
-                ((i + 1 as i32 as libc::c_long) as f64 * 0.125f64 - 2.0f64 + 5.965784f32 as f64)
+                ((i + 1 as i32 as isize) as f64 * 0.125f64 - 2.0f64 + 5.965784f32 as f64)
                     * 0.693147f32 as f64,
             ) * 2 as i32 as f64
                 * n as f64
                 / rate as f64,
         ) as i32;
         let mut base: f32 = ATH[i as usize];
-        if j < endpos as libc::c_long {
-            let mut delta: f32 = (ATH[(i + 1 as i32 as libc::c_long) as usize] - base)
-                / (endpos as libc::c_long - j) as f32;
-            while j < endpos as libc::c_long && j < n as libc::c_long {
+        if j < endpos as isize {
+            let mut delta: f32 = (ATH[(i + 1 as i32 as isize) as usize] - base)
+                / (endpos as isize - j) as f32;
+            while j < endpos as isize && j < n as isize {
                 *(*p).ath.offset(j as isize) = (base as f64 + 100.0f64) as f32;
                 base += delta;
                 j += 1
@@ -6727,74 +6727,74 @@ pub unsafe extern "C" fn _vp_psy_init(
         }
         i += 1
     }
-    while j < n as libc::c_long {
-        *(*p).ath.offset(j as isize) = *(*p).ath.offset((j - 1 as i32 as libc::c_long) as isize);
+    while j < n as isize {
+        *(*p).ath.offset(j as isize) = *(*p).ath.offset((j - 1 as i32 as isize) as isize);
         j += 1
     }
-    i = 0 as i32 as libc::c_long;
-    while i < n as libc::c_long {
+    i = 0 as i32 as isize;
+    while i < n as isize {
         let mut bark: f32 = (13.1f32 as f64
             * crate::stdlib::atan(
-                (0.00074f32 * (rate / (2 as i32 * n) as libc::c_long * i) as f32) as f64,
+                (0.00074f32 * (rate / (2 as i32 * n) as isize * i) as f32) as f64,
             )
             + 2.24f32 as f64
                 * crate::stdlib::atan(
-                    ((rate / (2 as i32 * n) as libc::c_long
+                    ((rate / (2 as i32 * n) as isize
                         * i
-                        * (rate / (2 as i32 * n) as libc::c_long * i)) as f32
+                        * (rate / (2 as i32 * n) as isize * i)) as f32
                         * 1.85e-8f32) as f64,
                 )
-            + (1e-4f32 * (rate / (2 as i32 * n) as libc::c_long * i) as f32) as f64)
+            + (1e-4f32 * (rate / (2 as i32 * n) as isize * i) as f32) as f64)
             as f32;
-        while (lo + (*vi).noisewindowlomin as libc::c_long) < i
+        while (lo + (*vi).noisewindowlomin as isize) < i
             && (13.1f32 as f64
                 * crate::stdlib::atan(
-                    (0.00074f32 * (rate / (2 as i32 * n) as libc::c_long * lo) as f32) as f64,
+                    (0.00074f32 * (rate / (2 as i32 * n) as isize * lo) as f32) as f64,
                 )
                 + 2.24f32 as f64
                     * crate::stdlib::atan(
-                        ((rate / (2 as i32 * n) as libc::c_long
+                        ((rate / (2 as i32 * n) as isize
                             * lo
-                            * (rate / (2 as i32 * n) as libc::c_long * lo))
+                            * (rate / (2 as i32 * n) as isize * lo))
                             as f32
                             * 1.85e-8f32) as f64,
                     )
-                + (1e-4f32 * (rate / (2 as i32 * n) as libc::c_long * lo) as f32) as f64)
+                + (1e-4f32 * (rate / (2 as i32 * n) as isize * lo) as f32) as f64)
                 < (bark - (*vi).noisewindowlo) as f64
         {
             lo += 1
         }
-        while hi <= n as libc::c_long
-            && (hi < i + (*vi).noisewindowhimin as libc::c_long
+        while hi <= n as isize
+            && (hi < i + (*vi).noisewindowhimin as isize
                 || (13.1f32 as f64
                     * crate::stdlib::atan(
-                        (0.00074f32 * (rate / (2 as i32 * n) as libc::c_long * hi) as f32) as f64,
+                        (0.00074f32 * (rate / (2 as i32 * n) as isize * hi) as f32) as f64,
                     )
                     + 2.24f32 as f64
                         * crate::stdlib::atan(
-                            ((rate / (2 as i32 * n) as libc::c_long
+                            ((rate / (2 as i32 * n) as isize
                                 * hi
-                                * (rate / (2 as i32 * n) as libc::c_long * hi))
+                                * (rate / (2 as i32 * n) as isize * hi))
                                 as f32
                                 * 1.85e-8f32) as f64,
                         )
-                    + (1e-4f32 * (rate / (2 as i32 * n) as libc::c_long * hi) as f32) as f64)
+                    + (1e-4f32 * (rate / (2 as i32 * n) as isize * hi) as f32) as f64)
                     < (bark + (*vi).noisewindowhi) as f64)
         {
             hi += 1
         }
         *(*p).bark.offset(i as isize) =
-            ((lo - 1 as i32 as libc::c_long) << 16 as i32) + (hi - 1 as i32 as libc::c_long);
+            ((lo - 1 as i32 as isize) << 16 as i32) + (hi - 1 as i32 as isize);
         i += 1
     }
-    i = 0 as i32 as libc::c_long;
-    while i < n as libc::c_long {
+    i = 0 as i32 as isize;
+    while i < n as isize {
         *(*p).octave.offset(i as isize) =
             ((crate::stdlib::log((i as f32 + 0.25f32) as f64 * 0.5f64 * rate as f64 / n as f64)
                 * 1.442695f32 as f64
                 - 5.965784f32 as f64)
-                * ((1 as i32) << (*p).shiftoc + 1 as i32 as libc::c_long) as f64
-                + 0.5f32 as f64) as libc::c_long;
+                * ((1 as i32) << (*p).shiftoc + 1 as i32 as isize) as f64
+                + 0.5f32 as f64) as isize;
         i += 1
     }
     (*p).tonecurves = setup_tone_curves(
@@ -6809,16 +6809,16 @@ pub unsafe extern "C" fn _vp_psy_init(
         (3 as i32 as libc::c_ulong)
             .wrapping_mul(::std::mem::size_of::<*mut f32>() as libc::c_ulong),
     ) as *mut *mut f32;
-    i = 0 as i32 as libc::c_long;
-    while i < 3 as i32 as libc::c_long {
+    i = 0 as i32 as isize;
+    while i < 3 as i32 as isize {
         let ref mut fresh3 = *(*p).noiseoffset.offset(i as isize);
         *fresh3 = crate::stdlib::malloc(
             (n as libc::c_ulong).wrapping_mul(::std::mem::size_of::<f32>() as libc::c_ulong),
         ) as *mut f32;
         i += 1
     }
-    i = 0 as i32 as libc::c_long;
-    while i < n as libc::c_long {
+    i = 0 as i32 as isize;
+    while i < n as isize {
         let mut halfoc: f32 =
             ((crate::stdlib::log((i as f64 + 0.5f64) * rate as f64 / (2.0f64 * n as f64))
                 * 1.442695f32 as f64
@@ -6834,8 +6834,8 @@ pub unsafe extern "C" fn _vp_psy_init(
         }
         inthalfoc = halfoc as i32;
         del = halfoc - inthalfoc as f32;
-        j = 0 as i32 as libc::c_long;
-        while j < 3 as i32 as libc::c_long {
+        j = 0 as i32 as isize;
+        while j < 3 as i32 as isize {
             *(*(*p).noiseoffset.offset(j as isize)).offset(i as isize) =
                 ((*(*p).vi).noiseoff[j as usize][inthalfoc as usize] as f64 * (1.0f64 - del as f64)
                     + ((*(*p).vi).noiseoff[j as usize][(inthalfoc + 1 as i32) as usize] * del)
@@ -6945,16 +6945,16 @@ unsafe extern "C" fn seed_loop(
     mut specmax: f32,
 ) {
     let mut vi: *mut crate::src::libvorbis_1_3_6::lib::psy::vorbis_info_psy = (*p).vi;
-    let mut n: libc::c_long = (*p).n as libc::c_long;
-    let mut i: libc::c_long = 0;
+    let mut n: isize = (*p).n as isize;
+    let mut i: isize = 0;
     let mut dBoffset: f32 = (*vi).max_curve_dB - specmax;
     /* prime the working vector with peak values */
-    i = 0 as i32 as libc::c_long;
+    i = 0 as i32 as isize;
     while i < n {
         let mut max: f32 = *f.offset(i as isize);
-        let mut oc: libc::c_long = *(*p).octave.offset(i as isize);
-        while (i + 1 as i32 as libc::c_long) < n
-            && *(*p).octave.offset((i + 1 as i32 as libc::c_long) as isize) == oc
+        let mut oc: isize = *(*p).octave.offset(i as isize);
+        while (i + 1 as i32 as isize) < n
+            && *(*p).octave.offset((i + 1 as i32 as isize) as isize) == oc
         {
             i += 1;
             if *f.offset(i as isize) > max {
@@ -6963,11 +6963,11 @@ unsafe extern "C" fn seed_loop(
         }
         if max + 6.0f32 > *flr.offset(i as isize) {
             oc = oc >> (*p).shiftoc;
-            if oc >= 17 as i32 as libc::c_long {
-                oc = (17 as i32 - 1 as i32) as libc::c_long
+            if oc >= 17 as i32 as isize {
+                oc = (17 as i32 - 1 as i32) as isize
             }
-            if oc < 0 as i32 as libc::c_long {
-                oc = 0 as i32 as libc::c_long
+            if oc < 0 as i32 as isize {
+                oc = 0 as i32 as isize
             }
             seed_curve(
                 seed,
@@ -6983,24 +6983,24 @@ unsafe extern "C" fn seed_loop(
     }
 }
 
-unsafe extern "C" fn seed_chase(mut seeds: *mut f32, mut linesper: i32, mut n: libc::c_long) {
+unsafe extern "C" fn seed_chase(mut seeds: *mut f32, mut linesper: i32, mut n: isize) {
     let mut fresh4 = ::std::vec::from_elem(
         0,
-        (n as libc::c_ulong).wrapping_mul(::std::mem::size_of::<libc::c_long>() as libc::c_ulong)
+        (n as libc::c_ulong).wrapping_mul(::std::mem::size_of::<isize>() as libc::c_ulong)
             as usize,
     );
-    let mut posstack: *mut libc::c_long = fresh4.as_mut_ptr() as *mut libc::c_long;
+    let mut posstack: *mut isize = fresh4.as_mut_ptr() as *mut isize;
     let mut fresh5 = ::std::vec::from_elem(
         0,
         (n as libc::c_ulong).wrapping_mul(::std::mem::size_of::<f32>() as libc::c_ulong) as usize,
     );
     let mut ampstack: *mut f32 = fresh5.as_mut_ptr() as *mut f32;
-    let mut stack: libc::c_long = 0 as i32 as libc::c_long;
-    let mut pos: libc::c_long = 0 as i32 as libc::c_long;
-    let mut i: libc::c_long = 0;
-    i = 0 as i32 as libc::c_long;
+    let mut stack: isize = 0 as i32 as isize;
+    let mut pos: isize = 0 as i32 as isize;
+    let mut i: isize = 0;
+    i = 0 as i32 as isize;
     while i < n {
-        if stack < 2 as i32 as libc::c_long {
+        if stack < 2 as i32 as isize {
             *posstack.offset(stack as isize) = i;
             let fresh6 = stack;
             stack = stack + 1;
@@ -7008,7 +7008,7 @@ unsafe extern "C" fn seed_chase(mut seeds: *mut f32, mut linesper: i32, mut n: l
         } else {
             loop {
                 if *seeds.offset(i as isize)
-                    < *ampstack.offset((stack - 1 as i32 as libc::c_long) as isize)
+                    < *ampstack.offset((stack - 1 as i32 as isize) as isize)
                 {
                     *posstack.offset(stack as isize) = i;
                     let fresh7 = stack;
@@ -7016,14 +7016,14 @@ unsafe extern "C" fn seed_chase(mut seeds: *mut f32, mut linesper: i32, mut n: l
                     *ampstack.offset(fresh7 as isize) = *seeds.offset(i as isize);
                     break;
                 } else {
-                    if i < *posstack.offset((stack - 1 as i32 as libc::c_long) as isize)
-                        + linesper as libc::c_long
+                    if i < *posstack.offset((stack - 1 as i32 as isize) as isize)
+                        + linesper as isize
                     {
-                        if stack > 1 as i32 as libc::c_long
-                            && *ampstack.offset((stack - 1 as i32 as libc::c_long) as isize)
-                                <= *ampstack.offset((stack - 2 as i32 as libc::c_long) as isize)
-                            && i < *posstack.offset((stack - 2 as i32 as libc::c_long) as isize)
-                                + linesper as libc::c_long
+                        if stack > 1 as i32 as isize
+                            && *ampstack.offset((stack - 1 as i32 as isize) as isize)
+                                <= *ampstack.offset((stack - 2 as i32 as isize) as isize)
+                            && i < *posstack.offset((stack - 2 as i32 as isize) as isize)
+                                + linesper as isize
                         {
                             /* we completely overlap, making stack-1 irrelevant.  pop it */
                             stack -= 1;
@@ -7042,17 +7042,17 @@ unsafe extern "C" fn seed_chase(mut seeds: *mut f32, mut linesper: i32, mut n: l
     }
     /* the stack now contains only the positions that are relevant. Scan
     'em straight through */
-    i = 0 as i32 as libc::c_long;
+    i = 0 as i32 as isize;
     while i < stack {
-        let mut endpos: libc::c_long = 0;
-        if i < stack - 1 as i32 as libc::c_long
-            && *ampstack.offset((i + 1 as i32 as libc::c_long) as isize)
+        let mut endpos: isize = 0;
+        if i < stack - 1 as i32 as isize
+            && *ampstack.offset((i + 1 as i32 as isize) as isize)
                 > *ampstack.offset(i as isize)
         {
-            endpos = *posstack.offset((i + 1 as i32 as libc::c_long) as isize)
+            endpos = *posstack.offset((i + 1 as i32 as isize) as isize)
         } else {
             endpos =
-                *posstack.offset(i as isize) + linesper as libc::c_long + 1 as i32 as libc::c_long
+                *posstack.offset(i as isize) + linesper as isize + 1 as i32 as isize
             /* +1 is important, else bin 0 is
             discarded in short frames */
         }
@@ -7075,26 +7075,26 @@ unsafe extern "C" fn max_seeds(
     mut seed: *mut f32,
     mut flr: *mut f32,
 ) {
-    let mut n: libc::c_long = (*p).total_octave_lines as libc::c_long; /* for masking */
+    let mut n: isize = (*p).total_octave_lines as isize; /* for masking */
     let mut linesper: i32 = (*p).eighth_octave_lines;
-    let mut linpos: libc::c_long = 0 as i32 as libc::c_long;
-    let mut pos: libc::c_long = 0;
+    let mut linpos: isize = 0 as i32 as isize;
+    let mut pos: isize = 0;
     seed_chase(seed, linesper, n);
     pos = *(*p).octave.offset(0 as i32 as isize)
         - (*p).firstoc
-        - (linesper >> 1 as i32) as libc::c_long;
-    while (linpos + 1 as i32 as libc::c_long) < (*p).n as libc::c_long {
+        - (linesper >> 1 as i32) as isize;
+    while (linpos + 1 as i32 as isize) < (*p).n as isize {
         let mut minV: f32 = *seed.offset(pos as isize);
-        let mut end: libc::c_long = (*(*p).octave.offset(linpos as isize)
+        let mut end: isize = (*(*p).octave.offset(linpos as isize)
             + *(*p)
                 .octave
-                .offset((linpos + 1 as i32 as libc::c_long) as isize)
+                .offset((linpos + 1 as i32 as isize) as isize)
             >> 1 as i32)
             - (*p).firstoc;
         if minV > (*(*p).vi).tone_abs_limit {
             minV = (*(*p).vi).tone_abs_limit
         }
-        while pos + 1 as i32 as libc::c_long <= end {
+        while pos + 1 as i32 as isize <= end {
             pos += 1;
             if *seed.offset(pos as isize) > -9999.0f32 && *seed.offset(pos as isize) < minV
                 || minV == -9999.0f32
@@ -7103,7 +7103,7 @@ unsafe extern "C" fn max_seeds(
             }
         }
         end = pos + (*p).firstoc;
-        while linpos < (*p).n as libc::c_long && *(*p).octave.offset(linpos as isize) <= end {
+        while linpos < (*p).n as isize && *(*p).octave.offset(linpos as isize) <= end {
             if *flr.offset(linpos as isize) < minV {
                 *flr.offset(linpos as isize) = minV
             }
@@ -7111,7 +7111,7 @@ unsafe extern "C" fn max_seeds(
         }
     }
     let mut minV_0: f32 = *seed.offset(((*p).total_octave_lines - 1 as i32) as isize);
-    while linpos < (*p).n as libc::c_long {
+    while linpos < (*p).n as isize {
         if *flr.offset(linpos as isize) < minV_0 {
             *flr.offset(linpos as isize) = minV_0
         }
@@ -7121,7 +7121,7 @@ unsafe extern "C" fn max_seeds(
 
 unsafe extern "C" fn bark_noise_hybridmp(
     mut n: i32,
-    mut b: *const libc::c_long,
+    mut b: *const isize,
     mut f: *const f32,
     mut noise: *mut f32,
     offset: f32,
@@ -7213,7 +7213,7 @@ unsafe extern "C" fn bark_noise_hybridmp(
         if lo >= 0 as i32 {
             break;
         }
-        hi = (*b.offset(i as isize) & 0xffff as i32 as libc::c_long) as i32;
+        hi = (*b.offset(i as isize) & 0xffff as i32 as isize) as i32;
         tN = *N.offset(hi as isize) + *N.offset(-lo as isize);
         tX = *X.offset(hi as isize) - *X.offset(-lo as isize);
         tXX = *XX.offset(hi as isize) + *XX.offset(-lo as isize);
@@ -7232,7 +7232,7 @@ unsafe extern "C" fn bark_noise_hybridmp(
     }
     loop {
         lo = (*b.offset(i as isize) >> 16 as i32) as i32;
-        hi = (*b.offset(i as isize) & 0xffff as i32 as libc::c_long) as i32;
+        hi = (*b.offset(i as isize) & 0xffff as i32 as isize) as i32;
         if hi >= n {
             break;
         }
@@ -7484,7 +7484,7 @@ pub unsafe extern "C" fn _vp_ampmax_decay(
         (*vi).codec_setup as *mut crate::codec_internal_h::codec_setup_info;
     let mut gi: *mut crate::src::libvorbis_1_3_6::lib::psy::vorbis_info_psy_global =
         &mut (*ci).psy_g_param;
-    let mut n: i32 = ((*ci).blocksizes[(*vd).W as usize] / 2 as i32 as libc::c_long) as i32;
+    let mut n: i32 = ((*ci).blocksizes[(*vd).W as usize] / 2 as i32 as isize) as i32;
     let mut secs: f32 = n as f32 / (*vi).rate as f32;
     amp += secs * (*gi).ampmax_att_per_sec;
     if amp < -(9999 as i32) as f32 {
@@ -7887,7 +7887,7 @@ unsafe extern "C" fn noise_normalize(
         );
         j = 0 as i32;
         while j < count {
-            let mut k: i32 = (*sort.offset(j as isize)).offset_from(q) as libc::c_long as i32;
+            let mut k: i32 = (*sort.offset(j as isize)).offset_from(q) as isize as i32;
             if acc as f64 >= (*vi).normal_thresh {
                 *out.offset(k as isize) = unitnorm(*r.offset(k as isize)) as i32;
                 acc -= 1.0f32;

--- a/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/res0.rs
+++ b/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/res0.rs
@@ -47,9 +47,9 @@ pub struct vorbis_look_residue0 {
     pub partbooks: *mut *mut *mut crate::src::libvorbis_1_3_6::lib::codebook::codebook,
     pub partvals: i32,
     pub decodemap: *mut *mut i32,
-    pub postbits: libc::c_long,
-    pub phrasebits: libc::c_long,
-    pub frames: libc::c_long,
+    pub postbits: isize,
+    pub phrasebits: isize,
+    pub frames: isize,
 }
 #[no_mangle]
 
@@ -233,11 +233,11 @@ pub unsafe extern "C" fn res0_unpack(
     (*info).grouping = (crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
         opb as *mut crate::ogg_h::oggpack_buffer,
         24 as i32,
-    ) + 1 as i32 as libc::c_long) as i32;
+    ) + 1 as i32 as isize) as i32;
     (*info).partitions = (crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
         opb as *mut crate::ogg_h::oggpack_buffer,
         6 as i32,
-    ) + 1 as i32 as libc::c_long) as i32;
+    ) + 1 as i32 as isize) as i32;
     (*info).groupbook = crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
         opb as *mut crate::ogg_h::oggpack_buffer,
         8 as i32,
@@ -443,17 +443,17 @@ pub unsafe extern "C" fn res0_look(
     ) as *mut *mut i32;
     j = 0 as i32;
     while j < (*look).partvals {
-        let mut val: libc::c_long = j as libc::c_long;
-        let mut mult: libc::c_long = ((*look).partvals / (*look).parts) as libc::c_long;
+        let mut val: isize = j as isize;
+        let mut mult: isize = ((*look).partvals / (*look).parts) as isize;
         let ref mut fresh3 = *(*look).decodemap.offset(j as isize);
         *fresh3 = crate::stdlib::malloc(
             (dim as libc::c_ulong).wrapping_mul(::std::mem::size_of::<i32>() as libc::c_ulong),
         ) as *mut i32;
         k = 0 as i32;
         while k < dim {
-            let mut deco: libc::c_long = val / mult;
+            let mut deco: isize = val / mult;
             val -= deco * mult;
-            mult /= (*look).parts as libc::c_long;
+            mult /= (*look).parts as isize;
             *(*(*look).decodemap.offset(j as isize)).offset(k as isize) = deco as i32;
             k += 1
         }
@@ -530,7 +530,7 @@ unsafe extern "C" fn local_book_besterror(
         ];
         let mut maxval: i32 = (*book).minval + (*book).delta * ((*book).quantvals - 1 as i32);
         i = 0 as i32;
-        while (i as libc::c_long) < (*book).entries {
+        while (i as isize) < (*book).entries {
             if *(*c).lengthlist.offset(i as isize) as i32 > 0 as i32 {
                 let mut this: i32 = 0 as i32;
                 j = 0 as i32;
@@ -603,10 +603,10 @@ unsafe extern "C" fn _01class(
     mut vl: *mut libc::c_void,
     mut in_0: *mut *mut i32,
     mut ch: i32,
-) -> *mut *mut libc::c_long {
-    let mut i: libc::c_long = 0;
-    let mut j: libc::c_long = 0;
-    let mut k: libc::c_long = 0;
+) -> *mut *mut isize {
+    let mut i: isize = 0;
+    let mut j: isize = 0;
+    let mut k: isize = 0;
     let mut look: *mut vorbis_look_residue0 = vl as *mut vorbis_look_residue0;
     let mut info: *mut crate::backends_h::vorbis_info_residue0 = (*look).info;
     /* move all this setup out later */
@@ -614,59 +614,59 @@ unsafe extern "C" fn _01class(
     let mut possible_partitions: i32 = (*info).partitions;
     let mut n: i32 = ((*info).end - (*info).begin) as i32;
     let mut partvals: i32 = n / samples_per_partition;
-    let mut partword: *mut *mut libc::c_long =
+    let mut partword: *mut *mut isize =
         crate::src::libvorbis_1_3_6::lib::block::_vorbis_block_alloc(
             vb as *mut crate::codec_h::vorbis_block,
             (ch as libc::c_ulong)
-                .wrapping_mul(::std::mem::size_of::<*mut libc::c_long>() as libc::c_ulong)
-                as libc::c_long,
-        ) as *mut *mut libc::c_long;
+                .wrapping_mul(::std::mem::size_of::<*mut isize>() as libc::c_ulong)
+                as isize,
+        ) as *mut *mut isize;
     let mut scale: f32 = (100.0f64 / samples_per_partition as f64) as f32;
     /* we find the partition type for each partition of each
     channel.  We'll go back and do the interleaved encoding in a
     bit.  For now, clarity */
-    i = 0 as i32 as libc::c_long;
-    while i < ch as libc::c_long {
+    i = 0 as i32 as isize;
+    while i < ch as isize {
         let ref mut fresh6 = *partword.offset(i as isize);
         *fresh6 = crate::src::libvorbis_1_3_6::lib::block::_vorbis_block_alloc(
             vb as *mut crate::codec_h::vorbis_block,
             ((n / samples_per_partition) as libc::c_ulong)
-                .wrapping_mul(::std::mem::size_of::<libc::c_long>() as libc::c_ulong)
-                as libc::c_long,
-        ) as *mut libc::c_long;
+                .wrapping_mul(::std::mem::size_of::<isize>() as libc::c_ulong)
+                as isize,
+        ) as *mut isize;
         crate::stdlib::memset(
             *partword.offset(i as isize) as *mut libc::c_void,
             0 as i32,
             ((n / samples_per_partition) as libc::c_ulong)
-                .wrapping_mul(::std::mem::size_of::<libc::c_long>() as libc::c_ulong),
+                .wrapping_mul(::std::mem::size_of::<isize>() as libc::c_ulong),
         );
         i += 1
     }
-    i = 0 as i32 as libc::c_long;
-    while i < partvals as libc::c_long {
-        let mut offset: i32 = (i * samples_per_partition as libc::c_long + (*info).begin) as i32;
-        j = 0 as i32 as libc::c_long;
-        while j < ch as libc::c_long {
+    i = 0 as i32 as isize;
+    while i < partvals as isize {
+        let mut offset: i32 = (i * samples_per_partition as isize + (*info).begin) as i32;
+        j = 0 as i32 as isize;
+        while j < ch as isize {
             let mut max: i32 = 0 as i32;
             let mut ent: i32 = 0 as i32;
-            k = 0 as i32 as libc::c_long;
-            while k < samples_per_partition as libc::c_long {
+            k = 0 as i32 as isize;
+            while k < samples_per_partition as isize {
                 if ::libc::abs(
-                    *(*in_0.offset(j as isize)).offset((offset as libc::c_long + k) as isize),
+                    *(*in_0.offset(j as isize)).offset((offset as isize + k) as isize),
                 ) > max
                 {
                     max = ::libc::abs(
-                        *(*in_0.offset(j as isize)).offset((offset as libc::c_long + k) as isize),
+                        *(*in_0.offset(j as isize)).offset((offset as isize + k) as isize),
                     )
                 }
                 ent += ::libc::abs(
-                    *(*in_0.offset(j as isize)).offset((offset as libc::c_long + k) as isize),
+                    *(*in_0.offset(j as isize)).offset((offset as isize + k) as isize),
                 );
                 k += 1
             }
             ent = (ent as f32 * scale) as i32;
-            k = 0 as i32 as libc::c_long;
-            while k < (possible_partitions - 1 as i32) as libc::c_long {
+            k = 0 as i32 as isize;
+            while k < (possible_partitions - 1 as i32) as isize {
                 if max <= (*info).classmetric1[k as usize]
                     && ((*info).classmetric2[k as usize] < 0 as i32
                         || ent < (*info).classmetric2[k as usize])
@@ -692,11 +692,11 @@ unsafe extern "C" fn _2class(
     mut vl: *mut libc::c_void,
     mut in_0: *mut *mut i32,
     mut ch: i32,
-) -> *mut *mut libc::c_long {
-    let mut i: libc::c_long = 0;
-    let mut j: libc::c_long = 0;
-    let mut k: libc::c_long = 0;
-    let mut l: libc::c_long = 0;
+) -> *mut *mut isize {
+    let mut i: isize = 0;
+    let mut j: isize = 0;
+    let mut k: isize = 0;
+    let mut l: isize = 0;
     let mut look: *mut vorbis_look_residue0 = vl as *mut vorbis_look_residue0;
     let mut info: *mut crate::backends_h::vorbis_info_residue0 = (*look).info;
     /* move all this setup out later */
@@ -704,46 +704,46 @@ unsafe extern "C" fn _2class(
     let mut possible_partitions: i32 = (*info).partitions;
     let mut n: i32 = ((*info).end - (*info).begin) as i32;
     let mut partvals: i32 = n / samples_per_partition;
-    let mut partword: *mut *mut libc::c_long =
+    let mut partword: *mut *mut isize =
         crate::src::libvorbis_1_3_6::lib::block::_vorbis_block_alloc(
             vb as *mut crate::codec_h::vorbis_block,
-            ::std::mem::size_of::<*mut libc::c_long>() as libc::c_ulong as libc::c_long,
-        ) as *mut *mut libc::c_long;
+            ::std::mem::size_of::<*mut isize>() as libc::c_ulong as isize,
+        ) as *mut *mut isize;
     let ref mut fresh7 = *partword.offset(0 as i32 as isize);
     *fresh7 = crate::src::libvorbis_1_3_6::lib::block::_vorbis_block_alloc(
         vb as *mut crate::codec_h::vorbis_block,
         (partvals as libc::c_ulong)
-            .wrapping_mul(::std::mem::size_of::<libc::c_long>() as libc::c_ulong)
-            as libc::c_long,
-    ) as *mut libc::c_long;
+            .wrapping_mul(::std::mem::size_of::<isize>() as libc::c_ulong)
+            as isize,
+    ) as *mut isize;
     crate::stdlib::memset(
         *partword.offset(0 as i32 as isize) as *mut libc::c_void,
         0 as i32,
         (partvals as libc::c_ulong)
-            .wrapping_mul(::std::mem::size_of::<libc::c_long>() as libc::c_ulong),
+            .wrapping_mul(::std::mem::size_of::<isize>() as libc::c_ulong),
     );
-    i = 0 as i32 as libc::c_long;
-    l = (*info).begin / ch as libc::c_long;
-    while i < partvals as libc::c_long {
+    i = 0 as i32 as isize;
+    l = (*info).begin / ch as isize;
+    while i < partvals as isize {
         let mut magmax: i32 = 0 as i32;
         let mut angmax: i32 = 0 as i32;
-        j = 0 as i32 as libc::c_long;
-        while j < samples_per_partition as libc::c_long {
+        j = 0 as i32 as isize;
+        while j < samples_per_partition as isize {
             if ::libc::abs(*(*in_0.offset(0 as i32 as isize)).offset(l as isize)) > magmax {
                 magmax = ::libc::abs(*(*in_0.offset(0 as i32 as isize)).offset(l as isize))
             }
-            k = 1 as i32 as libc::c_long;
-            while k < ch as libc::c_long {
+            k = 1 as i32 as isize;
+            while k < ch as isize {
                 if ::libc::abs(*(*in_0.offset(k as isize)).offset(l as isize)) > angmax {
                     angmax = ::libc::abs(*(*in_0.offset(k as isize)).offset(l as isize))
                 }
                 k += 1
             }
             l += 1;
-            j += ch as libc::c_long
+            j += ch as isize
         }
-        j = 0 as i32 as libc::c_long;
-        while j < (possible_partitions - 1 as i32) as libc::c_long {
+        j = 0 as i32 as isize;
+        while j < (possible_partitions - 1 as i32) as isize {
             if magmax <= (*info).classmetric1[j as usize]
                 && angmax <= (*info).classmetric2[j as usize]
             {
@@ -763,7 +763,7 @@ unsafe extern "C" fn _01forward(
     mut vl: *mut libc::c_void,
     mut in_0: *mut *mut i32,
     mut ch: i32,
-    mut partword: *mut *mut libc::c_long,
+    mut partword: *mut *mut isize,
     mut encode: Option<
         unsafe extern "C" fn(
             _: *mut crate::ogg_h::oggpack_buffer,
@@ -773,10 +773,10 @@ unsafe extern "C" fn _01forward(
         ) -> i32,
     >,
 ) -> i32 {
-    let mut i: libc::c_long = 0;
-    let mut j: libc::c_long = 0;
-    let mut k: libc::c_long = 0;
-    let mut s: libc::c_long = 0;
+    let mut i: isize = 0;
+    let mut j: isize = 0;
+    let mut k: isize = 0;
+    let mut s: isize = 0;
     let mut look: *mut vorbis_look_residue0 = vl as *mut vorbis_look_residue0;
     let mut info: *mut crate::backends_h::vorbis_info_residue0 = (*look).info;
     /* move all this setup out later */
@@ -785,35 +785,35 @@ unsafe extern "C" fn _01forward(
     let mut partitions_per_word: i32 = (*(*look).phrasebook).dim as i32;
     let mut n: i32 = ((*info).end - (*info).begin) as i32;
     let mut partvals: i32 = n / samples_per_partition;
-    let mut resbits: [libc::c_long; 128] = [0; 128];
-    let mut resvals: [libc::c_long; 128] = [0; 128];
+    let mut resbits: [isize; 128] = [0; 128];
+    let mut resvals: [isize; 128] = [0; 128];
     crate::stdlib::memset(
         resbits.as_mut_ptr() as *mut libc::c_void,
         0 as i32,
-        ::std::mem::size_of::<[libc::c_long; 128]>() as libc::c_ulong,
+        ::std::mem::size_of::<[isize; 128]>() as libc::c_ulong,
     );
     crate::stdlib::memset(
         resvals.as_mut_ptr() as *mut libc::c_void,
         0 as i32,
-        ::std::mem::size_of::<[libc::c_long; 128]>() as libc::c_ulong,
+        ::std::mem::size_of::<[isize; 128]>() as libc::c_ulong,
     );
     /* we code the partition words for each channel, then the residual
     words for a partition per channel until we've written all the
     residual words for that partition word.  Then write the next
     partition channel words... */
-    s = 0 as i32 as libc::c_long;
-    while s < (*look).stages as libc::c_long {
-        i = 0 as i32 as libc::c_long;
-        while i < partvals as libc::c_long {
+    s = 0 as i32 as isize;
+    while s < (*look).stages as isize {
+        i = 0 as i32 as isize;
+        while i < partvals as isize {
             /* first we encode a partition codeword for each channel */
-            if s == 0 as i32 as libc::c_long {
-                j = 0 as i32 as libc::c_long;
-                while j < ch as libc::c_long {
-                    let mut val: libc::c_long = *(*partword.offset(j as isize)).offset(i as isize);
-                    k = 1 as i32 as libc::c_long;
-                    while k < partitions_per_word as libc::c_long {
-                        val *= possible_partitions as libc::c_long;
-                        if i + k < partvals as libc::c_long {
+            if s == 0 as i32 as isize {
+                j = 0 as i32 as isize;
+                while j < ch as isize {
+                    let mut val: isize = *(*partword.offset(j as isize)).offset(i as isize);
+                    k = 1 as i32 as isize;
+                    while k < partitions_per_word as isize {
+                        val *= possible_partitions as isize;
+                        if i + k < partvals as isize {
                             val += *(*partword.offset(j as isize)).offset((i + k) as isize)
                         }
                         k += 1
@@ -826,22 +826,22 @@ unsafe extern "C" fn _01forward(
                                     as *mut crate::src::libvorbis_1_3_6::lib::codebook::codebook,
                                 val as i32,
                                 opb as *mut crate::ogg_h::oggpack_buffer,
-                            ) as libc::c_long
+                            ) as isize
                     }
                     j += 1
                 }
             }
             /* training hack */
             /* now we encode interleaved residual values for the partitions */
-            k = 0 as i32 as libc::c_long;
-            while k < partitions_per_word as libc::c_long && i < partvals as libc::c_long {
-                let mut offset: libc::c_long =
-                    i * samples_per_partition as libc::c_long + (*info).begin;
-                j = 0 as i32 as libc::c_long;
-                while j < ch as libc::c_long {
-                    if s == 0 as i32 as libc::c_long {
+            k = 0 as i32 as isize;
+            while k < partitions_per_word as isize && i < partvals as isize {
+                let mut offset: isize =
+                    i * samples_per_partition as isize + (*info).begin;
+                j = 0 as i32 as isize;
+                while j < ch as isize {
+                    if s == 0 as i32 as isize {
                         resvals[*(*partword.offset(j as isize)).offset(i as isize) as usize] +=
-                            samples_per_partition as libc::c_long
+                            samples_per_partition as isize
                     }
                     if (*info).secondstages
                         [*(*partword.offset(j as isize)).offset(i as isize) as usize]
@@ -866,9 +866,9 @@ unsafe extern "C" fn _01forward(
                                 samples_per_partition,
                                 statebook,
                             );
-                            (*look).postbits += ret as libc::c_long;
+                            (*look).postbits += ret as isize;
                             resbits[*(*partword.offset(j as isize)).offset(i as isize) as usize] +=
-                                ret as libc::c_long
+                                ret as isize
                         }
                     }
                     j += 1
@@ -894,26 +894,26 @@ unsafe extern "C" fn _01inverse(
             _: *mut f32,
             _: *mut crate::ogg_h::oggpack_buffer,
             _: i32,
-        ) -> libc::c_long,
+        ) -> isize,
     >,
 ) -> i32 {
-    let mut i: libc::c_long = 0;
-    let mut j: libc::c_long = 0;
-    let mut k: libc::c_long = 0;
-    let mut l: libc::c_long = 0;
-    let mut s: libc::c_long = 0;
+    let mut i: isize = 0;
+    let mut j: isize = 0;
+    let mut k: isize = 0;
+    let mut l: isize = 0;
+    let mut s: isize = 0;
     let mut look: *mut vorbis_look_residue0 = vl as *mut vorbis_look_residue0;
     let mut info: *mut crate::backends_h::vorbis_info_residue0 = (*look).info;
     /* move all this setup out later */
     let mut samples_per_partition: i32 = (*info).grouping;
     let mut partitions_per_word: i32 = (*(*look).phrasebook).dim as i32;
     let mut max: i32 = (*vb).pcmend >> 1 as i32;
-    let mut end: i32 = if (*info).end < max as libc::c_long {
+    let mut end: i32 = if (*info).end < max as isize {
         (*info).end
     } else {
-        max as libc::c_long
+        max as isize
     } as i32;
-    let mut n: i32 = (end as libc::c_long - (*info).begin) as i32;
+    let mut n: i32 = (end as isize - (*info).begin) as i32;
     if n > 0 as i32 {
         let mut partvals: i32 = n / samples_per_partition;
         let mut partwords: i32 = (partvals + partitions_per_word - 1 as i32) / partitions_per_word;
@@ -924,28 +924,28 @@ unsafe extern "C" fn _01inverse(
                 as usize,
         );
         let mut partword: *mut *mut *mut i32 = fresh8.as_mut_ptr() as *mut *mut *mut i32;
-        j = 0 as i32 as libc::c_long;
-        while j < ch as libc::c_long {
+        j = 0 as i32 as isize;
+        while j < ch as isize {
             let ref mut fresh9 = *partword.offset(j as isize);
             *fresh9 = crate::src::libvorbis_1_3_6::lib::block::_vorbis_block_alloc(
                 vb as *mut crate::codec_h::vorbis_block,
                 (partwords as libc::c_ulong)
                     .wrapping_mul(::std::mem::size_of::<*mut i32>() as libc::c_ulong)
-                    as libc::c_long,
+                    as isize,
             ) as *mut *mut i32;
             j += 1
         }
-        s = 0 as i32 as libc::c_long;
-        's_55: while s < (*look).stages as libc::c_long {
+        s = 0 as i32 as isize;
+        's_55: while s < (*look).stages as isize {
             /* each loop decodes on partition codeword containing
             partitions_per_word partitions */
-            i = 0 as i32 as libc::c_long;
-            l = 0 as i32 as libc::c_long;
-            while i < partvals as libc::c_long {
-                if s == 0 as i32 as libc::c_long {
+            i = 0 as i32 as isize;
+            l = 0 as i32 as isize;
+            while i < partvals as isize {
+                if s == 0 as i32 as isize {
                     /* fetch the partition word for each channel */
-                    j = 0 as i32 as libc::c_long;
-                    while j < ch as libc::c_long {
+                    j = 0 as i32 as isize;
+                    while j < ch as isize {
                         let mut temp: i32 =
                             crate::src::libvorbis_1_3_6::lib::codebook::vorbis_book_decode(
                                 (*look).phrasebook
@@ -964,12 +964,12 @@ unsafe extern "C" fn _01inverse(
                     }
                 }
                 /* now we decode residual values for the partitions */
-                k = 0 as i32 as libc::c_long;
-                while k < partitions_per_word as libc::c_long && i < partvals as libc::c_long {
-                    j = 0 as i32 as libc::c_long;
-                    while j < ch as libc::c_long {
-                        let mut offset: libc::c_long =
-                            (*info).begin + i * samples_per_partition as libc::c_long;
+                k = 0 as i32 as isize;
+                while k < partitions_per_word as isize && i < partvals as isize {
+                    j = 0 as i32 as isize;
+                    while j < ch as isize {
+                        let mut offset: isize =
+                            (*info).begin + i * samples_per_partition as isize;
                         if (*info).secondstages[*(*(*partword.offset(j as isize))
                             .offset(l as isize))
                         .offset(k as isize)
@@ -995,7 +995,7 @@ unsafe extern "C" fn _01inverse(
                                     (*in_0.offset(j as isize)).offset(offset as isize),
                                     &mut (*vb).opb,
                                     samples_per_partition,
-                                ) == -(1 as i32) as libc::c_long
+                                ) == -(1 as i32) as isize
                                 {
                                     break 's_55;
                                 }
@@ -1047,7 +1047,7 @@ pub unsafe extern "C" fn res0_inverse(
                         _: *mut f32,
                         _: *mut crate::ogg_h::oggpack_buffer,
                         _: i32,
-                    ) -> libc::c_long,
+                    ) -> isize,
             ),
         );
     } else {
@@ -1063,7 +1063,7 @@ pub unsafe extern "C" fn res1_forward(
     mut in_0: *mut *mut i32,
     mut nonzero: *mut i32,
     mut ch: i32,
-    mut partword: *mut *mut libc::c_long,
+    mut partword: *mut *mut isize,
     mut _submap: i32,
 ) -> i32 {
     let mut i: i32 = 0;
@@ -1107,7 +1107,7 @@ pub unsafe extern "C" fn res1_class(
     mut in_0: *mut *mut i32,
     mut nonzero: *mut i32,
     mut ch: i32,
-) -> *mut *mut libc::c_long {
+) -> *mut *mut isize {
     let mut i: i32 = 0;
     let mut used: i32 = 0 as i32;
     i = 0 as i32;
@@ -1123,7 +1123,7 @@ pub unsafe extern "C" fn res1_class(
     if used != 0 {
         return _01class(vb, vl, in_0, used);
     } else {
-        return 0 as *mut *mut libc::c_long;
+        return 0 as *mut *mut isize;
     };
 }
 #[no_mangle]
@@ -1160,7 +1160,7 @@ pub unsafe extern "C" fn res1_inverse(
                         _: *mut f32,
                         _: *mut crate::ogg_h::oggpack_buffer,
                         _: i32,
-                    ) -> libc::c_long,
+                    ) -> isize,
             ),
         );
     } else {
@@ -1175,7 +1175,7 @@ pub unsafe extern "C" fn res2_class(
     mut in_0: *mut *mut i32,
     mut nonzero: *mut i32,
     mut ch: i32,
-) -> *mut *mut libc::c_long {
+) -> *mut *mut isize {
     let mut i: i32 = 0;
     let mut used: i32 = 0 as i32;
     i = 0 as i32;
@@ -1188,7 +1188,7 @@ pub unsafe extern "C" fn res2_class(
     if used != 0 {
         return _2class(vb, vl, in_0, ch);
     } else {
-        return 0 as *mut *mut libc::c_long;
+        return 0 as *mut *mut isize;
     };
 }
 /* res2 is slightly more different; all the channels are interleaved
@@ -1202,34 +1202,34 @@ pub unsafe extern "C" fn res2_forward(
     mut in_0: *mut *mut i32,
     mut nonzero: *mut i32,
     mut ch: i32,
-    mut partword: *mut *mut libc::c_long,
+    mut partword: *mut *mut isize,
     mut _submap: i32,
 ) -> i32 {
-    let mut i: libc::c_long = 0;
-    let mut j: libc::c_long = 0;
-    let mut k: libc::c_long = 0;
-    let mut n: libc::c_long = ((*vb).pcmend / 2 as i32) as libc::c_long;
-    let mut used: libc::c_long = 0 as i32 as libc::c_long;
+    let mut i: isize = 0;
+    let mut j: isize = 0;
+    let mut k: isize = 0;
+    let mut n: isize = ((*vb).pcmend / 2 as i32) as isize;
+    let mut used: isize = 0 as i32 as isize;
     /* don't duplicate the code; use a working vector hack for now and
     reshape ourselves into a single channel res1 */
     /* ugly; reallocs for each coupling pass :-( */
     let mut work: *mut i32 = crate::src::libvorbis_1_3_6::lib::block::_vorbis_block_alloc(
         vb as *mut crate::codec_h::vorbis_block,
-        ((ch as libc::c_long * n) as libc::c_ulong)
-            .wrapping_mul(::std::mem::size_of::<i32>() as libc::c_ulong) as libc::c_long,
+        ((ch as isize * n) as libc::c_ulong)
+            .wrapping_mul(::std::mem::size_of::<i32>() as libc::c_ulong) as isize,
     ) as *mut i32;
-    i = 0 as i32 as libc::c_long;
-    while i < ch as libc::c_long {
+    i = 0 as i32 as isize;
+    while i < ch as isize {
         let mut pcm: *mut i32 = *in_0.offset(i as isize);
         if *nonzero.offset(i as isize) != 0 {
             used += 1
         }
-        j = 0 as i32 as libc::c_long;
+        j = 0 as i32 as isize;
         k = i;
         while j < n {
             *work.offset(k as isize) = *pcm.offset(j as isize);
             j += 1;
-            k += ch as libc::c_long
+            k += ch as isize
         }
         i += 1
     }
@@ -1264,22 +1264,22 @@ pub unsafe extern "C" fn res2_inverse(
     mut nonzero: *mut i32,
     mut ch: i32,
 ) -> i32 {
-    let mut i: libc::c_long = 0;
-    let mut k: libc::c_long = 0;
-    let mut l: libc::c_long = 0;
-    let mut s: libc::c_long = 0;
+    let mut i: isize = 0;
+    let mut k: isize = 0;
+    let mut l: isize = 0;
+    let mut s: isize = 0;
     let mut look: *mut vorbis_look_residue0 = vl as *mut vorbis_look_residue0;
     let mut info: *mut crate::backends_h::vorbis_info_residue0 = (*look).info;
     /* move all this setup out later */
     let mut samples_per_partition: i32 = (*info).grouping; /* no nonzero vectors */
     let mut partitions_per_word: i32 = (*(*look).phrasebook).dim as i32;
     let mut max: i32 = (*vb).pcmend * ch >> 1 as i32;
-    let mut end: i32 = if (*info).end < max as libc::c_long {
+    let mut end: i32 = if (*info).end < max as isize {
         (*info).end
     } else {
-        max as libc::c_long
+        max as isize
     } as i32;
-    let mut n: i32 = (end as libc::c_long - (*info).begin) as i32;
+    let mut n: i32 = (end as isize - (*info).begin) as i32;
     if n > 0 as i32 {
         let mut partvals: i32 = n / samples_per_partition;
         let mut partwords: i32 = (partvals + partitions_per_word - 1 as i32) / partitions_per_word;
@@ -1288,24 +1288,24 @@ pub unsafe extern "C" fn res2_inverse(
                 vb as *mut crate::codec_h::vorbis_block,
                 (partwords as libc::c_ulong)
                     .wrapping_mul(::std::mem::size_of::<*mut i32>() as libc::c_ulong)
-                    as libc::c_long,
+                    as isize,
             ) as *mut *mut i32;
-        i = 0 as i32 as libc::c_long;
-        while i < ch as libc::c_long {
+        i = 0 as i32 as isize;
+        while i < ch as isize {
             if *nonzero.offset(i as isize) != 0 {
                 break;
             }
             i += 1
         }
-        if i == ch as libc::c_long {
+        if i == ch as isize {
             return 0 as i32;
         }
-        s = 0 as i32 as libc::c_long;
-        's_65: while s < (*look).stages as libc::c_long {
-            i = 0 as i32 as libc::c_long;
-            l = 0 as i32 as libc::c_long;
-            while i < partvals as libc::c_long {
-                if s == 0 as i32 as libc::c_long {
+        s = 0 as i32 as isize;
+        's_65: while s < (*look).stages as isize {
+            i = 0 as i32 as isize;
+            l = 0 as i32 as isize;
+            while i < partvals as isize {
+                if s == 0 as i32 as isize {
                     /* fetch the partition word */
                     let mut temp: i32 =
                         crate::src::libvorbis_1_3_6::lib::codebook::vorbis_book_decode(
@@ -1323,8 +1323,8 @@ pub unsafe extern "C" fn res2_inverse(
                     }
                 }
                 /* now we decode residual values for the partitions */
-                k = 0 as i32 as libc::c_long;
-                while k < partitions_per_word as libc::c_long && i < partvals as libc::c_long {
+                k = 0 as i32 as isize;
+                while k < partitions_per_word as isize && i < partvals as isize {
                     if (*info).secondstages
                         [*(*partword.offset(l as isize)).offset(k as isize) as usize]
                         & (1 as i32) << s
@@ -1345,11 +1345,11 @@ pub unsafe extern "C" fn res2_inverse(
                                 stagebook
                                     as *mut crate::src::libvorbis_1_3_6::lib::codebook::codebook,
                                 in_0,
-                                i * samples_per_partition as libc::c_long + (*info).begin,
+                                i * samples_per_partition as isize + (*info).begin,
                                 ch,
                                 &mut (*vb).opb as *mut _ as *mut crate::ogg_h::oggpack_buffer,
                                 samples_per_partition,
-                            ) == -(1 as i32) as libc::c_long
+                            ) == -(1 as i32) as isize
                             {
                                 break 's_65;
                             }
@@ -1436,7 +1436,7 @@ pub static mut residue1_exportbundle: crate::backends_h::vorbis_func_residue = {
                     _: *mut *mut i32,
                     _: *mut i32,
                     _: i32,
-                ) -> *mut *mut libc::c_long,
+                ) -> *mut *mut isize,
         ),
         forward: Some(
             res1_forward
@@ -1447,7 +1447,7 @@ pub static mut residue1_exportbundle: crate::backends_h::vorbis_func_residue = {
                     _: *mut *mut i32,
                     _: *mut i32,
                     _: i32,
-                    _: *mut *mut libc::c_long,
+                    _: *mut *mut isize,
                     _: i32,
                 ) -> i32,
         ),
@@ -1499,7 +1499,7 @@ pub static mut residue2_exportbundle: crate::backends_h::vorbis_func_residue = {
                     _: *mut *mut i32,
                     _: *mut i32,
                     _: i32,
-                ) -> *mut *mut libc::c_long,
+                ) -> *mut *mut isize,
         ),
         forward: Some(
             res2_forward
@@ -1510,7 +1510,7 @@ pub static mut residue2_exportbundle: crate::backends_h::vorbis_func_residue = {
                     _: *mut *mut i32,
                     _: *mut i32,
                     _: i32,
-                    _: *mut *mut libc::c_long,
+                    _: *mut *mut isize,
                     _: i32,
                 ) -> i32,
         ),

--- a/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/sharedbook.rs
+++ b/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/sharedbook.rs
@@ -59,36 +59,36 @@ pub unsafe extern "C" fn ov_ilog(mut v: crate::config_types_h::ogg_uint32_t) -> 
 /* doesn't currently guard under/overflow */
 #[no_mangle]
 
-pub unsafe extern "C" fn _float32_pack(mut val: f32) -> libc::c_long {
+pub unsafe extern "C" fn _float32_pack(mut val: f32) -> isize {
     let mut sign: i32 = 0 as i32; //+epsilon
-    let mut exp: libc::c_long = 0;
-    let mut mant: libc::c_long = 0;
+    let mut exp: isize = 0;
+    let mut mant: isize = 0;
     if val < 0 as i32 as f32 {
         sign = 0x80000000 as u32 as i32;
         val = -val
     }
     exp = crate::stdlib::floor(
         crate::stdlib::log(val as f64) / crate::stdlib::log(2.0f32 as f64) + 0.001f64,
-    ) as libc::c_long;
+    ) as isize;
     mant = crate::stdlib::rint(crate::stdlib::ldexp(
         val as f64,
-        ((21 as i32 - 1 as i32) as libc::c_long - exp) as i32,
-    )) as libc::c_long;
-    exp = (exp + 768 as i32 as libc::c_long) << 21 as i32;
-    return sign as libc::c_long | exp | mant;
+        ((21 as i32 - 1 as i32) as isize - exp) as i32,
+    )) as isize;
+    exp = (exp + 768 as i32 as isize) << 21 as i32;
+    return sign as isize | exp | mant;
 }
 #[no_mangle]
 
-pub unsafe extern "C" fn _float32_unpack(mut val: libc::c_long) -> f32 {
-    let mut mant: f64 = (val & 0x1fffff as i32 as libc::c_long) as f64;
-    let mut sign: i32 = (val & 0x80000000 as u32 as libc::c_long) as i32;
-    let mut exp: libc::c_long = (val & 0x7fe00000 as libc::c_long) >> 21 as i32;
+pub unsafe extern "C" fn _float32_unpack(mut val: isize) -> f32 {
+    let mut mant: f64 = (val & 0x1fffff as i32 as isize) as f64;
+    let mut sign: i32 = (val & 0x80000000 as u32 as isize) as i32;
+    let mut exp: isize = (val & 0x7fe00000 as isize) >> 21 as i32;
     if sign != 0 {
         mant = -mant
     }
     return crate::stdlib::ldexp(
         mant,
-        (exp - (21 as i32 - 1 as i32) as libc::c_long - 768 as i32 as libc::c_long) as i32,
+        (exp - (21 as i32 - 1 as i32) as isize - 768 as i32 as isize) as i32,
     ) as f32;
 }
 /* given a list of word lengths, generate a list of codewords.  Works
@@ -98,12 +98,12 @@ codewords first.  Extended to handle unused entries (length 0) */
 
 pub unsafe extern "C" fn _make_words(
     mut l: *mut libc::c_char,
-    mut n: libc::c_long,
-    mut sparsecount: libc::c_long,
+    mut n: isize,
+    mut sparsecount: isize,
 ) -> *mut crate::config_types_h::ogg_uint32_t {
-    let mut i: libc::c_long = 0;
-    let mut j: libc::c_long = 0;
-    let mut count: libc::c_long = 0 as i32 as libc::c_long;
+    let mut i: isize = 0;
+    let mut j: isize = 0;
+    let mut count: isize = 0 as i32 as isize;
     let mut marker: [crate::config_types_h::ogg_uint32_t; 33] = [0; 33];
     let mut r: *mut crate::config_types_h::ogg_uint32_t = crate::stdlib::malloc(
         ((if sparsecount != 0 { sparsecount } else { n }) as libc::c_ulong).wrapping_mul(
@@ -116,17 +116,17 @@ pub unsafe extern "C" fn _make_words(
         0 as i32,
         ::std::mem::size_of::<[crate::config_types_h::ogg_uint32_t; 33]>() as libc::c_ulong,
     );
-    i = 0 as i32 as libc::c_long;
+    i = 0 as i32 as isize;
     while i < n {
-        let mut length: libc::c_long = *l.offset(i as isize) as libc::c_long;
-        if length > 0 as i32 as libc::c_long {
+        let mut length: isize = *l.offset(i as isize) as isize;
+        if length > 0 as i32 as isize {
             let mut entry: crate::config_types_h::ogg_uint32_t = marker[length as usize];
             /* when we claim a node for an entry, we also claim the nodes
             below it (pruning off the imagined tree that may have dangled
             from it) as well as blocking the use of any nodes directly
             above for leaves */
             /* update ourself */
-            if length < 32 as i32 as libc::c_long && entry >> length != 0 {
+            if length < 32 as i32 as isize && entry >> length != 0 {
                 /* error condition; the lengths must specify an overpopulated tree */
                 ::libc::free(r as *mut libc::c_void);
                 return 0 as *mut crate::config_types_h::ogg_uint32_t;
@@ -137,14 +137,14 @@ pub unsafe extern "C" fn _make_words(
             /* Look to see if the next shorter marker points to the node
             above. if so, update it and repeat.  */
             j = length;
-            while j > 0 as i32 as libc::c_long {
+            while j > 0 as i32 as isize {
                 if marker[j as usize] & 1 as i32 as u32 != 0 {
                     /* have to jump branches */
-                    if j == 1 as i32 as libc::c_long {
+                    if j == 1 as i32 as isize {
                         marker[1 as i32 as usize] = marker[1 as i32 as usize].wrapping_add(1)
                     } else {
                         marker[j as usize] =
-                            marker[(j - 1 as i32 as libc::c_long) as usize] << 1 as i32
+                            marker[(j - 1 as i32 as isize) as usize] << 1 as i32
                     }
                     break;
                 /* invariant says next upper marker would already
@@ -157,16 +157,16 @@ pub unsafe extern "C" fn _make_words(
             /* prune the tree; the implicit invariant says all the longer
             markers were dangling from our just-taken node.  Dangle them
             from our *new* node. */
-            j = length + 1 as i32 as libc::c_long;
-            while j < 33 as i32 as libc::c_long {
+            j = length + 1 as i32 as isize;
+            while j < 33 as i32 as isize {
                 if !(marker[j as usize] >> 1 as i32 == entry) {
                     break;
                 }
                 entry = marker[j as usize];
-                marker[j as usize] = marker[(j - 1 as i32 as libc::c_long) as usize] << 1 as i32;
+                marker[j as usize] = marker[(j - 1 as i32 as isize) as usize] << 1 as i32;
                 j += 1
             }
-        } else if sparsecount == 0 as i32 as libc::c_long {
+        } else if sparsecount == 0 as i32 as isize {
             count += 1
         }
         i += 1
@@ -175,11 +175,11 @@ pub unsafe extern "C" fn _make_words(
     /* Single-entry codebooks are a retconned extension to the spec.
     They have a single codeword '0' of length 1 that results in an
     underpopulated tree.  Shield that case from the underformed tree check. */
-    if !(count == 1 as i32 as libc::c_long && marker[2 as i32 as usize] == 2 as i32 as u32) {
-        i = 1 as i32 as libc::c_long;
-        while i < 33 as i32 as libc::c_long {
+    if !(count == 1 as i32 as isize && marker[2 as i32 as usize] == 2 as i32 as u32) {
+        i = 1 as i32 as isize;
+        while i < 33 as i32 as isize {
             if marker[i as usize] as libc::c_ulong
-                & 0xffffffff as libc::c_ulong >> 32 as i32 as libc::c_long - i
+                & 0xffffffff as libc::c_ulong >> 32 as i32 as isize - i
                 != 0
             {
                 ::libc::free(r as *mut libc::c_void);
@@ -190,13 +190,13 @@ pub unsafe extern "C" fn _make_words(
     }
     /* bitreverse the words because our bitwise packer/unpacker is LSb
     endian */
-    i = 0 as i32 as libc::c_long;
-    count = 0 as i32 as libc::c_long;
+    i = 0 as i32 as isize;
+    count = 0 as i32 as isize;
     while i < n {
         let mut temp: crate::config_types_h::ogg_uint32_t =
             0 as i32 as crate::config_types_h::ogg_uint32_t;
-        j = 0 as i32 as libc::c_long;
-        while j < *l.offset(i as isize) as libc::c_long {
+        j = 0 as i32 as isize;
+        while j < *l.offset(i as isize) as isize {
             temp <<= 1 as i32;
             temp |= *r.offset(count as isize) >> j & 1 as i32 as u32;
             j += 1
@@ -223,44 +223,44 @@ thought of it.  Therefore, we opt on the side of caution */
 
 pub unsafe extern "C" fn _book_maptype1_quantvals(
     mut b: *const crate::src::libvorbis_1_3_6::lib::codebook::static_codebook,
-) -> libc::c_long {
-    let mut vals: libc::c_long = 0;
-    if (*b).entries < 1 as i32 as libc::c_long {
-        return 0 as i32 as libc::c_long;
+) -> isize {
+    let mut vals: isize = 0;
+    if (*b).entries < 1 as i32 as isize {
+        return 0 as i32 as isize;
     }
     vals = crate::stdlib::floor(crate::stdlib::pow(
         (*b).entries as f32 as f64,
         (1.0f32 / (*b).dim as f32) as f64,
-    )) as libc::c_long;
+    )) as isize;
     /* the above *should* be reliable, but we'll not assume that FP is
     ever reliable when bitstream sync is at stake; verify via integer
     means that vals really is the greatest value of dim for which
     vals^b->bim <= b->entries */
     /* treat the above as an initial guess */
-    if vals < 1 as i32 as libc::c_long {
-        vals = 1 as i32 as libc::c_long
+    if vals < 1 as i32 as isize {
+        vals = 1 as i32 as isize
     }
     loop {
-        let mut acc: libc::c_long = 1 as i32 as libc::c_long;
-        let mut acc1: libc::c_long = 1 as i32 as libc::c_long;
+        let mut acc: isize = 1 as i32 as isize;
+        let mut acc1: isize = 1 as i32 as isize;
         let mut i: i32 = 0;
         i = 0 as i32;
-        while (i as libc::c_long) < (*b).dim {
+        while (i as isize) < (*b).dim {
             if (*b).entries / vals < acc {
                 break;
             }
             acc *= vals;
-            if (9223372036854775807 as libc::c_long / (vals + 1 as i32 as libc::c_long)) < acc1 {
-                acc1 = 9223372036854775807 as libc::c_long
+            if (9223372036854775807 as isize / (vals + 1 as i32 as isize)) < acc1 {
+                acc1 = 9223372036854775807 as isize
             } else {
-                acc1 *= vals + 1 as i32 as libc::c_long
+                acc1 *= vals + 1 as i32 as isize
             }
             i += 1
         }
-        if i as libc::c_long >= (*b).dim && acc <= (*b).entries && acc1 > (*b).entries {
+        if i as isize >= (*b).dim && acc <= (*b).entries && acc1 > (*b).entries {
             return vals;
         } else {
-            if (i as libc::c_long) < (*b).dim || acc > (*b).entries {
+            if (i as isize) < (*b).dim || acc > (*b).entries {
                 vals -= 1
             } else {
                 vals += 1
@@ -280,15 +280,15 @@ pub unsafe extern "C" fn _book_unquantize(
     mut n: i32,
     mut sparsemap: *mut i32,
 ) -> *mut f32 {
-    let mut j: libc::c_long = 0;
-    let mut k: libc::c_long = 0;
-    let mut count: libc::c_long = 0 as i32 as libc::c_long;
+    let mut j: isize = 0;
+    let mut k: isize = 0;
+    let mut count: isize = 0 as i32 as isize;
     if (*b).maptype == 1 as i32 || (*b).maptype == 2 as i32 {
         let mut quantvals: i32 = 0;
         let mut mindel: f32 = _float32_unpack((*b).q_min);
         let mut delta: f32 = _float32_unpack((*b).q_delta);
         let mut r: *mut f32 = crate::stdlib::calloc(
-            (n as libc::c_long * (*b).dim) as libc::c_ulong,
+            (n as isize * (*b).dim) as libc::c_ulong,
             ::std::mem::size_of::<f32>() as libc::c_ulong,
         ) as *mut f32;
         /* maptype 1 and 2 both use a quantized value vector, but
@@ -303,17 +303,17 @@ pub unsafe extern "C" fn _book_unquantize(
                 values (and are wasted).  So don't generate codebooks like
                 that */
                 quantvals = _book_maptype1_quantvals(b) as i32;
-                j = 0 as i32 as libc::c_long;
+                j = 0 as i32 as isize;
                 while j < (*b).entries {
                     if !sparsemap.is_null() && *(*b).lengthlist.offset(j as isize) as i32 != 0
                         || sparsemap.is_null()
                     {
                         let mut last: f32 = 0.0f32;
                         let mut indexdiv: i32 = 1 as i32;
-                        k = 0 as i32 as libc::c_long;
+                        k = 0 as i32 as isize;
                         while k < (*b).dim {
                             let mut index: i32 =
-                                (j / indexdiv as libc::c_long % quantvals as libc::c_long) as i32;
+                                (j / indexdiv as isize % quantvals as isize) as i32;
                             let mut val: f32 = *(*b).quantlist.offset(index as isize) as f32;
                             val = (crate::stdlib::fabs(val as f64) * delta as f64
                                 + mindel as f64
@@ -323,7 +323,7 @@ pub unsafe extern "C" fn _book_unquantize(
                             }
                             if !sparsemap.is_null() {
                                 *r.offset(
-                                    (*sparsemap.offset(count as isize) as libc::c_long * (*b).dim
+                                    (*sparsemap.offset(count as isize) as isize * (*b).dim
                                         + k) as isize,
                                 ) = val
                             } else {
@@ -338,13 +338,13 @@ pub unsafe extern "C" fn _book_unquantize(
                 }
             }
             2 => {
-                j = 0 as i32 as libc::c_long;
+                j = 0 as i32 as isize;
                 while j < (*b).entries {
                     if !sparsemap.is_null() && *(*b).lengthlist.offset(j as isize) as i32 != 0
                         || sparsemap.is_null()
                     {
                         let mut last_0: f32 = 0.0f32;
-                        k = 0 as i32 as libc::c_long;
+                        k = 0 as i32 as isize;
                         while k < (*b).dim {
                             let mut val_0: f32 =
                                 *(*b).quantlist.offset((j * (*b).dim + k) as isize) as f32;
@@ -356,7 +356,7 @@ pub unsafe extern "C" fn _book_unquantize(
                             }
                             if !sparsemap.is_null() {
                                 *r.offset(
-                                    (*sparsemap.offset(count as isize) as libc::c_long * (*b).dim
+                                    (*sparsemap.offset(count as isize) as isize * (*b).dim
                                         + k) as isize,
                                 ) = val_0
                             } else {
@@ -442,7 +442,7 @@ pub unsafe extern "C" fn vorbis_book_init_encode(
     (*c).entries = (*s).entries;
     (*c).used_entries = (*s).entries;
     (*c).dim = (*s).dim;
-    (*c).codelist = _make_words((*s).lengthlist, (*s).entries, 0 as i32 as libc::c_long);
+    (*c).codelist = _make_words((*s).lengthlist, (*s).entries, 0 as i32 as isize);
     //c->valuelist=_book_unquantize(s,s->entries,NULL);
     (*c).quantvals = _book_maptype1_quantvals(s) as i32;
     (*c).minval = crate::stdlib::rint(_float32_unpack((*s).q_min) as f64) as i32;
@@ -496,14 +496,14 @@ pub unsafe extern "C" fn vorbis_book_init_decode(
     );
     /* count actually used entries and find max length */
     i = 0 as i32;
-    while (i as libc::c_long) < (*s).entries {
+    while (i as isize) < (*s).entries {
         if *(*s).lengthlist.offset(i as isize) as i32 > 0 as i32 {
             n += 1
         }
         i += 1
     }
     (*c).entries = (*s).entries;
-    (*c).used_entries = n as libc::c_long;
+    (*c).used_entries = n as isize;
     (*c).dim = (*s).dim;
     if n > 0 as i32 {
         /* two different remappings go on here.
@@ -561,7 +561,7 @@ pub unsafe extern "C" fn vorbis_book_init_decode(
             i = 0 as i32;
             while i < n {
                 let mut position: i32 =
-                    (*codep.offset(i as isize)).offset_from(codes) as libc::c_long as i32;
+                    (*codep.offset(i as isize)).offset_from(codes) as isize as i32;
                 *sortindex.offset(position as isize) = i;
                 i += 1
             }
@@ -578,7 +578,7 @@ pub unsafe extern "C" fn vorbis_book_init_decode(
             ) as *mut i32;
             n = 0 as i32;
             i = 0 as i32;
-            while (i as libc::c_long) < (*s).entries {
+            while (i as isize) < (*s).entries {
                 if *(*s).lengthlist.offset(i as isize) as i32 > 0 as i32 {
                     let fresh6 = n;
                     n = n + 1;
@@ -595,7 +595,7 @@ pub unsafe extern "C" fn vorbis_book_init_decode(
             (*c).dec_maxlength = 0 as i32;
             n = 0 as i32;
             i = 0 as i32;
-            while (i as libc::c_long) < (*s).entries {
+            while (i as isize) < (*s).entries {
                 if *(*s).lengthlist.offset(i as isize) as i32 > 0 as i32 {
                     let fresh7 = n;
                     n = n + 1;
@@ -661,23 +661,23 @@ pub unsafe extern "C" fn vorbis_book_init_decode(
                 let mut mask: crate::config_types_h::ogg_uint32_t = ((0xfffffffe as libc::c_ulong)
                     << 31 as i32 - (*c).dec_firsttablen)
                     as crate::config_types_h::ogg_uint32_t;
-                let mut lo: libc::c_long = 0 as i32 as libc::c_long;
-                let mut hi: libc::c_long = 0 as i32 as libc::c_long;
+                let mut lo: isize = 0 as i32 as isize;
+                let mut hi: isize = 0 as i32 as isize;
                 i = 0 as i32;
                 while i < tabn {
                     let mut word: crate::config_types_h::ogg_uint32_t = (i
                         << 32 as i32 - (*c).dec_firsttablen)
                         as crate::config_types_h::ogg_uint32_t;
                     if *(*c).dec_firsttable.offset(bitreverse(word) as isize) == 0 as i32 as u32 {
-                        while (lo + 1 as i32 as libc::c_long) < n as libc::c_long
+                        while (lo + 1 as i32 as isize) < n as isize
                             && *(*c)
                                 .codelist
-                                .offset((lo + 1 as i32 as libc::c_long) as isize)
+                                .offset((lo + 1 as i32 as isize) as isize)
                                 <= word
                         {
                             lo += 1
                         }
-                        while hi < n as libc::c_long
+                        while hi < n as isize
                             && word >= *(*c).codelist.offset(hi as isize) & mask
                         {
                             hi += 1
@@ -686,7 +686,7 @@ pub unsafe extern "C" fn vorbis_book_init_decode(
                         In order to overflow gracefully (nothing breaks, efficiency
                         just drops), encode as the difference from the extremes. */
                         let mut loval: libc::c_ulong = lo as libc::c_ulong;
-                        let mut hival: libc::c_ulong = (n as libc::c_long - hi) as libc::c_ulong;
+                        let mut hival: libc::c_ulong = (n as isize - hi) as libc::c_ulong;
                         if loval > 0x7fff as i32 as libc::c_ulong {
                             loval = 0x7fff as i32 as libc::c_ulong
                         }
@@ -709,24 +709,24 @@ pub unsafe extern "C" fn vorbis_book_init_decode(
 pub unsafe extern "C" fn vorbis_book_codeword(
     mut book: *mut crate::src::libvorbis_1_3_6::lib::codebook::codebook,
     mut entry: i32,
-) -> libc::c_long {
+) -> isize {
     if !(*book).c.is_null() {
         /* only use with encode; decode optimizations are
         allowed to break this */
-        return *(*book).codelist.offset(entry as isize) as libc::c_long;
+        return *(*book).codelist.offset(entry as isize) as isize;
     }
-    return -(1 as i32) as libc::c_long;
+    return -(1 as i32) as isize;
 }
 #[no_mangle]
 
 pub unsafe extern "C" fn vorbis_book_codelen(
     mut book: *mut crate::src::libvorbis_1_3_6::lib::codebook::codebook,
     mut entry: i32,
-) -> libc::c_long {
+) -> isize {
     if !(*book).c.is_null() {
         /* only use with encode; decode optimizations are
         allowed to break this */
-        return *(*(*book).c).lengthlist.offset(entry as isize) as libc::c_long;
+        return *(*(*book).c).lengthlist.offset(entry as isize) as isize;
     }
-    return -(1 as i32) as libc::c_long;
+    return -(1 as i32) as isize;
 }

--- a/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/synthesis.rs
+++ b/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/synthesis.rs
@@ -109,7 +109,7 @@ pub unsafe extern "C" fn vorbis_synthesis(
     if crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
         opb as *mut crate::ogg_h::oggpack_buffer,
         1 as i32,
-    ) != 0 as i32 as libc::c_long
+    ) != 0 as i32 as isize
     {
         /* Oops.  This is not an audio data packet */
         return -(135 as i32);
@@ -126,7 +126,7 @@ pub unsafe extern "C" fn vorbis_synthesis(
     if (*ci).mode_param[mode as usize].is_null() {
         return -(136 as i32);
     }
-    (*vb).W = (*(*ci).mode_param[mode as usize]).blockflag as libc::c_long;
+    (*vb).W = (*(*ci).mode_param[mode as usize]).blockflag as isize;
     if (*vb).W != 0 {
         /* this doesn;t get mapped through mode selection as it's used
         only for window selection */
@@ -138,12 +138,12 @@ pub unsafe extern "C" fn vorbis_synthesis(
             opb as *mut crate::ogg_h::oggpack_buffer,
             1 as i32,
         );
-        if (*vb).nW == -(1 as i32) as libc::c_long {
+        if (*vb).nW == -(1 as i32) as isize {
             return -(136 as i32);
         }
     } else {
-        (*vb).lW = 0 as i32 as libc::c_long;
-        (*vb).nW = 0 as i32 as libc::c_long
+        (*vb).lW = 0 as i32 as isize;
+        (*vb).nW = 0 as i32 as isize
     }
     /* more setup */
     (*vb).granulepos = (*op).granulepos;
@@ -154,7 +154,7 @@ pub unsafe extern "C" fn vorbis_synthesis(
     (*vb).pcm = crate::src::libvorbis_1_3_6::lib::block::_vorbis_block_alloc(
         vb as *mut crate::codec_h::vorbis_block,
         (::std::mem::size_of::<*mut f32>() as libc::c_ulong)
-            .wrapping_mul((*vi).channels as libc::c_ulong) as libc::c_long,
+            .wrapping_mul((*vi).channels as libc::c_ulong) as isize,
     ) as *mut *mut f32;
     i = 0 as i32;
     while i < (*vi).channels {
@@ -163,7 +163,7 @@ pub unsafe extern "C" fn vorbis_synthesis(
             vb as *mut crate::codec_h::vorbis_block,
             ((*vb).pcmend as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<f32>() as libc::c_ulong)
-                as libc::c_long,
+                as isize,
         ) as *mut f32;
         i += 1
     }
@@ -207,7 +207,7 @@ pub unsafe extern "C" fn vorbis_synthesis_trackonly(
     if crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
         opb as *mut crate::ogg_h::oggpack_buffer,
         1 as i32,
-    ) != 0 as i32 as libc::c_long
+    ) != 0 as i32 as isize
     {
         /* Oops.  This is not an audio data packet */
         return -(135 as i32);
@@ -224,7 +224,7 @@ pub unsafe extern "C" fn vorbis_synthesis_trackonly(
     if (*ci).mode_param[mode as usize].is_null() {
         return -(136 as i32);
     }
-    (*vb).W = (*(*ci).mode_param[mode as usize]).blockflag as libc::c_long;
+    (*vb).W = (*(*ci).mode_param[mode as usize]).blockflag as isize;
     if (*vb).W != 0 {
         (*vb).lW = crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
             opb as *mut crate::ogg_h::oggpack_buffer,
@@ -234,12 +234,12 @@ pub unsafe extern "C" fn vorbis_synthesis_trackonly(
             opb as *mut crate::ogg_h::oggpack_buffer,
             1 as i32,
         );
-        if (*vb).nW == -(1 as i32) as libc::c_long {
+        if (*vb).nW == -(1 as i32) as isize {
             return -(136 as i32);
         }
     } else {
-        (*vb).lW = 0 as i32 as libc::c_long;
-        (*vb).nW = 0 as i32 as libc::c_long
+        (*vb).lW = 0 as i32 as isize;
+        (*vb).nW = 0 as i32 as isize
     }
     /* more setup */
     (*vb).granulepos = (*op).granulepos;
@@ -255,7 +255,7 @@ pub unsafe extern "C" fn vorbis_synthesis_trackonly(
 pub unsafe extern "C" fn vorbis_packet_blocksize(
     mut vi: *mut crate::codec_h::vorbis_info,
     mut op: *mut crate::ogg_h::ogg_packet,
-) -> libc::c_long {
+) -> isize {
     let mut ci: *mut crate::codec_internal_h::codec_setup_info =
         (*vi).codec_setup as *mut crate::codec_internal_h::codec_setup_info;
     let mut opb: crate::ogg_h::oggpack_buffer = crate::ogg_h::oggpack_buffer {
@@ -268,7 +268,7 @@ pub unsafe extern "C" fn vorbis_packet_blocksize(
     let mut mode: i32 = 0;
     if ci.is_null() || (*ci).modes <= 0 as i32 {
         /* codec setup not properly intialized */
-        return -(129 as i32) as libc::c_long;
+        return -(129 as i32) as isize;
     }
     crate::src::libogg_1_3_3::src::bitwise::oggpack_readinit(
         &mut opb as *mut _ as *mut crate::ogg_h::oggpack_buffer,
@@ -279,10 +279,10 @@ pub unsafe extern "C" fn vorbis_packet_blocksize(
     if crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
         &mut opb as *mut _ as *mut crate::ogg_h::oggpack_buffer,
         1 as i32,
-    ) != 0 as i32 as libc::c_long
+    ) != 0 as i32 as isize
     {
         /* Oops.  This is not an audio data packet */
-        return -(135 as i32) as libc::c_long;
+        return -(135 as i32) as isize;
     }
     /* read our mode and pre/post windowsize */
     mode = crate::src::libogg_1_3_3::src::bitwise::oggpack_read(
@@ -292,7 +292,7 @@ pub unsafe extern "C" fn vorbis_packet_blocksize(
         ),
     ) as i32;
     if mode == -(1 as i32) || (*ci).mode_param[mode as usize].is_null() {
-        return -(136 as i32) as libc::c_long;
+        return -(136 as i32) as isize;
     }
     return (*ci).blocksizes[(*(*ci).mode_param[mode as usize]).blockflag as usize];
 }
@@ -306,7 +306,7 @@ pub unsafe extern "C" fn vorbis_synthesis_halfrate(
     let mut ci: *mut crate::codec_internal_h::codec_setup_info =
         (*vi).codec_setup as *mut crate::codec_internal_h::codec_setup_info;
     /* right now, our MDCT can't handle < 64 sample windows. */
-    if (*ci).blocksizes[0 as i32 as usize] <= 64 as i32 as libc::c_long && flag != 0 {
+    if (*ci).blocksizes[0 as i32 as usize] <= 64 as i32 as isize && flag != 0 {
         return -(1 as i32);
     }
     (*ci).halfrate_flag = if flag != 0 { 1 as i32 } else { 0 as i32 };

--- a/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/vorbisfile.rs
+++ b/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/vorbisfile.rs
@@ -18,7 +18,7 @@ pub struct ov_callbacks {
         ) -> i32,
     >,
     pub close_func: Option<unsafe extern "C" fn(_: *mut libc::c_void) -> i32>,
-    pub tell_func: Option<unsafe extern "C" fn(_: *mut libc::c_void) -> libc::c_long>,
+    pub tell_func: Option<unsafe extern "C" fn(_: *mut libc::c_void) -> isize>,
 }
 
 #[repr(C)]
@@ -32,13 +32,13 @@ pub struct OggVorbis_File {
     pub links: i32,
     pub offsets: *mut crate::config_types_h::ogg_int64_t,
     pub dataoffsets: *mut crate::config_types_h::ogg_int64_t,
-    pub serialnos: *mut libc::c_long,
+    pub serialnos: *mut isize,
     pub pcmlengths: *mut crate::config_types_h::ogg_int64_t,
     pub vi: *mut crate::codec_h::vorbis_info,
     pub vc: *mut crate::codec_h::vorbis_comment,
     pub pcm_offset: crate::config_types_h::ogg_int64_t,
     pub ready_state: i32,
-    pub current_serialno: libc::c_long,
+    pub current_serialno: isize,
     pub current_link: i32,
     pub bittrack: f64,
     pub samptrack: f64,
@@ -177,17 +177,17 @@ extern "C" {
 
 unsafe extern "C" fn _get_data(
     mut vf: *mut crate::src::libvorbis_1_3_6::lib::vorbisfile::OggVorbis_File,
-) -> libc::c_long {
+) -> isize {
     *::libc::__errno_location() = 0 as i32;
     if (*vf).callbacks.read_func.is_none() {
-        return -(1 as i32) as libc::c_long;
+        return -(1 as i32) as isize;
     }
     if !(*vf).datasource.is_null() {
         let mut buffer: *mut libc::c_char = crate::src::libogg_1_3_3::src::framing::ogg_sync_buffer(
             &mut (*vf).oy as *mut _ as *mut crate::ogg_h::ogg_sync_state,
-            2048 as i32 as libc::c_long,
+            2048 as i32 as isize,
         );
-        let mut bytes: libc::c_long = (*vf)
+        let mut bytes: isize = (*vf)
             .callbacks
             .read_func
             .expect("non-null function pointer")(
@@ -195,19 +195,19 @@ unsafe extern "C" fn _get_data(
             1 as i32 as crate::stddef_h::size_t,
             2048 as i32 as crate::stddef_h::size_t,
             (*vf).datasource,
-        ) as libc::c_long;
-        if bytes > 0 as i32 as libc::c_long {
+        ) as isize;
+        if bytes > 0 as i32 as isize {
             crate::src::libogg_1_3_3::src::framing::ogg_sync_wrote(
                 &mut (*vf).oy as *mut _ as *mut crate::ogg_h::ogg_sync_state,
                 bytes,
             );
         }
-        if bytes == 0 as i32 as libc::c_long && *::libc::__errno_location() != 0 {
-            return -(1 as i32) as libc::c_long;
+        if bytes == 0 as i32 as isize && *::libc::__errno_location() != 0 {
+            return -(1 as i32) as isize;
         }
         return bytes;
     } else {
-        return 0 as i32 as libc::c_long;
+        return 0 as i32 as isize;
     };
 }
 /* save a tiny smidge of verbosity to make the code more readable */
@@ -257,31 +257,31 @@ unsafe extern "C" fn _get_next_page(
     mut og: *mut crate::ogg_h::ogg_page,
     mut boundary: crate::config_types_h::ogg_int64_t,
 ) -> crate::config_types_h::ogg_int64_t {
-    if boundary > 0 as i32 as libc::c_long {
+    if boundary > 0 as i32 as isize {
         boundary += (*vf).offset
     }
     loop {
-        let mut more: libc::c_long = 0;
-        if boundary > 0 as i32 as libc::c_long && (*vf).offset >= boundary {
+        let mut more: isize = 0;
+        if boundary > 0 as i32 as isize && (*vf).offset >= boundary {
             return -(1 as i32) as crate::config_types_h::ogg_int64_t;
         }
         more = crate::src::libogg_1_3_3::src::framing::ogg_sync_pageseek(
             &mut (*vf).oy as *mut _ as *mut crate::ogg_h::ogg_sync_state,
             og as *mut crate::ogg_h::ogg_page,
         );
-        if more < 0 as i32 as libc::c_long {
+        if more < 0 as i32 as isize {
             /* skipped n bytes */
             (*vf).offset -= more
-        } else if more == 0 as i32 as libc::c_long {
+        } else if more == 0 as i32 as isize {
             /* send more paramedics */
             if boundary == 0 {
                 return -(1 as i32) as crate::config_types_h::ogg_int64_t;
             }
-            let mut ret: libc::c_long = _get_data(vf);
-            if ret == 0 as i32 as libc::c_long {
+            let mut ret: isize = _get_data(vf);
+            if ret == 0 as i32 as isize {
                 return -(2 as i32) as crate::config_types_h::ogg_int64_t;
             }
-            if ret < 0 as i32 as libc::c_long {
+            if ret < 0 as i32 as isize {
                 return -(128 as i32) as crate::config_types_h::ogg_int64_t;
             }
         } else {
@@ -307,9 +307,9 @@ unsafe extern "C" fn _get_prev_page(
     let mut ret: crate::config_types_h::ogg_int64_t = 0;
     let mut offset: crate::config_types_h::ogg_int64_t =
         -(1 as i32) as crate::config_types_h::ogg_int64_t;
-    while offset == -(1 as i32) as libc::c_long {
-        begin -= 65536 as i32 as libc::c_long;
-        if begin < 0 as i32 as libc::c_long {
+    while offset == -(1 as i32) as isize {
+        begin -= 65536 as i32 as isize;
+        if begin < 0 as i32 as isize {
             begin = 0 as i32 as crate::config_types_h::ogg_int64_t
         }
         ret = _seek_helper(vf, begin) as crate::config_types_h::ogg_int64_t;
@@ -323,10 +323,10 @@ unsafe extern "C" fn _get_prev_page(
                 ::std::mem::size_of::<crate::ogg_h::ogg_page>() as libc::c_ulong,
             );
             ret = _get_next_page(vf, og, end - (*vf).offset);
-            if ret == -(128 as i32) as libc::c_long {
+            if ret == -(128 as i32) as isize {
                 return -(128 as i32) as crate::config_types_h::ogg_int64_t;
             }
-            if ret < 0 as i32 as libc::c_long {
+            if ret < 0 as i32 as isize {
                 break;
             }
             offset = ret
@@ -335,13 +335,13 @@ unsafe extern "C" fn _get_prev_page(
     /* In a fully compliant, non-multiplexed stream, we'll still be
     holding the last page.  In multiplexed (or noncompliant streams),
     we will probably have to re-read the last page we saw */
-    if (*og).header_len == 0 as i32 as libc::c_long {
+    if (*og).header_len == 0 as i32 as isize {
         ret = _seek_helper(vf, offset) as crate::config_types_h::ogg_int64_t;
         if ret != 0 {
             return ret;
         }
         ret = _get_next_page(vf, og, 65536 as i32 as crate::config_types_h::ogg_int64_t);
-        if ret < 0 as i32 as libc::c_long {
+        if ret < 0 as i32 as isize {
             /* this shouldn't be possible */
             return -(129 as i32) as crate::config_types_h::ogg_int64_t;
         }
@@ -351,31 +351,31 @@ unsafe extern "C" fn _get_prev_page(
 
 unsafe extern "C" fn _add_serialno(
     mut og: *mut crate::ogg_h::ogg_page,
-    mut serialno_list: *mut *mut libc::c_long,
+    mut serialno_list: *mut *mut isize,
     mut n: *mut i32,
 ) {
-    let mut s: libc::c_long = crate::src::libogg_1_3_3::src::framing::ogg_page_serialno(
+    let mut s: isize = crate::src::libogg_1_3_3::src::framing::ogg_page_serialno(
         og as *const crate::ogg_h::ogg_page,
-    ) as libc::c_long;
+    ) as isize;
     *n += 1;
     if !(*serialno_list).is_null() {
         *serialno_list = crate::stdlib::realloc(
             *serialno_list as *mut libc::c_void,
-            (::std::mem::size_of::<libc::c_long>() as libc::c_ulong)
+            (::std::mem::size_of::<isize>() as libc::c_ulong)
                 .wrapping_mul(*n as libc::c_ulong),
-        ) as *mut libc::c_long
+        ) as *mut isize
     } else {
         *serialno_list =
-            crate::stdlib::malloc(::std::mem::size_of::<libc::c_long>() as libc::c_ulong)
-                as *mut libc::c_long
+            crate::stdlib::malloc(::std::mem::size_of::<isize>() as libc::c_ulong)
+                as *mut isize
     }
     *(*serialno_list).offset((*n - 1 as i32) as isize) = s;
 }
 /* returns nonzero if found */
 
 unsafe extern "C" fn _lookup_serialno(
-    mut s: libc::c_long,
-    mut serialno_list: *mut libc::c_long,
+    mut s: isize,
+    mut serialno_list: *mut isize,
     mut n: i32,
 ) -> i32 {
     if !serialno_list.is_null() {
@@ -396,12 +396,12 @@ unsafe extern "C" fn _lookup_serialno(
 
 unsafe extern "C" fn _lookup_page_serialno(
     mut og: *mut crate::ogg_h::ogg_page,
-    mut serialno_list: *mut libc::c_long,
+    mut serialno_list: *mut isize,
     mut n: i32,
 ) -> i32 {
-    let mut s: libc::c_long = crate::src::libogg_1_3_3::src::framing::ogg_page_serialno(
+    let mut s: isize = crate::src::libogg_1_3_3::src::framing::ogg_page_serialno(
         og as *const crate::ogg_h::ogg_page,
-    ) as libc::c_long;
+    ) as isize;
     return _lookup_serialno(s, serialno_list, n);
 }
 /* performs the same search as _get_prev_page, but prefers pages of
@@ -414,7 +414,7 @@ return the info of last page and alter *serialno.  */
 unsafe extern "C" fn _get_prev_page_serial(
     mut vf: *mut crate::src::libvorbis_1_3_6::lib::vorbisfile::OggVorbis_File,
     mut begin: crate::config_types_h::ogg_int64_t,
-    mut serial_list: *mut libc::c_long,
+    mut serial_list: *mut isize,
     mut serial_n: i32,
     mut serialno: *mut i32,
     mut granpos: *mut crate::config_types_h::ogg_int64_t,
@@ -435,9 +435,9 @@ unsafe extern "C" fn _get_prev_page_serial(
         -(1 as i32) as crate::config_types_h::ogg_int64_t;
     let mut ret_gran: crate::config_types_h::ogg_int64_t =
         -(1 as i32) as crate::config_types_h::ogg_int64_t;
-    while offset == -(1 as i32) as libc::c_long {
-        begin -= 65536 as i32 as libc::c_long;
-        if begin < 0 as i32 as libc::c_long {
+    while offset == -(1 as i32) as isize {
+        begin -= 65536 as i32 as isize;
+        if begin < 0 as i32 as isize {
             begin = 0 as i32 as crate::config_types_h::ogg_int64_t
         }
         ret = _seek_helper(vf, begin) as crate::config_types_h::ogg_int64_t;
@@ -446,10 +446,10 @@ unsafe extern "C" fn _get_prev_page_serial(
         }
         while (*vf).offset < end {
             ret = _get_next_page(vf, &mut og, end - (*vf).offset);
-            if ret == -(128 as i32) as libc::c_long {
+            if ret == -(128 as i32) as isize {
                 return -(128 as i32) as crate::config_types_h::ogg_int64_t;
             }
-            if ret < 0 as i32 as libc::c_long {
+            if ret < 0 as i32 as isize {
                 break;
             }
             ret_serialno = crate::src::libogg_1_3_3::src::framing::ogg_page_serialno(
@@ -459,7 +459,7 @@ unsafe extern "C" fn _get_prev_page_serial(
                 &mut og as *mut _ as *const crate::ogg_h::ogg_page,
             );
             offset = ret;
-            if ret_serialno == *serialno as libc::c_long {
+            if ret_serialno == *serialno as isize {
                 prefoffset = ret;
                 *granpos = ret_gran
             }
@@ -473,7 +473,7 @@ unsafe extern "C" fn _get_prev_page_serial(
         }
     }
     /* we're not interested in the page... just the serialno and granpos. */
-    if prefoffset >= 0 as i32 as libc::c_long {
+    if prefoffset >= 0 as i32 as isize {
         return prefoffset;
     }
     *serialno = ret_serialno as i32;
@@ -487,7 +487,7 @@ unsafe extern "C" fn _fetch_headers(
     mut vf: *mut crate::src::libvorbis_1_3_6::lib::vorbisfile::OggVorbis_File,
     mut vi: *mut crate::codec_h::vorbis_info,
     mut vc: *mut crate::codec_h::vorbis_comment,
-    mut serialno_list: *mut *mut libc::c_long,
+    mut serialno_list: *mut *mut isize,
     mut serialno_n: *mut i32,
     mut og_ptr: *mut crate::ogg_h::ogg_page,
 ) -> i32 {
@@ -515,10 +515,10 @@ unsafe extern "C" fn _fetch_headers(
             &mut og,
             65536 as i32 as crate::config_types_h::ogg_int64_t,
         );
-        if llret == -(128 as i32) as libc::c_long {
+        if llret == -(128 as i32) as isize {
             return -(128 as i32);
         }
-        if llret < 0 as i32 as libc::c_long {
+        if llret < 0 as i32 as isize {
             return -(132 as i32);
         }
         og_ptr = &mut og
@@ -547,7 +547,7 @@ unsafe extern "C" fn _fetch_headers(
                 if !(*serialno_list).is_null() {
                     ::libc::free(*serialno_list as *mut libc::c_void);
                 }
-                *serialno_list = 0 as *mut libc::c_long;
+                *serialno_list = 0 as *mut isize;
                 *serialno_n = 0 as i32;
                 ret = -(133 as i32);
                 current_block = 5963935241184096755;
@@ -597,11 +597,11 @@ unsafe extern "C" fn _fetch_headers(
             og_ptr,
             65536 as i32 as crate::config_types_h::ogg_int64_t,
         );
-        if llret_0 == -(128 as i32) as libc::c_long {
+        if llret_0 == -(128 as i32) as isize {
             ret = -(128 as i32);
             current_block = 5963935241184096755;
             break;
-        } else if llret_0 < 0 as i32 as libc::c_long {
+        } else if llret_0 < 0 as i32 as isize {
             ret = -(132 as i32);
             current_block = 5963935241184096755;
             break;
@@ -611,7 +611,7 @@ unsafe extern "C" fn _fetch_headers(
                 && (*vf).os.serialno
                     == crate::src::libogg_1_3_3::src::framing::ogg_page_serialno(
                         og_ptr as *const crate::ogg_h::ogg_page,
-                    ) as libc::c_long)
+                    ) as isize)
             {
                 continue;
             }
@@ -667,7 +667,7 @@ unsafe extern "C" fn _fetch_headers(
                             vf,
                             og_ptr,
                             65536 as i32 as crate::config_types_h::ogg_int64_t,
-                        ) < 0 as i32 as libc::c_long
+                        ) < 0 as i32 as isize
                         {
                             ret = -(133 as i32);
                             current_block = 5963935241184096755;
@@ -675,7 +675,7 @@ unsafe extern "C" fn _fetch_headers(
                         } else if (*vf).os.serialno
                             == crate::src::libogg_1_3_3::src::framing::ogg_page_serialno(
                                 og_ptr as *const crate::ogg_h::ogg_page,
-                            ) as libc::c_long
+                            ) as isize
                         {
                             crate::src::libogg_1_3_3::src::framing::ogg_stream_pagein(
                                 &mut (*vf).os as *mut _ as *mut crate::ogg_h::ogg_stream_state,
@@ -737,7 +737,7 @@ unsafe extern "C" fn _initial_pcmoffset(
     }; /* should not be possible unless the file is truncated/mangled */
     let mut accumulated: crate::config_types_h::ogg_int64_t =
         0 as i32 as crate::config_types_h::ogg_int64_t;
-    let mut lastblock: libc::c_long = -(1 as i32) as libc::c_long;
+    let mut lastblock: isize = -(1 as i32) as isize;
     let mut result: i32 = 0;
     let mut serialno: i32 = (*vf).os.serialno as i32;
     loop {
@@ -753,7 +753,7 @@ unsafe extern "C" fn _initial_pcmoffset(
             vf,
             &mut og,
             -(1 as i32) as crate::config_types_h::ogg_int64_t,
-        ) < 0 as i32 as libc::c_long
+        ) < 0 as i32 as isize
         {
             break;
         }
@@ -784,13 +784,13 @@ unsafe extern "C" fn _initial_pcmoffset(
             }
             if result > 0 as i32 {
                 /* ignore holes */
-                let mut thisblock: libc::c_long =
+                let mut thisblock: isize =
                     crate::src::libvorbis_1_3_6::lib::synthesis::vorbis_packet_blocksize(
                         vi as *mut crate::codec_h::vorbis_info,
                         &mut op as *mut _ as *mut crate::ogg_h::ogg_packet,
                     );
-                if thisblock >= 0 as i32 as libc::c_long {
-                    if lastblock != -(1 as i32) as libc::c_long {
+                if thisblock >= 0 as i32 as isize {
+                    if lastblock != -(1 as i32) as isize {
                         accumulated += lastblock + thisblock >> 2 as i32
                     }
                     lastblock = thisblock
@@ -799,7 +799,7 @@ unsafe extern "C" fn _initial_pcmoffset(
         }
         if !(crate::src::libogg_1_3_3::src::framing::ogg_page_granulepos(
             &mut og as *mut _ as *const crate::ogg_h::ogg_page,
-        ) != -(1 as i32) as libc::c_long)
+        ) != -(1 as i32) as isize)
         {
             continue;
         }
@@ -812,7 +812,7 @@ unsafe extern "C" fn _initial_pcmoffset(
     /* less than zero?  Either a corrupt file or a stream with samples
     trimmed off the beginning, a normal occurrence; in both cases set
     the offset to zero */
-    if accumulated < 0 as i32 as libc::c_long {
+    if accumulated < 0 as i32 as isize {
         accumulated = 0 as i32 as crate::config_types_h::ogg_int64_t
     }
     return accumulated;
@@ -829,9 +829,9 @@ unsafe extern "C" fn _bisect_forward_serialno(
     mut end: crate::config_types_h::ogg_int64_t,
     mut endgran: crate::config_types_h::ogg_int64_t,
     mut endserial: i32,
-    mut currentno_list: *mut libc::c_long,
+    mut currentno_list: *mut isize,
     mut currentnos: i32,
-    mut m: libc::c_long,
+    mut m: isize,
 ) -> i32 {
     let mut pcmoffset: crate::config_types_h::ogg_int64_t = 0;
     let mut dataoffset: crate::config_types_h::ogg_int64_t = searched;
@@ -854,7 +854,7 @@ unsafe extern "C" fn _bisect_forward_serialno(
          not a page we care about)
     */
     /* Is the last page in our list of current serialnumbers? */
-    if _lookup_serialno(endserial as libc::c_long, currentno_list, currentnos) != 0 {
+    if _lookup_serialno(endserial as isize, currentno_list, currentnos) != 0 {
         /* last page is in the starting serialno list, so we've bisected
         down to (or just started with) a single link.  Now we need to
         find the last vorbis page belonging to the first vorbis stream
@@ -871,7 +871,7 @@ unsafe extern "C" fn _bisect_forward_serialno(
                 &mut endgran,
             )
         }
-        (*vf).links = (m + 1 as i32 as libc::c_long) as i32;
+        (*vf).links = (m + 1 as i32 as isize) as i32;
         if !(*vf).offsets.is_null() {
             ::libc::free((*vf).offsets as *mut libc::c_void);
         }
@@ -900,8 +900,8 @@ unsafe extern "C" fn _bisect_forward_serialno(
         ) as *mut crate::codec_h::vorbis_comment;
         (*vf).serialnos = crate::stdlib::malloc(
             ((*vf).links as libc::c_ulong)
-                .wrapping_mul(::std::mem::size_of::<libc::c_long>() as libc::c_ulong),
-        ) as *mut libc::c_long;
+                .wrapping_mul(::std::mem::size_of::<isize>() as libc::c_ulong),
+        ) as *mut isize;
         (*vf).dataoffsets = crate::stdlib::malloc(((*vf).links as libc::c_ulong).wrapping_mul(
             ::std::mem::size_of::<crate::config_types_h::ogg_int64_t>() as libc::c_ulong,
         )) as *mut crate::config_types_h::ogg_int64_t;
@@ -911,13 +911,13 @@ unsafe extern "C" fn _bisect_forward_serialno(
             )) as *mut crate::config_types_h::ogg_int64_t;
         *(*vf)
             .offsets
-            .offset((m + 1 as i32 as libc::c_long) as isize) = end;
+            .offset((m + 1 as i32 as isize) as isize) = end;
         *(*vf).offsets.offset(m as isize) = begin;
         *(*vf)
             .pcmlengths
-            .offset((m * 2 as i32 as libc::c_long + 1 as i32 as libc::c_long) as isize) =
-            if endgran < 0 as i32 as libc::c_long {
-                0 as i32 as libc::c_long
+            .offset((m * 2 as i32 as isize + 1 as i32 as isize) as isize) =
+            if endgran < 0 as i32 as isize {
+                0 as i32 as isize
             } else {
                 endgran
             }
@@ -925,7 +925,7 @@ unsafe extern "C" fn _bisect_forward_serialno(
         /* last page is not in the starting stream's serial number list,
         so we have multiple links.  Find where the stream that begins
         our bisection ends. */
-        let mut next_serialno_list: *mut libc::c_long = 0 as *mut libc::c_long;
+        let mut next_serialno_list: *mut isize = 0 as *mut isize;
         let mut next_serialnos: i32 = 0 as i32;
         let mut vi: crate::codec_h::vorbis_info = crate::codec_h::vorbis_info {
             version: 0,
@@ -948,10 +948,10 @@ unsafe extern "C" fn _bisect_forward_serialno(
         first pages of two links. */
         while searched < endsearched {
             let mut bisect: crate::config_types_h::ogg_int64_t = 0;
-            if endsearched - searched < 65536 as i32 as libc::c_long {
+            if endsearched - searched < 65536 as i32 as isize {
                 bisect = searched
             } else {
-                bisect = (searched + endsearched) / 2 as i32 as libc::c_long
+                bisect = (searched + endsearched) / 2 as i32 as isize
             }
             ret = _seek_helper(vf, bisect) as crate::config_types_h::ogg_int64_t;
             if ret != 0 {
@@ -962,14 +962,14 @@ unsafe extern "C" fn _bisect_forward_serialno(
                 &mut og,
                 -(1 as i32) as crate::config_types_h::ogg_int64_t,
             );
-            if last == -(128 as i32) as libc::c_long {
+            if last == -(128 as i32) as isize {
                 return -(128 as i32);
             }
-            if last < 0 as i32 as libc::c_long
+            if last < 0 as i32 as isize
                 || _lookup_page_serialno(&mut og, currentno_list, currentnos) == 0
             {
                 endsearched = bisect;
-                if last >= 0 as i32 as libc::c_long {
+                if last >= 0 as i32 as isize {
                     next = last
                 }
             } else {
@@ -1019,7 +1019,7 @@ unsafe extern "C" fn _bisect_forward_serialno(
             endserial,
             next_serialno_list,
             next_serialnos,
-            m + 1 as i32 as libc::c_long,
+            m + 1 as i32 as isize,
         ) as crate::config_types_h::ogg_int64_t;
         if ret != 0 {
             return ret as i32;
@@ -1029,34 +1029,34 @@ unsafe extern "C" fn _bisect_forward_serialno(
         }
         *(*vf)
             .offsets
-            .offset((m + 1 as i32 as libc::c_long) as isize) = next;
+            .offset((m + 1 as i32 as isize) as isize) = next;
         *(*vf)
             .serialnos
-            .offset((m + 1 as i32 as libc::c_long) as isize) = serialno as libc::c_long;
+            .offset((m + 1 as i32 as isize) as isize) = serialno as isize;
         *(*vf)
             .dataoffsets
-            .offset((m + 1 as i32 as libc::c_long) as isize) = dataoffset;
-        *(*vf).vi.offset((m + 1 as i32 as libc::c_long) as isize) = vi;
-        *(*vf).vc.offset((m + 1 as i32 as libc::c_long) as isize) = vc;
+            .offset((m + 1 as i32 as isize) as isize) = dataoffset;
+        *(*vf).vi.offset((m + 1 as i32 as isize) as isize) = vi;
+        *(*vf).vc.offset((m + 1 as i32 as isize) as isize) = vc;
         *(*vf)
             .pcmlengths
-            .offset((m * 2 as i32 as libc::c_long + 1 as i32 as libc::c_long) as isize) =
+            .offset((m * 2 as i32 as isize + 1 as i32 as isize) as isize) =
             searchgran;
         *(*vf)
             .pcmlengths
-            .offset((m * 2 as i32 as libc::c_long + 2 as i32 as libc::c_long) as isize) = pcmoffset;
+            .offset((m * 2 as i32 as isize + 2 as i32 as isize) as isize) = pcmoffset;
         let ref mut fresh1 = *(*vf)
             .pcmlengths
-            .offset((m * 2 as i32 as libc::c_long + 3 as i32 as libc::c_long) as isize);
+            .offset((m * 2 as i32 as isize + 3 as i32 as isize) as isize);
         *fresh1 -= pcmoffset;
         if *(*vf)
             .pcmlengths
-            .offset((m * 2 as i32 as libc::c_long + 3 as i32 as libc::c_long) as isize)
-            < 0 as i32 as libc::c_long
+            .offset((m * 2 as i32 as isize + 3 as i32 as isize) as isize)
+            < 0 as i32 as isize
         {
             *(*vf)
                 .pcmlengths
-                .offset((m * 2 as i32 as libc::c_long + 3 as i32 as libc::c_long) as isize) =
+                .offset((m * 2 as i32 as isize + 3 as i32 as isize) as isize) =
                 0 as i32 as crate::config_types_h::ogg_int64_t
         }
     }
@@ -1131,7 +1131,7 @@ unsafe extern "C" fn _open_seekable2(
         (*vf).offset = (*vf).end
     }
     /* If seek_func is implemented, tell_func must also be implemented */
-    if (*vf).end == -(1 as i32) as libc::c_long {
+    if (*vf).end == -(1 as i32) as isize {
         return -(131 as i32);
     }
     /* Get the offset of the last page of the physical bitstream, or, if
@@ -1145,7 +1145,7 @@ unsafe extern "C" fn _open_seekable2(
         &mut endserial,
         &mut endgran,
     );
-    if end < 0 as i32 as libc::c_long {
+    if end < 0 as i32 as isize {
         return end as i32;
     }
     /* now determine bitstream structure recursively */
@@ -1158,18 +1158,18 @@ unsafe extern "C" fn _open_seekable2(
         endserial,
         (*vf).serialnos.offset(2 as i32 as isize),
         *(*vf).serialnos.offset(1 as i32 as isize) as i32,
-        0 as i32 as libc::c_long,
+        0 as i32 as isize,
     ) < 0 as i32
     {
         return -(128 as i32);
     }
     *(*vf).offsets.offset(0 as i32 as isize) = 0 as i32 as crate::config_types_h::ogg_int64_t;
-    *(*vf).serialnos.offset(0 as i32 as isize) = serialno as libc::c_long;
+    *(*vf).serialnos.offset(0 as i32 as isize) = serialno as isize;
     *(*vf).dataoffsets.offset(0 as i32 as isize) = dataoffset;
     *(*vf).pcmlengths.offset(0 as i32 as isize) = pcmoffset;
     let ref mut fresh2 = *(*vf).pcmlengths.offset(1 as i32 as isize);
     *fresh2 -= pcmoffset;
-    if *(*vf).pcmlengths.offset(1 as i32 as isize) < 0 as i32 as libc::c_long {
+    if *(*vf).pcmlengths.offset(1 as i32 as isize) < 0 as i32 as isize {
         *(*vf).pcmlengths.offset(1 as i32 as isize) = 0 as i32 as crate::config_types_h::ogg_int64_t
     }
     return ov_raw_seek(vf, dataoffset);
@@ -1283,9 +1283,9 @@ unsafe extern "C" fn _fetch_and_process_packet(
                             &mut (*vf).vd as *mut _ as *mut crate::codec_h::vorbis_dsp_state,
                             0 as *mut *mut *mut f32,
                         ) << hs) as f64;
-                    (*vf).bittrack += ((*op_ptr).bytes * 8 as i32 as libc::c_long) as f64;
+                    (*vf).bittrack += ((*op_ptr).bytes * 8 as i32 as isize) as f64;
                     /* update the pcm offset. */
-                    if granulepos != -(1 as i32) as libc::c_long && (*op_ptr).e_o_s == 0 {
+                    if granulepos != -(1 as i32) as isize && (*op_ptr).e_o_s == 0 {
                         let mut link: i32 = if (*vf).seekable != 0 {
                             (*vf).current_link
                         } else {
@@ -1311,14 +1311,14 @@ unsafe extern "C" fn _fetch_and_process_packet(
                           shouldn't be possible
                           here unless the stream
                           is very broken */
-                        if granulepos < 0 as i32 as libc::c_long {
+                        if granulepos < 0 as i32 as isize {
                             granulepos = 0 as i32 as crate::config_types_h::ogg_int64_t
                         }
                         samples = crate::src::libvorbis_1_3_6::lib::block::vorbis_synthesis_pcmout(
                             &mut (*vf).vd as *mut _ as *mut crate::codec_h::vorbis_dsp_state,
                             0 as *mut *mut *mut f32,
                         ) << hs;
-                        granulepos -= samples as libc::c_long;
+                        granulepos -= samples as isize;
                         i = 0 as i32;
                         while i < link {
                             granulepos +=
@@ -1347,20 +1347,20 @@ unsafe extern "C" fn _fetch_and_process_packet(
                     &mut og,
                     -(1 as i32) as crate::config_types_h::ogg_int64_t,
                 );
-                if ret_0 < 0 as i32 as libc::c_long {
+                if ret_0 < 0 as i32 as isize {
                     return -(2 as i32);
                     /* eof. leave unitialized */
                 }
                 /* bitrate tracking; add the header's bytes here, the body bytes
                 are done by packet above */
-                (*vf).bittrack += (og.header_len * 8 as i32 as libc::c_long) as f64;
+                (*vf).bittrack += (og.header_len * 8 as i32 as isize) as f64;
                 if !((*vf).ready_state == 4 as i32) {
                     break;
                 }
                 if !((*vf).current_serialno
                     != crate::src::libogg_1_3_3::src::framing::ogg_page_serialno(
                         &mut og as *mut _ as *const crate::ogg_h::ogg_page,
-                    ) as libc::c_long)
+                    ) as isize)
                 {
                     break;
                 }
@@ -1405,10 +1405,10 @@ unsafe extern "C" fn _fetch_and_process_packet(
             let mut link_0: i32 = 0;
             if (*vf).ready_state < 3 as i32 {
                 if (*vf).seekable != 0 {
-                    let mut serialno: libc::c_long =
+                    let mut serialno: isize =
                         crate::src::libogg_1_3_3::src::framing::ogg_page_serialno(
                             &mut og as *mut _ as *const crate::ogg_h::ogg_page,
-                        ) as libc::c_long;
+                        ) as isize;
                     /* match the serialno to bitstream section.  We use this rather than
                     offset positions to avoid problems near logical bitstream
                     boundaries */
@@ -1438,7 +1438,7 @@ unsafe extern "C" fn _fetch_and_process_packet(
                         vf,
                         (*vf).vi,
                         (*vf).vc,
-                        0 as *mut *mut libc::c_long,
+                        0 as *mut *mut isize,
                         0 as *mut i32,
                         &mut og,
                     );
@@ -1477,7 +1477,7 @@ unsafe extern "C" fn _ov_open1(
     mut f: *mut libc::c_void,
     mut vf: *mut crate::src::libvorbis_1_3_6::lib::vorbisfile::OggVorbis_File,
     mut initial: *const libc::c_char,
-    mut ibytes: libc::c_long,
+    mut ibytes: isize,
     mut callbacks: crate::src::libvorbis_1_3_6::lib::vorbisfile::ov_callbacks,
 ) -> i32 {
     let mut offsettest: i32 = if !f.is_null() && callbacks.seek_func.is_some() {
@@ -1489,7 +1489,7 @@ unsafe extern "C" fn _ov_open1(
     } else {
         -(1 as i32)
     };
-    let mut serialno_list: *mut libc::c_long = 0 as *mut libc::c_long;
+    let mut serialno_list: *mut isize = 0 as *mut isize;
     let mut serialno_list_size: i32 = 0 as i32;
     let mut ret: i32 = 0;
     crate::stdlib::memset(
@@ -1561,16 +1561,16 @@ unsafe extern "C" fn _ov_open1(
         seek/reread first link's serialnumber data then. */
         (*vf).serialnos = crate::stdlib::calloc(
             (serialno_list_size + 2 as i32) as libc::c_ulong,
-            ::std::mem::size_of::<libc::c_long>() as libc::c_ulong,
-        ) as *mut libc::c_long;
+            ::std::mem::size_of::<isize>() as libc::c_ulong,
+        ) as *mut isize;
         (*vf).current_serialno = (*vf).os.serialno;
         *(*vf).serialnos.offset(0 as i32 as isize) = (*vf).current_serialno;
-        *(*vf).serialnos.offset(1 as i32 as isize) = serialno_list_size as libc::c_long;
+        *(*vf).serialnos.offset(1 as i32 as isize) = serialno_list_size as isize;
         crate::stdlib::memcpy(
             (*vf).serialnos.offset(2 as i32 as isize) as *mut libc::c_void,
             serialno_list as *const libc::c_void,
             (serialno_list_size as libc::c_ulong)
-                .wrapping_mul(::std::mem::size_of::<libc::c_long>() as libc::c_ulong),
+                .wrapping_mul(::std::mem::size_of::<isize>() as libc::c_ulong),
         );
         (*vf).offsets = crate::stdlib::calloc(
             1 as i32 as libc::c_ulong,
@@ -1683,7 +1683,7 @@ pub unsafe extern "C" fn ov_open_callbacks(
     mut f: *mut libc::c_void,
     mut vf: *mut crate::src::libvorbis_1_3_6::lib::vorbisfile::OggVorbis_File,
     mut initial: *const libc::c_char,
-    mut ibytes: libc::c_long,
+    mut ibytes: isize,
     mut callbacks: crate::src::libvorbis_1_3_6::lib::vorbisfile::ov_callbacks,
 ) -> i32 {
     let mut ret: i32 = _ov_open1(f, vf, initial, ibytes, callbacks);
@@ -1698,7 +1698,7 @@ pub unsafe extern "C" fn ov_open(
     mut f: *mut crate::stdlib::FILE,
     mut vf: *mut crate::src::libvorbis_1_3_6::lib::vorbisfile::OggVorbis_File,
     mut initial: *const libc::c_char,
-    mut ibytes: libc::c_long,
+    mut ibytes: isize,
 ) -> i32 {
     let mut callbacks: crate::src::libvorbis_1_3_6::lib::vorbisfile::ov_callbacks = {
         let mut init = crate::src::libvorbis_1_3_6::lib::vorbisfile::ov_callbacks {
@@ -1758,11 +1758,11 @@ pub unsafe extern "C" fn ov_open(
                 crate::stdlib::fclose as unsafe extern "C" fn(_: *mut crate::stdlib::FILE) -> i32,
             )),
             tell_func: ::std::mem::transmute::<
-                Option<unsafe extern "C" fn(_: *mut crate::stdlib::FILE) -> libc::c_long>,
-                Option<unsafe extern "C" fn(_: *mut libc::c_void) -> libc::c_long>,
+                Option<unsafe extern "C" fn(_: *mut crate::stdlib::FILE) -> isize>,
+                Option<unsafe extern "C" fn(_: *mut libc::c_void) -> isize>,
             >(Some(
                 crate::stdlib::ftell
-                    as unsafe extern "C" fn(_: *mut crate::stdlib::FILE) -> libc::c_long,
+                    as unsafe extern "C" fn(_: *mut crate::stdlib::FILE) -> isize,
             )),
         };
         init
@@ -1781,7 +1781,7 @@ pub unsafe extern "C" fn ov_fopen(
     if f.is_null() {
         return -(1 as i32);
     }
-    ret = ov_open(f, vf, 0 as *const libc::c_char, 0 as i32 as libc::c_long);
+    ret = ov_open(f, vf, 0 as *const libc::c_char, 0 as i32 as isize);
     if ret != 0 {
         crate::stdlib::fclose(f);
     }
@@ -1809,7 +1809,7 @@ pub unsafe extern "C" fn ov_halfrate(
             &mut (*vf).vb as *mut _ as *mut crate::codec_h::vorbis_block,
         );
         (*vf).ready_state = 3 as i32;
-        if (*vf).pcm_offset >= 0 as i32 as libc::c_long {
+        if (*vf).pcm_offset >= 0 as i32 as isize {
             let mut pos: crate::config_types_h::ogg_int64_t = (*vf).pcm_offset;
             (*vf).pcm_offset = -(1 as i32) as crate::config_types_h::ogg_int64_t;
             ov_pcm_seek(vf, pos);
@@ -1857,7 +1857,7 @@ pub unsafe extern "C" fn ov_test_callbacks(
     mut f: *mut libc::c_void,
     mut vf: *mut crate::src::libvorbis_1_3_6::lib::vorbisfile::OggVorbis_File,
     mut initial: *const libc::c_char,
-    mut ibytes: libc::c_long,
+    mut ibytes: isize,
     mut callbacks: crate::src::libvorbis_1_3_6::lib::vorbisfile::ov_callbacks,
 ) -> i32 {
     return _ov_open1(f, vf, initial, ibytes, callbacks);
@@ -1868,7 +1868,7 @@ pub unsafe extern "C" fn ov_test(
     mut f: *mut crate::stdlib::FILE,
     mut vf: *mut crate::src::libvorbis_1_3_6::lib::vorbisfile::OggVorbis_File,
     mut initial: *const libc::c_char,
-    mut ibytes: libc::c_long,
+    mut ibytes: isize,
 ) -> i32 {
     let mut callbacks: crate::src::libvorbis_1_3_6::lib::vorbisfile::ov_callbacks = {
         let mut init = crate::src::libvorbis_1_3_6::lib::vorbisfile::ov_callbacks {
@@ -1928,11 +1928,11 @@ pub unsafe extern "C" fn ov_test(
                 crate::stdlib::fclose as unsafe extern "C" fn(_: *mut crate::stdlib::FILE) -> i32,
             )),
             tell_func: ::std::mem::transmute::<
-                Option<unsafe extern "C" fn(_: *mut crate::stdlib::FILE) -> libc::c_long>,
-                Option<unsafe extern "C" fn(_: *mut libc::c_void) -> libc::c_long>,
+                Option<unsafe extern "C" fn(_: *mut crate::stdlib::FILE) -> isize>,
+                Option<unsafe extern "C" fn(_: *mut libc::c_void) -> isize>,
             >(Some(
                 crate::stdlib::ftell
-                    as unsafe extern "C" fn(_: *mut crate::stdlib::FILE) -> libc::c_long,
+                    as unsafe extern "C" fn(_: *mut crate::stdlib::FILE) -> isize,
             )),
         };
         init
@@ -1954,16 +1954,16 @@ pub unsafe extern "C" fn ov_test_open(
 
 pub unsafe extern "C" fn ov_streams(
     mut vf: *mut crate::src::libvorbis_1_3_6::lib::vorbisfile::OggVorbis_File,
-) -> libc::c_long {
-    return (*vf).links as libc::c_long;
+) -> isize {
+    return (*vf).links as isize;
 }
 /* Is the FILE * associated with vf seekable? */
 #[no_mangle]
 
 pub unsafe extern "C" fn ov_seekable(
     mut vf: *mut crate::src::libvorbis_1_3_6::lib::vorbisfile::OggVorbis_File,
-) -> libc::c_long {
-    return (*vf).seekable as libc::c_long;
+) -> isize {
+    return (*vf).seekable as isize;
 }
 /* returns the bitrate for a given logical bitstream or the entire
 physical bitstream.  If the file is open for random access, it will
@@ -1978,12 +1978,12 @@ vorbis_info structs */
 pub unsafe extern "C" fn ov_bitrate(
     mut vf: *mut crate::src::libvorbis_1_3_6::lib::vorbisfile::OggVorbis_File,
     mut i: i32,
-) -> libc::c_long {
+) -> isize {
     if (*vf).ready_state < 2 as i32 {
-        return -(131 as i32) as libc::c_long;
+        return -(131 as i32) as isize;
     }
     if i >= (*vf).links {
-        return -(131 as i32) as libc::c_long;
+        return -(131 as i32) as isize;
     }
     if (*vf).seekable == 0 && i != 0 as i32 {
         return ov_bitrate(vf, 0 as i32);
@@ -1997,7 +1997,7 @@ pub unsafe extern "C" fn ov_bitrate(
         while i_0 < (*vf).links {
             bits += (*(*vf).offsets.offset((i_0 + 1 as i32) as isize)
                 - *(*vf).dataoffsets.offset(i_0 as isize))
-                * 8 as i32 as libc::c_long;
+                * 8 as i32 as isize;
             i_0 += 1
         }
         /* This once read: return(rint(bits/ov_time_total(vf,-1)));
@@ -2005,28 +2005,28 @@ pub unsafe extern "C" fn ov_bitrate(
          * so this is slightly transformed to make it work.
          */
         br = (bits as f64 / ov_time_total(vf, -(1 as i32))) as f32;
-        return crate::stdlib::rint(br as f64) as libc::c_long;
+        return crate::stdlib::rint(br as f64) as isize;
     } else if (*vf).seekable != 0 {
         /* return the actual bitrate */
         return crate::stdlib::rint(
             ((*(*vf).offsets.offset((i + 1 as i32) as isize)
                 - *(*vf).dataoffsets.offset(i as isize))
-                * 8 as i32 as libc::c_long) as f64
+                * 8 as i32 as isize) as f64
                 / ov_time_total(vf, i),
-        ) as libc::c_long;
-    } else if (*(*vf).vi.offset(i as isize)).bitrate_nominal > 0 as i32 as libc::c_long {
+        ) as isize;
+    } else if (*(*vf).vi.offset(i as isize)).bitrate_nominal > 0 as i32 as isize {
         return (*(*vf).vi.offset(i as isize)).bitrate_nominal;
     } else {
-        if (*(*vf).vi.offset(i as isize)).bitrate_upper > 0 as i32 as libc::c_long {
-            if (*(*vf).vi.offset(i as isize)).bitrate_lower > 0 as i32 as libc::c_long {
+        if (*(*vf).vi.offset(i as isize)).bitrate_upper > 0 as i32 as isize {
+            if (*(*vf).vi.offset(i as isize)).bitrate_lower > 0 as i32 as isize {
                 return ((*(*vf).vi.offset(i as isize)).bitrate_upper
                     + (*(*vf).vi.offset(i as isize)).bitrate_lower)
-                    / 2 as i32 as libc::c_long;
+                    / 2 as i32 as isize;
             } else {
                 return (*(*vf).vi.offset(i as isize)).bitrate_upper;
             }
         }
-        return -(1 as i32) as libc::c_long;
+        return -(1 as i32) as isize;
     };
 }
 /* return nominal if set */
@@ -2038,21 +2038,21 @@ pub unsafe extern "C" fn ov_bitrate(
 
 pub unsafe extern "C" fn ov_bitrate_instant(
     mut vf: *mut crate::src::libvorbis_1_3_6::lib::vorbisfile::OggVorbis_File,
-) -> libc::c_long {
+) -> isize {
     let mut link: i32 = if (*vf).seekable != 0 {
         (*vf).current_link
     } else {
         0 as i32
     };
-    let mut ret: libc::c_long = 0;
+    let mut ret: isize = 0;
     if (*vf).ready_state < 2 as i32 {
-        return -(131 as i32) as libc::c_long;
+        return -(131 as i32) as isize;
     }
     if (*vf).samptrack == 0 as i32 as f64 {
-        return -(1 as i32) as libc::c_long;
+        return -(1 as i32) as isize;
     }
     ret = ((*vf).bittrack / (*vf).samptrack * (*(*vf).vi.offset(link as isize)).rate as f64
-        + 0.5f64) as libc::c_long;
+        + 0.5f64) as isize;
     (*vf).bittrack = 0.0f32 as f64;
     (*vf).samptrack = 0.0f32 as f64;
     return ret;
@@ -2063,7 +2063,7 @@ pub unsafe extern "C" fn ov_bitrate_instant(
 pub unsafe extern "C" fn ov_serialnumber(
     mut vf: *mut crate::src::libvorbis_1_3_6::lib::vorbisfile::OggVorbis_File,
     mut i: i32,
-) -> libc::c_long {
+) -> isize {
     if i >= (*vf).links {
         return ov_serialnumber(vf, (*vf).links - 1 as i32);
     }
@@ -2208,7 +2208,7 @@ pub unsafe extern "C" fn ov_raw_seek(
     if (*vf).seekable == 0 {
         return -(138 as i32);
     }
-    if pos < 0 as i32 as libc::c_long || pos > (*vf).end {
+    if pos < 0 as i32 as isize || pos > (*vf).end {
         return -(131 as i32);
     }
     /* is the seek position outside our current link [if any]? */
@@ -2321,12 +2321,12 @@ pub unsafe extern "C" fn ov_raw_seek(
                         } else if lastblock != 0 {
                             accblock += lastblock + thisblock >> 2 as i32
                         }
-                        if op.granulepos != -(1 as i32) as libc::c_long {
+                        if op.granulepos != -(1 as i32) as isize {
                             let mut i: i32 = 0;
                             let mut link: i32 = (*vf).current_link;
                             let mut granulepos: crate::config_types_h::ogg_int64_t = op.granulepos
                                 - *(*vf).pcmlengths.offset((link * 2 as i32) as isize);
-                            if granulepos < 0 as i32 as libc::c_long {
+                            if granulepos < 0 as i32 as isize {
                                 granulepos = 0 as i32 as crate::config_types_h::ogg_int64_t
                             }
                             i = 0 as i32;
@@ -2335,8 +2335,8 @@ pub unsafe extern "C" fn ov_raw_seek(
                                     *(*vf).pcmlengths.offset((i * 2 as i32 + 1 as i32) as isize);
                                 i += 1
                             }
-                            (*vf).pcm_offset = granulepos - accblock as libc::c_long;
-                            if (*vf).pcm_offset < 0 as i32 as libc::c_long {
+                            (*vf).pcm_offset = granulepos - accblock as isize;
+                            if (*vf).pcm_offset < 0 as i32 as isize {
                                 (*vf).pcm_offset = 0 as i32 as crate::config_types_h::ogg_int64_t
                             }
                             break;
@@ -2358,7 +2358,7 @@ pub unsafe extern "C" fn ov_raw_seek(
                     &mut og,
                     -(1 as i32) as crate::config_types_h::ogg_int64_t,
                 );
-                if pagepos < 0 as i32 as libc::c_long {
+                if pagepos < 0 as i32 as isize {
                     (*vf).pcm_offset = ov_pcm_total(vf, -(1 as i32));
                     break;
                 } else {
@@ -2374,7 +2374,7 @@ pub unsafe extern "C" fn ov_raw_seek(
                         if (*vf).current_serialno
                             != crate::src::libogg_1_3_3::src::framing::ogg_page_serialno(
                                 &mut og as *mut _ as *const crate::ogg_h::ogg_page,
-                            ) as libc::c_long
+                            ) as isize
                         {
                             /* two possibilities:
                             1) our decoding just traversed a bitstream boundary
@@ -2396,10 +2396,10 @@ pub unsafe extern "C" fn ov_raw_seek(
                       trying */
                     if (*vf).ready_state < 3 as i32 {
                         let mut link_0: i32 = 0;
-                        let mut serialno: libc::c_long =
+                        let mut serialno: isize =
                             crate::src::libogg_1_3_3::src::framing::ogg_page_serialno(
                                 &mut og as *mut _ as *const crate::ogg_h::ogg_page,
-                            ) as libc::c_long;
+                            ) as isize;
                         link_0 = 0 as i32;
                         while link_0 < (*vf).links {
                             if *(*vf).serialnos.offset(link_0 as isize) == serialno {
@@ -2472,7 +2472,7 @@ pub unsafe extern "C" fn ov_pcm_seek_page(
     if (*vf).seekable == 0 {
         return -(138 as i32);
     }
-    if pos < 0 as i32 as libc::c_long || pos > total {
+    if pos < 0 as i32 as isize || pos > total {
         return -(131 as i32);
     }
     /* which bitstream section does this pcm offset occur in? */
@@ -2522,7 +2522,7 @@ pub unsafe extern "C" fn ov_pcm_seek_page(
             current_block = 11555952146732080064;
         } else {
             result = _get_next_page(vf, &mut og, 1 as i32 as crate::config_types_h::ogg_int64_t);
-            if result < 0 as i32 as libc::c_long {
+            if result < 0 as i32 as isize {
                 current_block = 11555952146732080064;
             } else {
                 got_page = 1 as i32;
@@ -2545,7 +2545,7 @@ pub unsafe extern "C" fn ov_pcm_seek_page(
             {
                 if begin < end {
                     let mut bisect: crate::config_types_h::ogg_int64_t = 0;
-                    if end - begin < 65536 as i32 as libc::c_long {
+                    if end - begin < 65536 as i32 as isize {
                         bisect = begin
                     } else {
                         /* take a (pretty decent) guess. */
@@ -2553,8 +2553,8 @@ pub unsafe extern "C" fn ov_pcm_seek_page(
                             + ((target - begintime) as f64 * (end - begin) as f64
                                 / (endtime - begintime) as f64)
                                 as crate::config_types_h::ogg_int64_t
-                            - 65536 as i32 as libc::c_long;
-                        if bisect < begin + 65536 as i32 as libc::c_long {
+                            - 65536 as i32 as isize;
+                        if bisect < begin + 65536 as i32 as isize {
                             bisect = begin
                         }
                     }
@@ -2571,27 +2571,27 @@ pub unsafe extern "C" fn ov_pcm_seek_page(
                             break;
                         }
                         result = _get_next_page(vf, &mut og, end - (*vf).offset);
-                        if result == -(128 as i32) as libc::c_long {
+                        if result == -(128 as i32) as isize {
                             current_block = 11555952146732080064;
                             break;
                         }
-                        if result < 0 as i32 as libc::c_long {
+                        if result < 0 as i32 as isize {
                             /* there is no next page! */
-                            if bisect <= begin + 1 as i32 as libc::c_long {
+                            if bisect <= begin + 1 as i32 as isize {
                                 /* No bisection left to perform.  We've either found the
                                 best candidate already or failed. Exit loop. */
                                 end = begin
                             } else {
                                 /* We tried to load a fraction of the last page; back up a
                                 bit and try to get the whole last page */
-                                if bisect == 0 as i32 as libc::c_long {
+                                if bisect == 0 as i32 as isize {
                                     current_block = 11555952146732080064;
                                     break;
                                 }
-                                bisect -= 65536 as i32 as libc::c_long;
+                                bisect -= 65536 as i32 as isize;
                                 /* don't repeat/loop on a read we've already performed */
                                 if bisect <= begin {
-                                    bisect = begin + 1 as i32 as libc::c_long
+                                    bisect = begin + 1 as i32 as isize
                                 }
                                 /* seek and cntinue bisection */
                                 result =
@@ -2608,7 +2608,7 @@ pub unsafe extern "C" fn ov_pcm_seek_page(
                             /* only consider pages from primary vorbis stream */
                             if crate::src::libogg_1_3_3::src::framing::ogg_page_serialno(
                                 &mut og as *mut _ as *const crate::ogg_h::ogg_page,
-                            ) as libc::c_long
+                            ) as isize
                                 != *(*vf).serialnos.offset(link as isize)
                             {
                                 continue;
@@ -2618,7 +2618,7 @@ pub unsafe extern "C" fn ov_pcm_seek_page(
                                 crate::src::libogg_1_3_3::src::framing::ogg_page_granulepos(
                                     &mut og as *mut _ as *const crate::ogg_h::ogg_page,
                                 );
-                            if granulepos == -(1 as i32) as libc::c_long {
+                            if granulepos == -(1 as i32) as isize {
                                 continue;
                             }
                             if granulepos < target {
@@ -2629,12 +2629,12 @@ pub unsafe extern "C" fn ov_pcm_seek_page(
                                 begintime = granulepos;
                                 /* if we're before our target but within a short distance,
                                 don't bisect; read forward */
-                                if target - begintime > 44100 as i32 as libc::c_long {
+                                if target - begintime > 44100 as i32 as isize {
                                     current_block = 11307063007268554308;
                                     break;
                                 }
                                 bisect = begin
-                            } else if bisect <= begin + 1 as i32 as libc::c_long {
+                            } else if bisect <= begin + 1 as i32 as isize {
                                 /* This is one of our pages, but the granpos is
                                 post-target; it is not a bisection return
                                 candidate. (The only way we'd use it is if it's the
@@ -2648,9 +2648,9 @@ pub unsafe extern "C" fn ov_pcm_seek_page(
                                 boundary (result) to update bisection, back up a
                                 little bit, and try again */
                                 end = result;
-                                bisect -= 65536 as i32 as libc::c_long;
+                                bisect -= 65536 as i32 as isize;
                                 if bisect <= begin {
-                                    bisect = begin + 1 as i32 as libc::c_long
+                                    bisect = begin + 1 as i32 as isize
                                 }
                                 result =
                                     _seek_helper(vf, bisect) as crate::config_types_h::ogg_int64_t;
@@ -2669,7 +2669,7 @@ pub unsafe extern "C" fn ov_pcm_seek_page(
                     }
                 } else {
                     /* Out of bisection: did it 'fail?' */
-                    if best == -(1 as i32) as libc::c_long {
+                    if best == -(1 as i32) as isize {
                         /* Check the 'looking for data in first page' special case;
                         bisection would 'fail' because our search target was before the
                         first PCM granule position fencepost. */
@@ -2677,7 +2677,7 @@ pub unsafe extern "C" fn ov_pcm_seek_page(
                             && begin == *(*vf).dataoffsets.offset(link as isize)
                             && crate::src::libogg_1_3_3::src::framing::ogg_page_serialno(
                                 &mut og as *mut _ as *const crate::ogg_h::ogg_page,
-                            ) as libc::c_long
+                            ) as isize
                                 == *(*vf).serialnos.offset(link as isize))
                         {
                             current_block = 11555952146732080064;
@@ -2735,7 +2735,7 @@ pub unsafe extern "C" fn ov_pcm_seek_page(
                             &mut og_0,
                             -(1 as i32) as crate::config_types_h::ogg_int64_t,
                         );
-                        if result < 0 as i32 as libc::c_long {
+                        if result < 0 as i32 as isize {
                             current_block = 11555952146732080064;
                             continue;
                         }
@@ -2766,7 +2766,7 @@ pub unsafe extern "C" fn ov_pcm_seek_page(
                                 &mut op as *mut _ as *mut crate::ogg_h::ogg_packet,
                             )
                                 as crate::config_types_h::ogg_int64_t;
-                            if result == 0 as i32 as libc::c_long {
+                            if result == 0 as i32 as isize {
                                 /* No packet returned; we exited the bisection with 'best'
                                 pointing to a page with a granule position, so the packet
                                 finishing this page ('best') originated on a preceding
@@ -2778,33 +2778,33 @@ pub unsafe extern "C" fn ov_pcm_seek_page(
                                 result = best;
                                 while result > *(*vf).dataoffsets.offset(link as isize) {
                                     result = _get_prev_page(vf, result, &mut og_0);
-                                    if result < 0 as i32 as libc::c_long {
+                                    if result < 0 as i32 as isize {
                                         current_block = 11555952146732080064;
                                         continue 's_118;
                                     }
                                     if crate::src::libogg_1_3_3::src::framing::ogg_page_serialno(&mut og_0 as *mut _ as *const crate::ogg_h::ogg_page) as
-                                               libc::c_long ==
+                                               isize ==
                                                (*vf).current_serialno &&
                                                (crate::src::libogg_1_3_3::src::framing::ogg_page_granulepos(&mut og_0 as *mut _ as *const crate::ogg_h::ogg_page)
                                                     >
                                                     -(1 as i32) as
-                                                        libc::c_long ||
+                                                        isize ||
                                                     crate::src::libogg_1_3_3::src::framing::ogg_page_continued(&mut og_0 as *mut _ as *const crate::ogg_h::ogg_page)
                                                         == 0) {
                                             return ov_raw_seek(vf, result)
                                         }
                                 }
                             }
-                            if result < 0 as i32 as libc::c_long {
+                            if result < 0 as i32 as isize {
                                 result = -(136 as i32) as crate::config_types_h::ogg_int64_t;
                                 current_block = 11555952146732080064;
                                 continue 's_118;
-                            } else if op.granulepos != -(1 as i32) as libc::c_long {
+                            } else if op.granulepos != -(1 as i32) as isize {
                                 (*vf).pcm_offset = op.granulepos
                                     - *(*vf)
                                         .pcmlengths
                                         .offset(((*vf).current_link * 2 as i32) as isize);
-                                if (*vf).pcm_offset < 0 as i32 as libc::c_long {
+                                if (*vf).pcm_offset < 0 as i32 as isize {
                                     (*vf).pcm_offset =
                                         0 as i32 as crate::config_types_h::ogg_int64_t
                                 }
@@ -2889,7 +2889,7 @@ pub unsafe extern "C" fn ov_pcm_seek(
             /* non audio packet */
             } else {
                 if lastblock != 0 {
-                    (*vf).pcm_offset += (lastblock + thisblock >> 2 as i32) as libc::c_long
+                    (*vf).pcm_offset += (lastblock + thisblock >> 2 as i32) as isize
                 }
                 if (*vf).pcm_offset
                     + (thisblock
@@ -2897,7 +2897,7 @@ pub unsafe extern "C" fn ov_pcm_seek(
                             (*vf).vi as *mut crate::codec_h::vorbis_info,
                             1 as i32,
                         )
-                        >> 2 as i32) as libc::c_long
+                        >> 2 as i32) as isize
                     >= pos
                 {
                     break;
@@ -2919,14 +2919,14 @@ pub unsafe extern "C" fn ov_pcm_seek(
                 );
                 /* end of logical stream case is hard, especially with exact
                 length positioning. */
-                if op.granulepos > -(1 as i32) as libc::c_long {
+                if op.granulepos > -(1 as i32) as isize {
                     let mut i: i32 = 0;
                     /* always believe the stream markers */
                     (*vf).pcm_offset = op.granulepos
                         - *(*vf)
                             .pcmlengths
                             .offset(((*vf).current_link * 2 as i32) as isize);
-                    if (*vf).pcm_offset < 0 as i32 as libc::c_long {
+                    if (*vf).pcm_offset < 0 as i32 as isize {
                         (*vf).pcm_offset = 0 as i32 as crate::config_types_h::ogg_int64_t
                     }
                     i = 0 as i32;
@@ -2947,7 +2947,7 @@ pub unsafe extern "C" fn ov_pcm_seek(
                 vf,
                 &mut og,
                 -(1 as i32) as crate::config_types_h::ogg_int64_t,
-            ) < 0 as i32 as libc::c_long
+            ) < 0 as i32 as isize
             {
                 break;
             }
@@ -2958,10 +2958,10 @@ pub unsafe extern "C" fn ov_pcm_seek(
                 _decode_clear(vf);
             }
             if (*vf).ready_state < 3 as i32 {
-                let mut serialno: libc::c_long =
+                let mut serialno: isize =
                     crate::src::libogg_1_3_3::src::framing::ogg_page_serialno(
                         &mut og as *mut _ as *const crate::ogg_h::ogg_page,
-                    ) as libc::c_long;
+                    ) as isize;
                 let mut link: i32 = 0;
                 link = 0 as i32;
                 while link < (*vf).links {
@@ -2977,7 +2977,7 @@ pub unsafe extern "C" fn ov_pcm_seek(
                 (*vf).ready_state = 3 as i32;
                 (*vf).current_serialno = crate::src::libogg_1_3_3::src::framing::ogg_page_serialno(
                     &mut og as *mut _ as *const crate::ogg_h::ogg_page,
-                ) as libc::c_long;
+                ) as isize;
                 crate::src::libogg_1_3_3::src::framing::ogg_stream_reset_serialno(
                     &mut (*vf).os as *mut _ as *mut crate::ogg_h::ogg_stream_state,
                     serialno as i32,
@@ -3005,11 +3005,11 @@ pub unsafe extern "C" fn ov_pcm_seek(
     );
     while (*vf).pcm_offset < pos >> hs << hs {
         let mut target: crate::config_types_h::ogg_int64_t = pos - (*vf).pcm_offset >> hs;
-        let mut samples: libc::c_long =
+        let mut samples: isize =
             crate::src::libvorbis_1_3_6::lib::block::vorbis_synthesis_pcmout(
                 &mut (*vf).vd as *mut _ as *mut crate::codec_h::vorbis_dsp_state,
                 0 as *mut *mut *mut f32,
-            ) as libc::c_long;
+            ) as isize;
         if samples > target {
             samples = target
         }
@@ -3282,28 +3282,28 @@ pub unsafe extern "C" fn ov_read_filter(
     mut filter: Option<
         unsafe extern "C" fn(
             _: *mut *mut f32,
-            _: libc::c_long,
-            _: libc::c_long,
+            _: isize,
+            _: isize,
             _: *mut libc::c_void,
         ) -> (),
     >,
     mut filter_param: *mut libc::c_void,
-) -> libc::c_long {
+) -> isize {
     let mut i: i32 = 0;
     let mut j: i32 = 0;
     let mut host_endian: i32 = host_is_big_endian();
     let mut hs: i32 = 0;
     let mut pcm: *mut *mut f32 = 0 as *mut *mut f32;
-    let mut samples: libc::c_long = 0;
+    let mut samples: isize = 0;
     if (*vf).ready_state < 2 as i32 {
-        return -(131 as i32) as libc::c_long;
+        return -(131 as i32) as isize;
     }
     loop {
         if (*vf).ready_state == 4 as i32 {
             samples = crate::src::libvorbis_1_3_6::lib::block::vorbis_synthesis_pcmout(
                 &mut (*vf).vd as *mut _ as *mut crate::codec_h::vorbis_dsp_state,
                 &mut pcm,
-            ) as libc::c_long;
+            ) as isize;
             if samples != 0 {
                 break;
             }
@@ -3312,22 +3312,22 @@ pub unsafe extern "C" fn ov_read_filter(
         let mut ret: i32 =
             _fetch_and_process_packet(vf, 0 as *mut crate::ogg_h::ogg_packet, 1 as i32, 1 as i32);
         if ret == -(2 as i32) {
-            return 0 as i32 as libc::c_long;
+            return 0 as i32 as isize;
         }
         if ret <= 0 as i32 {
-            return ret as libc::c_long;
+            return ret as isize;
         }
     }
-    if samples > 0 as i32 as libc::c_long {
+    if samples > 0 as i32 as isize {
         /* yay! proceed to pack data into the byte buffer */
-        let mut channels: libc::c_long = (*ov_info(vf, -(1 as i32))).channels as libc::c_long;
-        let mut bytespersample: libc::c_long = word as libc::c_long * channels;
+        let mut channels: isize = (*ov_info(vf, -(1 as i32))).channels as isize;
+        let mut bytespersample: isize = word as isize * channels;
         let mut fpu: crate::os_h::vorbis_fpu_control = 0;
-        if samples > length as libc::c_long / bytespersample {
-            samples = length as libc::c_long / bytespersample
+        if samples > length as isize / bytespersample {
+            samples = length as isize / bytespersample
         }
-        if samples <= 0 as i32 as libc::c_long {
-            return -(131 as i32) as libc::c_long;
+        if samples <= 0 as i32 as isize {
+            return -(131 as i32) as isize;
         }
         /* Here. */
         if filter.is_some() {
@@ -3339,9 +3339,9 @@ pub unsafe extern "C" fn ov_read_filter(
             let mut off: i32 = if sgned != 0 { 0 as i32 } else { 128 as i32 };
             vorbis_fpu_setround(&mut fpu);
             j = 0 as i32;
-            while (j as libc::c_long) < samples {
+            while (j as isize) < samples {
                 i = 0 as i32;
-                while (i as libc::c_long) < channels {
+                while (i as isize) < channels {
                     val = vorbis_ftoi(
                         (*(*pcm.offset(i as isize)).offset(j as isize) * 128.0f32) as f64,
                     );
@@ -3364,12 +3364,12 @@ pub unsafe extern "C" fn ov_read_filter(
                 if sgned != 0 {
                     vorbis_fpu_setround(&mut fpu);
                     i = 0 as i32;
-                    while (i as libc::c_long) < channels {
+                    while (i as isize) < channels {
                         /* It's faster in this order */
                         let mut src: *mut f32 = *pcm.offset(i as isize);
                         let mut dest: *mut i16 = (buffer as *mut i16).offset(i as isize);
                         j = 0 as i32;
-                        while (j as libc::c_long) < samples {
+                        while (j as isize) < samples {
                             val = vorbis_ftoi((*src.offset(j as isize) * 32768.0f32) as f64);
                             if val > 32767 as i32 {
                                 val = 32767 as i32
@@ -3386,11 +3386,11 @@ pub unsafe extern "C" fn ov_read_filter(
                 } else {
                     vorbis_fpu_setround(&mut fpu);
                     i = 0 as i32;
-                    while (i as libc::c_long) < channels {
+                    while (i as isize) < channels {
                         let mut src_0: *mut f32 = *pcm.offset(i as isize);
                         let mut dest_0: *mut i16 = (buffer as *mut i16).offset(i as isize);
                         j = 0 as i32;
-                        while (j as libc::c_long) < samples {
+                        while (j as isize) < samples {
                             val = vorbis_ftoi((*src_0.offset(j as isize) * 32768.0f32) as f64);
                             if val > 32767 as i32 {
                                 val = 32767 as i32
@@ -3408,9 +3408,9 @@ pub unsafe extern "C" fn ov_read_filter(
             } else if bigendianp != 0 {
                 vorbis_fpu_setround(&mut fpu);
                 j = 0 as i32;
-                while (j as libc::c_long) < samples {
+                while (j as isize) < samples {
                     i = 0 as i32;
-                    while (i as libc::c_long) < channels {
+                    while (i as isize) < channels {
                         val = vorbis_ftoi(
                             (*(*pcm.offset(i as isize)).offset(j as isize) * 32768.0f32) as f64,
                         );
@@ -3435,9 +3435,9 @@ pub unsafe extern "C" fn ov_read_filter(
                 let mut val_0: i32 = 0;
                 vorbis_fpu_setround(&mut fpu);
                 j = 0 as i32;
-                while (j as libc::c_long) < samples {
+                while (j as isize) < samples {
                     i = 0 as i32;
-                    while (i as libc::c_long) < channels {
+                    while (i as isize) < channels {
                         val_0 = vorbis_ftoi(
                             (*(*pcm.offset(i as isize)).offset(j as isize) * 32768.0f32) as f64,
                         );
@@ -3486,7 +3486,7 @@ pub unsafe extern "C" fn ov_read(
     mut word: i32,
     mut sgned: i32,
     mut bitstream: *mut i32,
-) -> libc::c_long {
+) -> isize {
     return ov_read_filter(
         vf,
         buffer,
@@ -3517,18 +3517,18 @@ pub unsafe extern "C" fn ov_read_float(
     mut pcm_channels: *mut *mut *mut f32,
     mut length: i32,
     mut bitstream: *mut i32,
-) -> libc::c_long {
+) -> isize {
     if (*vf).ready_state < 2 as i32 {
-        return -(131 as i32) as libc::c_long;
+        return -(131 as i32) as isize;
     }
     loop {
         if (*vf).ready_state == 4 as i32 {
             let mut pcm: *mut *mut f32 = 0 as *mut *mut f32;
-            let mut samples: libc::c_long =
+            let mut samples: isize =
                 crate::src::libvorbis_1_3_6::lib::block::vorbis_synthesis_pcmout(
                     &mut (*vf).vd as *mut _ as *mut crate::codec_h::vorbis_dsp_state,
                     &mut pcm,
-                ) as libc::c_long;
+                ) as isize;
             if samples != 0 {
                 let mut hs: i32 =
                     crate::src::libvorbis_1_3_6::lib::synthesis::vorbis_synthesis_halfrate_p(
@@ -3537,8 +3537,8 @@ pub unsafe extern "C" fn ov_read_float(
                 if !pcm_channels.is_null() {
                     *pcm_channels = pcm
                 }
-                if samples > length as libc::c_long {
-                    samples = length as libc::c_long
+                if samples > length as isize {
+                    samples = length as isize
                 }
                 crate::src::libvorbis_1_3_6::lib::block::vorbis_synthesis_read(
                     &mut (*vf).vd as *mut _ as *mut crate::codec_h::vorbis_dsp_state,
@@ -3555,10 +3555,10 @@ pub unsafe extern "C" fn ov_read_float(
         let mut ret: i32 =
             _fetch_and_process_packet(vf, 0 as *mut crate::ogg_h::ogg_packet, 1 as i32, 1 as i32);
         if ret == -(2 as i32) {
-            return 0 as i32 as libc::c_long;
+            return 0 as i32 as isize;
         }
         if ret <= 0 as i32 {
-            return ret as libc::c_long;
+            return ret as isize;
         }
     }
 }

--- a/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/window.rs
+++ b/quake3-rs/ioquake3/src/libvorbis_1_3_6/lib/window.rs
@@ -8236,7 +8236,7 @@ pub unsafe extern "C" fn _vorbis_window_get(mut n: i32) -> *const f32 {
 pub unsafe extern "C" fn _vorbis_apply_window(
     mut d: *mut f32,
     mut winno: *mut i32,
-    mut blocksizes: *mut libc::c_long,
+    mut blocksizes: *mut isize,
     mut lW: i32,
     mut W: i32,
     mut nW: i32,
@@ -8245,35 +8245,35 @@ pub unsafe extern "C" fn _vorbis_apply_window(
     nW = if W != 0 { nW } else { 0 as i32 };
     let mut windowLW: *const f32 = vwin[*winno.offset(lW as isize) as usize];
     let mut windowNW: *const f32 = vwin[*winno.offset(nW as isize) as usize];
-    let mut n: libc::c_long = *blocksizes.offset(W as isize);
-    let mut ln: libc::c_long = *blocksizes.offset(lW as isize);
-    let mut rn: libc::c_long = *blocksizes.offset(nW as isize);
-    let mut leftbegin: libc::c_long = n / 4 as i32 as libc::c_long - ln / 4 as i32 as libc::c_long;
-    let mut leftend: libc::c_long = leftbegin + ln / 2 as i32 as libc::c_long;
-    let mut rightbegin: libc::c_long =
-        n / 2 as i32 as libc::c_long + n / 4 as i32 as libc::c_long - rn / 4 as i32 as libc::c_long;
-    let mut rightend: libc::c_long = rightbegin + rn / 2 as i32 as libc::c_long;
+    let mut n: isize = *blocksizes.offset(W as isize);
+    let mut ln: isize = *blocksizes.offset(lW as isize);
+    let mut rn: isize = *blocksizes.offset(nW as isize);
+    let mut leftbegin: isize = n / 4 as i32 as isize - ln / 4 as i32 as isize;
+    let mut leftend: isize = leftbegin + ln / 2 as i32 as isize;
+    let mut rightbegin: isize =
+        n / 2 as i32 as isize + n / 4 as i32 as isize - rn / 4 as i32 as isize;
+    let mut rightend: isize = rightbegin + rn / 2 as i32 as isize;
     let mut i: i32 = 0;
     let mut p: i32 = 0;
     i = 0 as i32;
-    while (i as libc::c_long) < leftbegin {
+    while (i as isize) < leftbegin {
         *d.offset(i as isize) = 0.0f32;
         i += 1
     }
     p = 0 as i32;
-    while (i as libc::c_long) < leftend {
+    while (i as isize) < leftend {
         *d.offset(i as isize) *= *windowLW.offset(p as isize);
         i += 1;
         p += 1
     }
     i = rightbegin as i32;
-    p = (rn / 2 as i32 as libc::c_long - 1 as i32 as libc::c_long) as i32;
-    while (i as libc::c_long) < rightend {
+    p = (rn / 2 as i32 as isize - 1 as i32 as isize) as i32;
+    while (i as isize) < rightend {
         *d.offset(i as isize) *= *windowNW.offset(p as isize);
         i += 1;
         p -= 1
     }
-    while (i as libc::c_long) < n {
+    while (i as isize) < n {
         *d.offset(i as isize) = 0.0f32;
         i += 1
     }

--- a/quake3-rs/ioquake3/src/opus_1_2_1/celt/bands.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/celt/bands.rs
@@ -744,7 +744,7 @@ unsafe extern "C" fn stereo_merge(
             (N as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_norm>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long * Y.offset_from(X) as libc::c_long) as libc::c_ulong,
+                    (0 as i32 as isize * Y.offset_from(X) as isize) as libc::c_ulong,
                 ),
         );
         return;
@@ -954,7 +954,7 @@ unsafe extern "C" fn deinterleave_hadamard(
         (N as libc::c_ulong)
             .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_norm>() as libc::c_ulong)
             .wrapping_add(
-                (0 as i32 as libc::c_long * X.offset_from(tmp) as libc::c_long) as libc::c_ulong,
+                (0 as i32 as isize * X.offset_from(tmp) as isize) as libc::c_ulong,
             ),
     );
 }
@@ -1008,7 +1008,7 @@ unsafe extern "C" fn interleave_hadamard(
         (N as libc::c_ulong)
             .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_norm>() as libc::c_ulong)
             .wrapping_add(
-                (0 as i32 as libc::c_long * X.offset_from(tmp) as libc::c_long) as libc::c_ulong,
+                (0 as i32 as isize * X.offset_from(tmp) as isize) as libc::c_ulong,
             ),
     );
 }
@@ -1744,8 +1744,8 @@ unsafe extern "C" fn quant_band(
             (N as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_norm>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long
-                        * lowband_scratch.offset_from(lowband) as libc::c_long)
+                    (0 as i32 as isize
+                        * lowband_scratch.offset_from(lowband) as isize)
                         as libc::c_ulong,
                 ),
         );
@@ -2125,10 +2125,10 @@ unsafe extern "C" fn special_hybrid_folding(
         ((n2 - n1) as libc::c_ulong)
             .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_norm>() as libc::c_ulong)
             .wrapping_add(
-                (0 as i32 as libc::c_long
+                (0 as i32 as isize
                     * (&mut *norm.offset(n1 as isize) as *mut crate::arch_h::celt_norm)
                         .offset_from(&mut *norm.offset((2 as i32 * n1 - n2) as isize))
-                        as libc::c_long) as libc::c_ulong,
+                        as isize) as libc::c_ulong,
             ),
     );
     if dual_stereo != 0 {
@@ -2139,10 +2139,10 @@ unsafe extern "C" fn special_hybrid_folding(
             ((n2 - n1) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_norm>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long
+                    (0 as i32 as isize
                         * (&mut *norm2.offset(n1 as isize) as *mut crate::arch_h::celt_norm)
                             .offset_from(&mut *norm2.offset((2 as i32 * n1 - n2) as isize))
-                            as libc::c_long) as libc::c_ulong,
+                            as isize) as libc::c_ulong,
                 ),
         );
     };
@@ -2662,7 +2662,7 @@ pub unsafe extern "C" fn quant_all_bands(
                                 ::std::mem::size_of::<crate::arch_h::celt_norm>() as libc::c_ulong
                             )
                             .wrapping_add(
-                                (0 as i32 as libc::c_long * X_save.offset_from(X) as libc::c_long)
+                                (0 as i32 as isize * X_save.offset_from(X) as isize)
                                     as libc::c_ulong,
                             ),
                     );
@@ -2674,7 +2674,7 @@ pub unsafe extern "C" fn quant_all_bands(
                                 ::std::mem::size_of::<crate::arch_h::celt_norm>() as libc::c_ulong
                             )
                             .wrapping_add(
-                                (0 as i32 as libc::c_long * Y_save.offset_from(Y) as libc::c_long)
+                                (0 as i32 as isize * Y_save.offset_from(Y) as isize)
                                     as libc::c_ulong,
                             ),
                     );
@@ -2716,7 +2716,7 @@ pub unsafe extern "C" fn quant_all_bands(
                                 ::std::mem::size_of::<crate::arch_h::celt_norm>() as libc::c_ulong
                             )
                             .wrapping_add(
-                                (0 as i32 as libc::c_long * X_save2.offset_from(X) as libc::c_long)
+                                (0 as i32 as isize * X_save2.offset_from(X) as isize)
                                     as libc::c_ulong,
                             ),
                     );
@@ -2728,7 +2728,7 @@ pub unsafe extern "C" fn quant_all_bands(
                                 ::std::mem::size_of::<crate::arch_h::celt_norm>() as libc::c_ulong
                             )
                             .wrapping_add(
-                                (0 as i32 as libc::c_long * Y_save2.offset_from(Y) as libc::c_long)
+                                (0 as i32 as isize * Y_save2.offset_from(Y) as isize)
                                     as libc::c_ulong,
                             ),
                     );
@@ -2742,13 +2742,13 @@ pub unsafe extern "C" fn quant_all_bands(
                                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_norm>()
                                     as libc::c_ulong)
                                 .wrapping_add(
-                                    (0 as i32 as libc::c_long
+                                    (0 as i32 as isize
                                         * norm_save2.offset_from(
                                             norm.offset(
                                                 (M * *eBands.offset(i as isize) as i32) as isize,
                                             )
                                             .offset(-(norm_offset as isize)),
-                                        ) as libc::c_long)
+                                        ) as isize)
                                         as libc::c_ulong,
                                 ),
                         );
@@ -2763,9 +2763,9 @@ pub unsafe extern "C" fn quant_all_bands(
                         (save_bytes as libc::c_ulong)
                             .wrapping_mul(::std::mem::size_of::<u8>() as libc::c_ulong)
                             .wrapping_add(
-                                (0 as i32 as libc::c_long
+                                (0 as i32 as isize
                                     * bytes_save.as_mut_ptr().offset_from(bytes_buf)
-                                        as libc::c_long)
+                                        as isize)
                                     as libc::c_ulong,
                             ),
                     );
@@ -2780,7 +2780,7 @@ pub unsafe extern "C" fn quant_all_bands(
                                 ::std::mem::size_of::<crate::arch_h::celt_norm>() as libc::c_ulong
                             )
                             .wrapping_add(
-                                (0 as i32 as libc::c_long * X.offset_from(X_save) as libc::c_long)
+                                (0 as i32 as isize * X.offset_from(X_save) as isize)
                                     as libc::c_ulong,
                             ),
                     );
@@ -2792,7 +2792,7 @@ pub unsafe extern "C" fn quant_all_bands(
                                 ::std::mem::size_of::<crate::arch_h::celt_norm>() as libc::c_ulong
                             )
                             .wrapping_add(
-                                (0 as i32 as libc::c_long * Y.offset_from(Y_save) as libc::c_long)
+                                (0 as i32 as isize * Y.offset_from(Y_save) as isize)
                                     as libc::c_ulong,
                             ),
                     );
@@ -2836,8 +2836,8 @@ pub unsafe extern "C" fn quant_all_bands(
                                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_norm>()
                                     as libc::c_ulong)
                                 .wrapping_add(
-                                    (0 as i32 as libc::c_long
-                                        * X.offset_from(X_save2) as libc::c_long)
+                                    (0 as i32 as isize
+                                        * X.offset_from(X_save2) as isize)
                                         as libc::c_ulong,
                                 ),
                         );
@@ -2848,8 +2848,8 @@ pub unsafe extern "C" fn quant_all_bands(
                                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_norm>()
                                     as libc::c_ulong)
                                 .wrapping_add(
-                                    (0 as i32 as libc::c_long
-                                        * Y.offset_from(Y_save2) as libc::c_long)
+                                    (0 as i32 as isize
+                                        * Y.offset_from(Y_save2) as isize)
                                         as libc::c_ulong,
                                 ),
                         );
@@ -2863,7 +2863,7 @@ pub unsafe extern "C" fn quant_all_bands(
                                     .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_norm>()
                                         as libc::c_ulong)
                                     .wrapping_add(
-                                        (0 as i32 as libc::c_long
+                                        (0 as i32 as isize
                                             * norm
                                                 .offset(
                                                     (M * *eBands.offset(i as isize) as i32)
@@ -2871,7 +2871,7 @@ pub unsafe extern "C" fn quant_all_bands(
                                                 )
                                                 .offset(-(norm_offset as isize))
                                                 .offset_from(norm_save2)
-                                                as libc::c_long)
+                                                as isize)
                                             as libc::c_ulong,
                                     ),
                             );
@@ -2882,9 +2882,9 @@ pub unsafe extern "C" fn quant_all_bands(
                             (save_bytes as libc::c_ulong)
                                 .wrapping_mul(::std::mem::size_of::<u8>() as libc::c_ulong)
                                 .wrapping_add(
-                                    (0 as i32 as libc::c_long
+                                    (0 as i32 as isize
                                         * bytes_buf.offset_from(bytes_save.as_mut_ptr())
-                                            as libc::c_long)
+                                            as isize)
                                         as libc::c_ulong,
                                 ),
                         );

--- a/quake3-rs/ioquake3/src/opus_1_2_1/celt/celt.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/celt/celt.rs
@@ -137,7 +137,7 @@ pub unsafe extern "C" fn comb_filter(
                         ::std::mem::size_of::<crate::arch_h::opus_val32>() as libc::c_ulong
                     )
                     .wrapping_add(
-                        (0 as i32 as libc::c_long * y.offset_from(x) as libc::c_long)
+                        (0 as i32 as isize * y.offset_from(x) as isize)
                             as libc::c_ulong,
                     ),
             );
@@ -198,10 +198,10 @@ pub unsafe extern "C" fn comb_filter(
                         ::std::mem::size_of::<crate::arch_h::opus_val32>() as libc::c_ulong
                     )
                     .wrapping_add(
-                        (0 as i32 as libc::c_long
+                        (0 as i32 as isize
                             * y.offset(overlap as isize)
                                 .offset_from(x.offset(overlap as isize))
-                                as libc::c_long) as libc::c_ulong,
+                                as isize) as libc::c_ulong,
                     ),
             );
         }

--- a/quake3-rs/ioquake3/src/opus_1_2_1/celt/celt_decoder.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/celt/celt_decoder.rs
@@ -505,7 +505,7 @@ unsafe extern "C" fn celt_synthesis(
             (N as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_sig>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long * freq2.offset_from(freq) as libc::c_long)
+                    (0 as i32 as isize * freq2.offset_from(freq) as isize)
                         as libc::c_ulong,
                 ),
         );
@@ -870,10 +870,10 @@ unsafe extern "C" fn celt_decode_lost(mut st: *mut OpusCustomDecoder, mut N: i32
                 ((2048 as i32 - N + (overlap >> 1 as i32)) as libc::c_ulong)
                     .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_sig>() as libc::c_ulong)
                     .wrapping_add(
-                        (0 as i32 as libc::c_long
+                        (0 as i32 as isize
                             * decode_mem[c as usize]
                                 .offset_from(decode_mem[c as usize].offset(N as isize))
-                                as libc::c_long) as libc::c_ulong,
+                                as isize) as libc::c_ulong,
                     ),
             );
             c += 1;
@@ -1022,8 +1022,8 @@ unsafe extern "C" fn celt_decode_lost(mut st: *mut OpusCustomDecoder, mut N: i32
                 ((2048 as i32 - N) as libc::c_ulong)
                     .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_sig>() as libc::c_ulong)
                     .wrapping_add(
-                        (0 as i32 as libc::c_long
-                            * buf.offset_from(buf.offset(N as isize)) as libc::c_long)
+                        (0 as i32 as isize
+                            * buf.offset_from(buf.offset(N as isize)) as isize)
                             as libc::c_ulong,
                     ),
             );
@@ -1609,10 +1609,10 @@ pub unsafe extern "C" fn celt_decode_with_ec(
             ((2048 as i32 - N + overlap / 2 as i32) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_sig>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long
+                    (0 as i32 as isize
                         * decode_mem[c as usize]
                             .offset_from(decode_mem[c as usize].offset(N as isize))
-                            as libc::c_long) as libc::c_ulong,
+                            as isize) as libc::c_ulong,
                 ),
         );
         c += 1;
@@ -1785,10 +1785,10 @@ pub unsafe extern "C" fn celt_decode_with_ec(
             (nbEBands as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long
+                    (0 as i32 as isize
                         * (&mut *oldBandE.offset(nbEBands as isize)
                             as *mut crate::arch_h::opus_val16)
-                            .offset_from(oldBandE) as libc::c_long)
+                            .offset_from(oldBandE) as isize)
                         as libc::c_ulong,
                 ),
         );
@@ -1802,7 +1802,7 @@ pub unsafe extern "C" fn celt_decode_with_ec(
             ((2 as i32 * nbEBands) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long * oldLogE2.offset_from(oldLogE) as libc::c_long)
+                    (0 as i32 as isize * oldLogE2.offset_from(oldLogE) as isize)
                         as libc::c_ulong,
                 ),
         );
@@ -1812,7 +1812,7 @@ pub unsafe extern "C" fn celt_decode_with_ec(
             ((2 as i32 * nbEBands) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long * oldLogE.offset_from(oldBandE) as libc::c_long)
+                    (0 as i32 as isize * oldLogE.offset_from(oldBandE) as isize)
                         as libc::c_ulong,
                 ),
         );
@@ -1980,9 +1980,9 @@ pub unsafe extern "C" fn opus_custom_decoder_ctl(
                 &mut (*st).rng as *mut crate::opus_types_h::opus_uint32 as *mut libc::c_char
                     as *mut libc::c_void,
                 0 as i32,
-                ((opus_custom_decoder_get_size((*st).mode, (*st).channels) as libc::c_long
+                ((opus_custom_decoder_get_size((*st).mode, (*st).channels) as isize
                     - (&mut (*st).rng as *mut crate::opus_types_h::opus_uint32 as *mut libc::c_char)
-                        .offset_from(st as *mut libc::c_char) as libc::c_long)
+                        .offset_from(st as *mut libc::c_char) as isize)
                     as libc::c_ulong)
                     .wrapping_mul(::std::mem::size_of::<libc::c_char>() as libc::c_ulong),
             );

--- a/quake3-rs/ioquake3/src/opus_1_2_1/celt/celt_encoder.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/celt/celt_encoder.rs
@@ -1083,11 +1083,11 @@ unsafe extern "C" fn tf_analysis(
             (N as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_norm>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long
+                    (0 as i32 as isize
                         * tmp.offset_from(&mut *X.offset(
                             (tf_chan * N0 + ((*(*m).eBands.offset(i as isize) as i32) << LM))
                                 as isize,
-                        )) as libc::c_long) as libc::c_ulong,
+                        )) as isize) as libc::c_ulong,
                 ),
         );
         L1 = l1_metric(tmp, N, if isTransient != 0 { LM } else { 0 as i32 }, bias);
@@ -1101,11 +1101,11 @@ unsafe extern "C" fn tf_analysis(
                                                                                          as
                                                                                          i32
                                                                                          as
-                                                                                         libc::c_long
+                                                                                         isize
                                                                                          *
                                                                                          tmp_1.offset_from(tmp)
                                                                                              as
-                                                                                             libc::c_long)
+                                                                                             isize)
                                                                                         as
                                                                                         libc::c_ulong));
             crate::src::opus_1_2_1::celt::bands::haar1(tmp_1, N >> LM, (1 as i32) << LM);
@@ -1957,10 +1957,10 @@ unsafe extern "C" fn run_prefilter(
             (1024 as i32 as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_sig>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long
+                    (0 as i32 as isize
                         * pre[c as usize]
                             .offset_from(prefilter_mem.offset((c * 1024 as i32) as isize))
-                            as libc::c_long) as libc::c_ulong,
+                            as isize) as libc::c_ulong,
                 ),
         );
         crate::stdlib::memcpy(
@@ -1970,11 +1970,11 @@ unsafe extern "C" fn run_prefilter(
             (N as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_sig>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long
+                    (0 as i32 as isize
                         * pre[c as usize].offset(1024 as i32 as isize).offset_from(
                             in_0.offset((c * (N + overlap)) as isize)
                                 .offset(overlap as isize),
-                        ) as libc::c_long) as libc::c_ulong,
+                        ) as isize) as libc::c_ulong,
                 ),
         );
         c += 1;
@@ -2098,11 +2098,11 @@ unsafe extern "C" fn run_prefilter(
             (overlap as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_sig>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long
+                    (0 as i32 as isize
                         * in_0
                             .offset((c * (N + overlap)) as isize)
                             .offset_from((*st).in_mem.as_mut_ptr().offset((c * overlap) as isize))
-                            as libc::c_long) as libc::c_ulong,
+                            as isize) as libc::c_ulong,
                 ),
         );
         if offset != 0 {
@@ -2146,14 +2146,14 @@ unsafe extern "C" fn run_prefilter(
             (overlap as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_sig>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long
+                    (0 as i32 as isize
                         * (*st)
                             .in_mem
                             .as_mut_ptr()
                             .offset((c * overlap) as isize)
                             .offset_from(
                                 in_0.offset((c * (N + overlap)) as isize).offset(N as isize),
-                            ) as libc::c_long) as libc::c_ulong,
+                            ) as isize) as libc::c_ulong,
                 ),
         );
         if N > 1024 as i32 {
@@ -2163,11 +2163,11 @@ unsafe extern "C" fn run_prefilter(
                 (1024 as i32 as libc::c_ulong)
                     .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_sig>() as libc::c_ulong)
                     .wrapping_add(
-                        (0 as i32 as libc::c_long
+                        (0 as i32 as isize
                             * prefilter_mem
                                 .offset((c * 1024 as i32) as isize)
                                 .offset_from(pre[c as usize].offset(N as isize))
-                                as libc::c_long) as libc::c_ulong,
+                                as isize) as libc::c_ulong,
                     ),
             );
         } else {
@@ -2179,14 +2179,14 @@ unsafe extern "C" fn run_prefilter(
                 ((1024 as i32 - N) as libc::c_ulong)
                     .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_sig>() as libc::c_ulong)
                     .wrapping_add(
-                        (0 as i32 as libc::c_long
+                        (0 as i32 as isize
                             * prefilter_mem
                                 .offset((c * 1024 as i32) as isize)
                                 .offset_from(
                                     prefilter_mem
                                         .offset((c * 1024 as i32) as isize)
                                         .offset(N as isize),
-                                ) as libc::c_long) as libc::c_ulong,
+                                ) as isize) as libc::c_ulong,
                     ),
             );
             crate::stdlib::memcpy(
@@ -2198,13 +2198,13 @@ unsafe extern "C" fn run_prefilter(
                 (N as libc::c_ulong)
                     .wrapping_mul(::std::mem::size_of::<crate::arch_h::celt_sig>() as libc::c_ulong)
                     .wrapping_add(
-                        (0 as i32 as libc::c_long
+                        (0 as i32 as isize
                             * prefilter_mem
                                 .offset((c * 1024 as i32) as isize)
                                 .offset(1024 as i32 as isize)
                                 .offset(-(N as isize))
                                 .offset_from(pre[c as usize].offset(1024 as i32 as isize))
-                                as libc::c_long) as libc::c_ulong,
+                                as isize) as libc::c_ulong,
                     ),
             );
         }
@@ -3119,7 +3119,7 @@ pub unsafe extern "C" fn celt_encode_with_ec(
             ((C * nbEBands) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long * bandLogE2.offset_from(bandLogE) as libc::c_long)
+                    (0 as i32 as isize * bandLogE2.offset_from(bandLogE) as isize)
                         as libc::c_ulong,
                 ),
         );
@@ -3942,10 +3942,10 @@ pub unsafe extern "C" fn celt_encode_with_ec(
             (nbEBands as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long
+                    (0 as i32 as isize
                         * (&mut *oldBandE.offset(nbEBands as isize)
                             as *mut crate::arch_h::opus_val16)
-                            .offset_from(oldBandE) as libc::c_long)
+                            .offset_from(oldBandE) as isize)
                         as libc::c_ulong,
                 ),
         );
@@ -3957,7 +3957,7 @@ pub unsafe extern "C" fn celt_encode_with_ec(
             ((CC * nbEBands) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long * oldLogE2.offset_from(oldLogE) as libc::c_long)
+                    (0 as i32 as isize * oldLogE2.offset_from(oldLogE) as isize)
                         as libc::c_ulong,
                 ),
         );
@@ -3967,7 +3967,7 @@ pub unsafe extern "C" fn celt_encode_with_ec(
             ((CC * nbEBands) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long * oldLogE.offset_from(oldBandE) as libc::c_long)
+                    (0 as i32 as isize * oldLogE.offset_from(oldBandE) as isize)
                         as libc::c_ulong,
                 ),
         );
@@ -4175,9 +4175,9 @@ pub unsafe extern "C" fn opus_custom_encoder_ctl(
                 &mut (*st).rng as *mut crate::opus_types_h::opus_uint32 as *mut libc::c_char
                     as *mut libc::c_void,
                 0 as i32,
-                ((opus_custom_encoder_get_size((*st).mode, (*st).channels) as libc::c_long
+                ((opus_custom_encoder_get_size((*st).mode, (*st).channels) as isize
                     - (&mut (*st).rng as *mut crate::opus_types_h::opus_uint32 as *mut libc::c_char)
-                        .offset_from(st as *mut libc::c_char) as libc::c_long)
+                        .offset_from(st as *mut libc::c_char) as isize)
                     as libc::c_ulong)
                     .wrapping_mul(::std::mem::size_of::<libc::c_char>() as libc::c_ulong),
             );
@@ -4214,10 +4214,10 @@ pub unsafe extern "C" fn opus_custom_encoder_ctl(
                             ::std::mem::size_of::<crate::celt_h::AnalysisInfo>() as libc::c_ulong
                         )
                         .wrapping_add(
-                            (0 as i32 as libc::c_long
+                            (0 as i32 as isize
                                 * (&mut (*st).analysis as *mut crate::celt_h::AnalysisInfo)
                                     .offset_from(info)
-                                    as libc::c_long) as libc::c_ulong,
+                                    as isize) as libc::c_ulong,
                         ),
                 );
             }
@@ -4235,10 +4235,10 @@ pub unsafe extern "C" fn opus_custom_encoder_ctl(
                             ::std::mem::size_of::<crate::celt_h::SILKInfo>() as libc::c_ulong
                         )
                         .wrapping_add(
-                            (0 as i32 as libc::c_long
+                            (0 as i32 as isize
                                 * (&mut (*st).silk_info as *mut crate::celt_h::SILKInfo)
                                     .offset_from(info_0)
-                                    as libc::c_long) as libc::c_ulong,
+                                    as isize) as libc::c_ulong,
                         ),
                 );
             }

--- a/quake3-rs/ioquake3/src/opus_1_2_1/celt/entenc.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/celt/entenc.rs
@@ -392,7 +392,7 @@ pub unsafe extern "C" fn ec_enc_shrink(
         ((*_this).end_offs as libc::c_ulong)
             .wrapping_mul(::std::mem::size_of::<u8>() as libc::c_ulong)
             .wrapping_add(
-                (0 as i32 as libc::c_long
+                (0 as i32 as isize
                     * (*_this)
                         .buf
                         .offset(_size as isize)
@@ -402,7 +402,7 @@ pub unsafe extern "C" fn ec_enc_shrink(
                                 .buf
                                 .offset((*_this).storage as isize)
                                 .offset(-((*_this).end_offs as isize)),
-                        ) as libc::c_long) as libc::c_ulong,
+                        ) as isize) as libc::c_ulong,
             ),
     );
     (*_this).storage = _size;

--- a/quake3-rs/ioquake3/src/opus_1_2_1/celt/quant_bands.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/celt/quant_bands.rs
@@ -801,7 +801,7 @@ pub unsafe extern "C" fn quant_coarse_energy(
         ((C * (*m).nbEBands) as libc::c_ulong)
             .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
             .wrapping_add(
-                (0 as i32 as libc::c_long * oldEBands_intra.offset_from(oldEBands) as libc::c_long)
+                (0 as i32 as isize * oldEBands_intra.offset_from(oldEBands) as isize)
                     as libc::c_ulong,
             ),
     );
@@ -871,7 +871,7 @@ pub unsafe extern "C" fn quant_coarse_energy(
             (nintra_bytes.wrapping_sub(nstart_bytes) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<u8>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long * intra_bits.offset_from(intra_buf) as libc::c_long)
+                    (0 as i32 as isize * intra_bits.offset_from(intra_buf) as isize)
                         as libc::c_ulong,
                 ),
         );
@@ -910,8 +910,8 @@ pub unsafe extern "C" fn quant_coarse_energy(
                 (nintra_bytes.wrapping_sub(nstart_bytes) as libc::c_ulong)
                     .wrapping_mul(::std::mem::size_of::<u8>() as libc::c_ulong)
                     .wrapping_add(
-                        (0 as i32 as libc::c_long
-                            * intra_buf.offset_from(intra_bits) as libc::c_long)
+                        (0 as i32 as isize
+                            * intra_buf.offset_from(intra_bits) as isize)
                             as libc::c_ulong,
                     ),
             );
@@ -923,8 +923,8 @@ pub unsafe extern "C" fn quant_coarse_energy(
                         ::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong
                     )
                     .wrapping_add(
-                        (0 as i32 as libc::c_long
-                            * oldEBands.offset_from(oldEBands_intra) as libc::c_long)
+                        (0 as i32 as isize
+                            * oldEBands.offset_from(oldEBands_intra) as isize)
                             as libc::c_ulong,
                     ),
             );
@@ -936,7 +936,7 @@ pub unsafe extern "C" fn quant_coarse_energy(
                         ::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong
                     )
                     .wrapping_add(
-                        (0 as i32 as libc::c_long * error.offset_from(error_intra) as libc::c_long)
+                        (0 as i32 as isize * error.offset_from(error_intra) as isize)
                             as libc::c_ulong,
                     ),
             );
@@ -949,8 +949,8 @@ pub unsafe extern "C" fn quant_coarse_energy(
             ((C * (*m).nbEBands) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long
-                        * oldEBands.offset_from(oldEBands_intra) as libc::c_long)
+                    (0 as i32 as isize
+                        * oldEBands.offset_from(oldEBands_intra) as isize)
                         as libc::c_ulong,
                 ),
         );
@@ -960,7 +960,7 @@ pub unsafe extern "C" fn quant_coarse_energy(
             ((C * (*m).nbEBands) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long * error.offset_from(error_intra) as libc::c_long)
+                    (0 as i32 as isize * error.offset_from(error_intra) as isize)
                         as libc::c_ulong,
                 ),
         );

--- a/quake3-rs/ioquake3/src/opus_1_2_1/celt/vq.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/celt/vq.rs
@@ -416,7 +416,7 @@ pub unsafe extern "C" fn op_pvq_search_c(
             since the condition is more often false than true and using
             a cmov introduces data dependencies across iterations. The optimal
             choice may be architecture-dependent. */
-            if (best_den * Rxy > Ryy * best_num) as i32 as libc::c_long != 0 {
+            if (best_den * Rxy > Ryy * best_num) as i32 as isize != 0 {
                 best_den = Ryy;
                 best_num = Rxy;
                 best_id = j

--- a/quake3-rs/ioquake3/src/opus_1_2_1/silk/A2NLSF.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/silk/A2NLSF.rs
@@ -189,7 +189,7 @@ unsafe extern "C" fn silk_A2NLSF_eval_poly(
     y32 = *p.offset(dd as isize);
     x_Q16 =
         ((x as crate::opus_types_h::opus_uint32) << 4 as i32) as crate::opus_types_h::opus_int32;
-    if (8 as i32 == dd) as i32 as libc::c_long != 0 {
+    if (8 as i32 == dd) as i32 as isize != 0 {
         y32 = (*p.offset(7 as i32 as isize) as i64 + (y32 as i64 * x_Q16 as i64 >> 16 as i32))
             as crate::opus_types_h::opus_int32;
         y32 = (*p.offset(6 as i32 as isize) as i64 + (y32 as i64 * x_Q16 as i64 >> 16 as i32))

--- a/quake3-rs/ioquake3/src/opus_1_2_1/silk/dec_API.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/silk/dec_API.rs
@@ -600,8 +600,8 @@ pub unsafe extern "C" fn silk_Decode(
                     ::std::mem::size_of::<crate::opus_types_h::opus_int16>() as libc::c_ulong
                 )
                 .wrapping_add(
-                    (0 as i32 as libc::c_long
-                        * samplesOut1_tmp_storage2.offset_from(samplesOut) as libc::c_long)
+                    (0 as i32 as isize
+                        * samplesOut1_tmp_storage2.offset_from(samplesOut) as isize)
                         as libc::c_ulong,
                 ),
         );

--- a/quake3-rs/ioquake3/src/opus_1_2_1/src/analysis.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/src/analysis.rs
@@ -731,7 +731,7 @@ unsafe extern "C" fn downmix_and_resample(
             (subframe as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val32>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long * y.offset_from(tmp) as libc::c_long)
+                    (0 as i32 as isize * y.offset_from(tmp) as isize)
                         as libc::c_ulong,
                 ),
         );
@@ -792,7 +792,7 @@ pub unsafe extern "C" fn tonality_analysis_reset(
         (::std::mem::size_of::<crate::src::opus_1_2_1::src::analysis::TonalityAnalysisState>()
             as libc::c_ulong)
             .wrapping_sub(
-                start.offset_from(tonal as *mut libc::c_char) as libc::c_long as libc::c_ulong,
+                start.offset_from(tonal as *mut libc::c_char) as isize as libc::c_ulong,
             )
             .wrapping_mul(::std::mem::size_of::<libc::c_char>() as libc::c_ulong),
     );
@@ -838,9 +838,9 @@ pub unsafe extern "C" fn tonality_get_info(
         (1 as i32 as libc::c_ulong)
             .wrapping_mul(::std::mem::size_of::<crate::celt_h::AnalysisInfo>() as libc::c_ulong)
             .wrapping_add(
-                (0 as i32 as libc::c_long
+                (0 as i32 as isize
                     * info_out.offset_from(&mut *(*tonal).info.as_mut_ptr().offset(pos as isize))
-                        as libc::c_long) as libc::c_ulong,
+                        as isize) as libc::c_ulong,
             ),
     );
     tonality_avg = (*info_out).tonality;
@@ -1089,14 +1089,14 @@ unsafe extern "C" fn tonality_analysis(
         (240 as i32 as libc::c_ulong)
             .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val32>() as libc::c_ulong)
             .wrapping_add(
-                (0 as i32 as libc::c_long
+                (0 as i32 as isize
                     * (*tonal).inmem.as_mut_ptr().offset_from(
                         (*tonal)
                             .inmem
                             .as_mut_ptr()
                             .offset(720 as i32 as isize)
                             .offset(-(240 as i32 as isize)),
-                    ) as libc::c_long) as libc::c_ulong,
+                    ) as isize) as libc::c_ulong,
             ),
     );
     remaining = len - (720 as i32 - (*tonal).mem_fill);

--- a/quake3-rs/ioquake3/src/opus_1_2_1/src/opus.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/src/opus.rs
@@ -464,7 +464,7 @@ pub unsafe extern "C" fn opus_packet_parse_impl(
         *size.offset((count - 1 as i32) as isize) = last_size as crate::opus_types_h::opus_int16
     }
     if !payload_offset.is_null() {
-        *payload_offset = data.offset_from(data0) as libc::c_long as i32
+        *payload_offset = data.offset_from(data0) as isize as i32
     }
     i = 0 as i32;
     while i < count {
@@ -477,7 +477,7 @@ pub unsafe extern "C" fn opus_packet_parse_impl(
     }
     if !packet_offset.is_null() {
         *packet_offset =
-            pad + data.offset_from(data0) as libc::c_long as crate::opus_types_h::opus_int32
+            pad + data.offset_from(data0) as isize as crate::opus_types_h::opus_int32
     }
     if !out_toc.is_null() {
         *out_toc = toc

--- a/quake3-rs/ioquake3/src/opus_1_2_1/src/opus_decoder.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/src/opus_decoder.rs
@@ -892,7 +892,7 @@ unsafe extern "C" fn opus_decode_frame(
             (&mut redundant_rng as *mut crate::opus_types_h::opus_uint32).offset(
                 (&mut redundant_rng as *mut crate::opus_types_h::opus_uint32)
                     .offset_from(&mut redundant_rng as *mut crate::opus_types_h::opus_uint32)
-                    as libc::c_long as isize,
+                    as isize as isize,
             ),
         );
     }
@@ -974,7 +974,7 @@ unsafe extern "C" fn opus_decode_frame(
                 .offset_from(
                     &mut celt_mode
                         as *mut *const crate::src::opus_1_2_1::celt::modes::OpusCustomMode,
-                ) as libc::c_long as isize,
+                ) as isize as isize,
         ),
     );
     window = (*celt_mode).window;
@@ -1002,7 +1002,7 @@ unsafe extern "C" fn opus_decode_frame(
             (&mut redundant_rng as *mut crate::opus_types_h::opus_uint32).offset(
                 (&mut redundant_rng as *mut crate::opus_types_h::opus_uint32)
                     .offset_from(&mut redundant_rng as *mut crate::opus_types_h::opus_uint32)
-                    as libc::c_long as isize,
+                    as isize as isize,
             ),
         );
         smooth_fade(
@@ -1448,7 +1448,7 @@ pub unsafe extern "C" fn opus_decoder_ctl(
                     .wrapping_sub(
                         (&mut (*st).stream_channels as *mut i32 as *mut libc::c_char)
                             .offset_from(st as *mut libc::c_char)
-                            as libc::c_long as libc::c_ulong,
+                            as isize as libc::c_ulong,
                     )
                     .wrapping_mul(::std::mem::size_of::<libc::c_char>() as libc::c_ulong),
             );
@@ -1483,7 +1483,7 @@ pub unsafe extern "C" fn opus_decoder_ctl(
                     crate::src::opus_1_2_1::celt::celt_decoder::opus_custom_decoder_ctl(
                         celt_dec,
                         4033 as i32,
-                        value_2.offset(value_2.offset_from(value_2) as libc::c_long as isize),
+                        value_2.offset(value_2.offset_from(value_2) as isize as isize),
                     );
                 } else {
                     *value_2 = (*st).DecControl.prevPitchLag
@@ -1547,7 +1547,7 @@ pub unsafe extern "C" fn opus_decoder_ctl(
                 crate::src::opus_1_2_1::celt::celt_decoder::opus_custom_decoder_ctl(
                     celt_dec,
                     4047 as i32,
-                    value_7.offset(value_7.offset_from(value_7) as libc::c_long as isize),
+                    value_7.offset(value_7.offset_from(value_7) as isize as isize),
                 );
                 current_block = 2116367355679836638;
             }

--- a/quake3-rs/ioquake3/src/opus_1_2_1/src/opus_encoder.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/src/opus_encoder.rs
@@ -1929,7 +1929,7 @@ pub unsafe extern "C" fn opus_encode_native(
                 .offset_from(
                     &mut celt_mode
                         as *mut *const crate::src::opus_1_2_1::celt::modes::OpusCustomMode,
-                ) as libc::c_long as isize,
+                ) as isize as isize,
         ),
     );
     analysis_info.valid = 0 as i32;
@@ -2543,12 +2543,12 @@ pub unsafe extern "C" fn opus_encode_native(
         ((total_buffer * (*st).channels) as libc::c_ulong)
             .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
             .wrapping_add(
-                (0 as i32 as libc::c_long
+                (0 as i32 as isize
                     * pcm_buf.offset_from(
                         &mut *(*st).delay_buffer.as_mut_ptr().offset(
                             (((*st).encoder_buffer - total_buffer) * (*st).channels) as isize,
                         ),
-                    ) as libc::c_long) as libc::c_ulong,
+                    ) as isize) as libc::c_ulong,
             ),
     );
     if (*st).mode == 1002 as i32 {
@@ -2980,11 +2980,11 @@ pub unsafe extern "C" fn opus_encode_native(
             (((*st).channels * (*st).Fs / 400 as i32) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long
+                    (0 as i32 as isize
                         * tmp_prefill.offset_from(&mut *(*st).delay_buffer.as_mut_ptr().offset(
                             (((*st).encoder_buffer - total_buffer - (*st).Fs / 400 as i32)
                                 * (*st).channels) as isize,
-                        )) as libc::c_long) as libc::c_ulong,
+                        )) as isize) as libc::c_ulong,
                 ),
         );
     }
@@ -3000,13 +3000,13 @@ pub unsafe extern "C" fn opus_encode_native(
                 as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long
+                    (0 as i32 as isize
                         * (*st).delay_buffer.as_mut_ptr().offset_from(
                             &mut *(*st)
                                 .delay_buffer
                                 .as_mut_ptr()
                                 .offset(((*st).channels * frame_size) as isize),
-                        ) as libc::c_long) as libc::c_ulong,
+                        ) as isize) as libc::c_ulong,
                 ),
         );
         crate::stdlib::memcpy(
@@ -3018,13 +3018,13 @@ pub unsafe extern "C" fn opus_encode_native(
             (((frame_size + total_buffer) * (*st).channels) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long
+                    (0 as i32 as isize
                         * (&mut *(*st).delay_buffer.as_mut_ptr().offset(
                             ((*st).channels * ((*st).encoder_buffer - frame_size - total_buffer))
                                 as isize,
                         ) as *mut crate::arch_h::opus_val16)
                             .offset_from(&mut *pcm_buf.offset(0 as i32 as isize))
-                            as libc::c_long) as libc::c_ulong,
+                            as isize) as libc::c_ulong,
                 ),
         );
     } else {
@@ -3036,14 +3036,14 @@ pub unsafe extern "C" fn opus_encode_native(
             (((*st).encoder_buffer * (*st).channels) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val16>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long
+                    (0 as i32 as isize
                         * (*st)
                             .delay_buffer
                             .as_mut_ptr()
                             .offset_from(&mut *pcm_buf.offset(
                                 ((frame_size + total_buffer - (*st).encoder_buffer)
                                     * (*st).channels) as isize,
-                            )) as libc::c_long) as libc::c_ulong,
+                            )) as isize) as libc::c_ulong,
                 ),
         );
     }
@@ -3194,7 +3194,7 @@ pub unsafe extern "C" fn opus_encode_native(
                 (&mut analysis_info as *mut crate::celt_h::AnalysisInfo).offset_from(
                     &mut analysis_info as *mut crate::celt_h::AnalysisInfo
                         as *const crate::celt_h::AnalysisInfo,
-                ) as libc::c_long as isize,
+                ) as isize as isize,
             ),
         );
     }
@@ -3211,7 +3211,7 @@ pub unsafe extern "C" fn opus_encode_native(
             (&mut info as *mut crate::celt_h::SILKInfo).offset(
                 (&mut info as *mut crate::celt_h::SILKInfo).offset_from(
                     &mut info as *mut crate::celt_h::SILKInfo as *const crate::celt_h::SILKInfo,
-                ) as libc::c_long as isize,
+                ) as isize as isize,
             ),
         );
     } else {
@@ -3222,7 +3222,7 @@ pub unsafe extern "C" fn opus_encode_native(
                 (0 as *mut libc::c_void as *mut crate::celt_h::SILKInfo).offset_from(
                     0 as *mut libc::c_void as *mut crate::celt_h::SILKInfo
                         as *const crate::celt_h::SILKInfo,
-                ) as libc::c_long as isize,
+                ) as isize as isize,
             ),
         );
     }
@@ -3262,7 +3262,7 @@ pub unsafe extern "C" fn opus_encode_native(
             (&mut redundant_rng as *mut crate::opus_types_h::opus_uint32).offset(
                 (&mut redundant_rng as *mut crate::opus_types_h::opus_uint32)
                     .offset_from(&mut redundant_rng as *mut crate::opus_types_h::opus_uint32)
-                    as libc::c_long as isize,
+                    as isize as isize,
             ),
         );
         crate::src::opus_1_2_1::celt::celt_encoder::opus_custom_encoder_ctl(celt_enc, 4028 as i32);
@@ -3337,11 +3337,11 @@ pub unsafe extern "C" fn opus_encode_native(
                     (redundancy_bytes as libc::c_ulong)
                         .wrapping_mul(::std::mem::size_of::<u8>() as libc::c_ulong)
                         .wrapping_add(
-                            (0 as i32 as libc::c_long
+                            (0 as i32 as isize
                                 * data
                                     .offset(ret as isize)
                                     .offset_from(data.offset(nb_compr_bytes as isize))
-                                    as libc::c_long) as libc::c_ulong,
+                                    as isize) as libc::c_ulong,
                         ),
                 );
                 nb_compr_bytes = nb_compr_bytes + redundancy_bytes
@@ -3413,7 +3413,7 @@ pub unsafe extern "C" fn opus_encode_native(
             (&mut redundant_rng as *mut crate::opus_types_h::opus_uint32).offset(
                 (&mut redundant_rng as *mut crate::opus_types_h::opus_uint32)
                     .offset_from(&mut redundant_rng as *mut crate::opus_types_h::opus_uint32)
-                    as libc::c_long as isize,
+                    as isize as isize,
             ),
         );
     }
@@ -4127,7 +4127,7 @@ pub unsafe extern "C" fn opus_encoder_ctl(
                 crate::src::opus_1_2_1::celt::celt_encoder::opus_custom_encoder_ctl(
                     celt_enc,
                     4047 as i32,
-                    value_35.offset(value_35.offset_from(value_35) as libc::c_long as isize),
+                    value_35.offset(value_35.offset_from(value_35) as isize as isize),
                 );
                 current_block = 12032176231992402880;
             }
@@ -4175,7 +4175,7 @@ pub unsafe extern "C" fn opus_encoder_ctl(
                 0 as i32,
                 (::std::mem::size_of::<OpusEncoder>() as libc::c_ulong)
                     .wrapping_sub(
-                        start.offset_from(st as *mut libc::c_char) as libc::c_long as libc::c_ulong
+                        start.offset_from(st as *mut libc::c_char) as isize as libc::c_ulong
                     )
                     .wrapping_mul(::std::mem::size_of::<libc::c_char>() as libc::c_ulong),
             );
@@ -4229,7 +4229,7 @@ pub unsafe extern "C" fn opus_encoder_ctl(
             ret = crate::src::opus_1_2_1::celt::celt_encoder::opus_custom_encoder_ctl(
                 celt_enc,
                 10026 as i32,
-                value_38.offset(value_38.offset_from(value_38) as libc::c_long as isize),
+                value_38.offset(value_38.offset_from(value_38) as isize as isize),
             );
             current_block = 12032176231992402880;
         }
@@ -4243,7 +4243,7 @@ pub unsafe extern "C" fn opus_encoder_ctl(
                 ret = crate::src::opus_1_2_1::celt::celt_encoder::opus_custom_encoder_ctl(
                     celt_enc,
                     10015 as i32,
-                    value_39.offset(value_39.offset_from(value_39) as libc::c_long as isize),
+                    value_39.offset(value_39.offset_from(value_39) as isize as isize),
                 );
                 current_block = 12032176231992402880;
             }

--- a/quake3-rs/ioquake3/src/opus_1_2_1/src/opus_multistream_decoder.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/src/opus_multistream_decoder.rs
@@ -450,7 +450,7 @@ unsafe extern "C" fn opus_multistream_decode_native(
         (&mut Fs as *mut crate::opus_types_h::opus_int32).offset(
             (&mut Fs as *mut crate::opus_types_h::opus_int32)
                 .offset_from(&mut Fs as *mut crate::opus_types_h::opus_int32)
-                as libc::c_long as isize,
+                as isize as isize,
         ),
     );
     frame_size = if frame_size < Fs / 25 as i32 * 3 as i32 {

--- a/quake3-rs/ioquake3/src/opus_1_2_1/src/opus_multistream_encoder.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/src/opus_multistream_encoder.rs
@@ -678,8 +678,8 @@ pub unsafe extern "C" fn surround_analysis(
             (overlap as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val32>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long
-                        * in_0.offset_from(mem.offset((c * overlap) as isize)) as libc::c_long)
+                    (0 as i32 as isize
+                        * in_0.offset_from(mem.offset((c * overlap) as isize)) as isize)
                         as libc::c_ulong,
                 ),
         );
@@ -835,11 +835,11 @@ pub unsafe extern "C" fn surround_analysis(
             (overlap as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::arch_h::opus_val32>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long
+                    (0 as i32 as isize
                         * mem
                             .offset((c * overlap) as isize)
                             .offset_from(in_0.offset(frame_size as isize))
-                            as libc::c_long) as libc::c_ulong,
+                            as isize) as libc::c_ulong,
                 ),
         );
         c += 1
@@ -1386,7 +1386,7 @@ unsafe extern "C" fn rate_allocation(
         (&mut Fs as *mut crate::opus_types_h::opus_int32).offset(
             (&mut Fs as *mut crate::opus_types_h::opus_int32)
                 .offset_from(&mut Fs as *mut crate::opus_types_h::opus_int32)
-                as libc::c_long as isize,
+                as isize as isize,
         ),
     );
     surround_rate_allocation(st, rate, frame_size, Fs);
@@ -1453,7 +1453,7 @@ unsafe extern "C" fn opus_multistream_encode_native(
         (&mut Fs as *mut crate::opus_types_h::opus_int32).offset(
             (&mut Fs as *mut crate::opus_types_h::opus_int32)
                 .offset_from(&mut Fs as *mut crate::opus_types_h::opus_int32)
-                as libc::c_long as isize,
+                as isize as isize,
         ),
     );
     crate::src::opus_1_2_1::src::opus_encoder::opus_encoder_ctl(
@@ -1462,7 +1462,7 @@ unsafe extern "C" fn opus_multistream_encode_native(
         (&mut vbr as *mut crate::opus_types_h::opus_int32).offset(
             (&mut vbr as *mut crate::opus_types_h::opus_int32)
                 .offset_from(&mut vbr as *mut crate::opus_types_h::opus_int32)
-                as libc::c_long as isize,
+                as isize as isize,
         ),
     );
     crate::src::opus_1_2_1::src::opus_encoder::opus_encoder_ctl(
@@ -1473,7 +1473,7 @@ unsafe extern "C" fn opus_multistream_encode_native(
                 .offset_from(
                     &mut celt_mode
                         as *mut *const crate::src::opus_1_2_1::celt::modes::OpusCustomMode,
-                ) as libc::c_long as isize,
+                ) as isize as isize,
         ),
     );
     frame_size = crate::src::opus_1_2_1::src::opus_encoder::frame_size_select(
@@ -1709,7 +1709,7 @@ unsafe extern "C" fn opus_multistream_encode_native(
                 enc_0,
                 10026 as i32,
                 bandLogE.as_mut_ptr().offset(
-                    bandLogE.as_mut_ptr().offset_from(bandLogE.as_mut_ptr()) as libc::c_long
+                    bandLogE.as_mut_ptr().offset_from(bandLogE.as_mut_ptr()) as isize
                         as isize,
                 ),
             );

--- a/quake3-rs/ioquake3/src/opus_1_2_1/src/repacketizer.rs
+++ b/quake3-rs/ioquake3/src/opus_1_2_1/src/repacketizer.rs
@@ -367,8 +367,8 @@ pub unsafe extern "C" fn opus_repacketizer_out_range_impl(
             (*len.offset(i as isize) as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<u8>() as libc::c_ulong)
                 .wrapping_add(
-                    (0 as i32 as libc::c_long
-                        * ptr.offset_from(*frames.offset(i as isize)) as libc::c_long)
+                    (0 as i32 as isize
+                        * ptr.offset_from(*frames.offset(i as isize)) as isize)
                         as libc::c_ulong,
                 ),
         );
@@ -446,11 +446,11 @@ pub unsafe extern "C" fn opus_packet_pad(
         (len as libc::c_ulong)
             .wrapping_mul(::std::mem::size_of::<u8>() as libc::c_ulong)
             .wrapping_add(
-                (0 as i32 as libc::c_long
+                (0 as i32 as isize
                     * data
                         .offset(new_len as isize)
                         .offset(-(len as isize))
-                        .offset_from(data) as libc::c_long) as libc::c_ulong,
+                        .offset_from(data) as isize) as libc::c_ulong,
             ),
     );
     ret = opus_repacketizer_cat(

--- a/quake3-rs/ioquake3/src/opusfile_0_9/src/http.rs
+++ b/quake3-rs/ioquake3/src/opusfile_0_9/src/http.rs
@@ -57,16 +57,16 @@ unsafe extern "C" fn op_string_range_dup(
 ) -> *mut libc::c_char {
     let mut len: crate::stddef_h::size_t = 0;
     let mut ret: *mut libc::c_char = 0 as *mut libc::c_char;
-    len = _end.offset_from(_start) as libc::c_long as crate::stddef_h::size_t;
+    len = _end.offset_from(_start) as isize as crate::stddef_h::size_t;
     /*This is to help avoid overflow elsewhere, later.*/
-    if (len >= 2147483647 as i32 as libc::c_ulong) as i32 as libc::c_long != 0 {
+    if (len >= 2147483647 as i32 as libc::c_ulong) as i32 as isize != 0 {
         return 0 as *mut libc::c_char;
     }
     ret = crate::stdlib::malloc(
         (::std::mem::size_of::<libc::c_char>() as libc::c_ulong)
             .wrapping_mul(len.wrapping_add(1 as i32 as libc::c_ulong)),
     ) as *mut libc::c_char;
-    if !ret.is_null() as i32 as libc::c_long != 0 {
+    if !ret.is_null() as i32 as isize != 0 {
         ret = crate::stdlib::memcpy(
             ret as *mut libc::c_void,
             _start as *const libc::c_void,
@@ -115,17 +115,17 @@ unsafe extern "C" fn op_validate_url_escapes(mut _s: *const libc::c_char) -> i32
             if (*(*crate::stdlib::__ctype_b_loc())
                 .offset(*_s.offset((i + 1 as i32) as isize) as i32 as isize) as i32
                 & crate::stdlib::_ISxdigit as i32 as u16 as i32
-                == 0) as i32 as libc::c_long
+                == 0) as i32 as isize
                 != 0
                 || (*(*crate::stdlib::__ctype_b_loc())
                     .offset(*_s.offset((i + 2 as i32) as isize) as i32 as isize)
                     as i32
                     & crate::stdlib::_ISxdigit as i32 as u16 as i32
-                    == 0) as i32 as libc::c_long
+                    == 0) as i32 as isize
                     != 0
                 || (*_s.offset((i + 1 as i32) as isize) as i32 == '0' as i32
                     && *_s.offset((i + 2 as i32) as isize) as i32 == '0' as i32)
-                    as i32 as libc::c_long
+                    as i32 as isize
                     != 0
             {
                 return -(1 as i32);
@@ -185,8 +185,8 @@ unsafe extern "C" fn op_parse_file_url(mut _src: *const libc::c_char) -> *const 
         b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-.\x00" as *const u8
             as *const libc::c_char,
     ) as isize);
-    if (*scheme_end as i32 != ':' as i32) as i32 as libc::c_long != 0
-        || scheme_end.offset_from(_src) as libc::c_long != 4 as i32 as libc::c_long
+    if (*scheme_end as i32 != ':' as i32) as i32 as isize != 0
+        || scheme_end.offset_from(_src) as isize != 4 as i32 as isize
         || crate::src::opusfile_0_9::src::internal::op_strncasecmp(
             _src,
             b"file\x00" as *const u8 as *const libc::c_char,
@@ -198,7 +198,7 @@ unsafe extern "C" fn op_parse_file_url(mut _src: *const libc::c_char) -> *const 
     }
     /*Make sure all escape sequences are valid to simplify unescaping later.*/
     if (op_validate_url_escapes(scheme_end.offset(1 as i32 as isize)) < 0 as i32) as i32
-        as libc::c_long
+        as isize
         != 0
     {
         return 0 as *const libc::c_char;
@@ -215,7 +215,7 @@ unsafe extern "C" fn op_parse_file_url(mut _src: *const libc::c_char) -> *const 
          understatement.*/
         host = scheme_end.offset(3 as i32 as isize);
         /*The empty host is what we expect.*/
-        if (*host as i32 == '/' as i32) as i32 as libc::c_long != 0 {
+        if (*host as i32 == '/' as i32) as i32 as isize != 0 {
             path = host
         } else {
             let mut host_end: *const libc::c_char = 0 as *const libc::c_char;
@@ -233,8 +233,8 @@ unsafe extern "C" fn op_parse_file_url(mut _src: *const libc::c_char) -> *const 
                 return 0 as *const libc::c_char;
             }
             /*An escaped "localhost" can take at most 27 characters.*/
-            if (host_end.offset_from(host) as libc::c_long > 27 as i32 as libc::c_long) as i32
-                as libc::c_long
+            if (host_end.offset_from(host) as isize > 27 as i32 as isize) as i32
+                as isize
                 != 0
             {
                 return 0 as *const libc::c_char;
@@ -243,9 +243,9 @@ unsafe extern "C" fn op_parse_file_url(mut _src: *const libc::c_char) -> *const 
                 host_buf.as_mut_ptr() as *mut libc::c_void,
                 host as *const libc::c_void,
                 (::std::mem::size_of::<libc::c_char>() as libc::c_ulong)
-                    .wrapping_mul(host_end.offset_from(host) as libc::c_long as libc::c_ulong),
+                    .wrapping_mul(host_end.offset_from(host) as isize as libc::c_ulong),
             );
-            host_buf[host_end.offset_from(host) as libc::c_long as usize] =
+            host_buf[host_end.offset_from(host) as isize as usize] =
                 '\u{0}' as i32 as libc::c_char;
             op_unescape_url_component(host_buf.as_mut_ptr());
             op_string_tolower(host_buf.as_mut_ptr());
@@ -253,7 +253,7 @@ unsafe extern "C" fn op_parse_file_url(mut _src: *const libc::c_char) -> *const 
             if (::libc::strcmp(
                 host_buf.as_mut_ptr(),
                 b"localhost\x00" as *const u8 as *const libc::c_char,
-            ) != 0 as i32) as i32 as libc::c_long
+            ) != 0 as i32) as i32 as isize
                 != 0
             {
                 return 0 as *const libc::c_char;
@@ -327,7 +327,7 @@ unsafe extern "C" fn op_url_stream_create_impl(
         let mut unescaped_path: *mut libc::c_char = 0 as *mut libc::c_char;
         let mut ret: *mut libc::c_void = 0 as *mut libc::c_void;
         unescaped_path = op_string_dup(path);
-        if unescaped_path.is_null() as i32 as libc::c_long != 0 {
+        if unescaped_path.is_null() as i32 as isize != 0 {
             return 0 as *mut libc::c_void;
         }
         ret = crate::src::opusfile_0_9::src::stream::op_fopen(
@@ -382,7 +382,7 @@ unsafe extern "C" fn op_url_stream_vcreate_impl(
             .as_va_list()
             .arg::<*mut libc::c_char>()
             .offset_from(0 as *mut libc::c_void as *mut libc::c_char)
-            as libc::c_long;
+            as isize;
         /*If we hit NULL, we're done processing options.*/
         if request == 0 {
             break;
@@ -518,7 +518,7 @@ pub unsafe extern "C" fn op_vopen_url(
         0 as *mut crate::src::opusfile_0_9::src::opusfile::OpusServerInfo;
     let mut source: *mut libc::c_void = 0 as *mut libc::c_void;
     source = op_url_stream_vcreate_impl(&mut cb, _url, &mut info, &mut pinfo, _ap.as_va_list());
-    if source.is_null() as i32 as libc::c_long != 0 {
+    if source.is_null() as i32 as isize != 0 {
         if !_error.is_null() {
             *_error = -(129 as i32)
         }
@@ -531,7 +531,7 @@ pub unsafe extern "C" fn op_vopen_url(
         0 as i32 as crate::stddef_h::size_t,
         _error,
     ) as *mut crate::internal_h::OggOpusFile;
-    if of.is_null() as i32 as libc::c_long != 0 {
+    if of.is_null() as i32 as isize != 0 {
         if !pinfo.is_null() {
             opus_server_info_clear(&mut info);
         }
@@ -587,7 +587,7 @@ pub unsafe extern "C" fn op_vtest_url(
         0 as *mut crate::src::opusfile_0_9::src::opusfile::OpusServerInfo;
     let mut source: *mut libc::c_void = 0 as *mut libc::c_void;
     source = op_url_stream_vcreate_impl(&mut cb, _url, &mut info, &mut pinfo, _ap.as_va_list());
-    if source.is_null() as i32 as libc::c_long != 0 {
+    if source.is_null() as i32 as isize != 0 {
         if !_error.is_null() {
             *_error = -(129 as i32)
         }
@@ -600,7 +600,7 @@ pub unsafe extern "C" fn op_vtest_url(
         0 as i32 as crate::stddef_h::size_t,
         _error,
     ) as *mut crate::internal_h::OggOpusFile;
-    if of.is_null() as i32 as libc::c_long != 0 {
+    if of.is_null() as i32 as isize != 0 {
         if !pinfo.is_null() {
             opus_server_info_clear(&mut info);
         }

--- a/quake3-rs/ioquake3/src/opusfile_0_9/src/info.rs
+++ b/quake3-rs/ioquake3/src/opusfile_0_9/src/info.rs
@@ -159,7 +159,7 @@ pub unsafe extern "C" fn opus_head_parse(
                 as *const libc::c_void,
             head.mapping.as_mut_ptr().offset_from(
                 &mut head as *mut crate::src::opusfile_0_9::src::opusfile::OpusHead as *mut u8,
-            ) as libc::c_long as libc::c_ulong,
+            ) as isize as libc::c_ulong,
         );
     }
     return 0 as i32;
@@ -209,7 +209,7 @@ unsafe extern "C" fn op_tags_ensure_capacity(
     let mut comment_lengths: *mut i32 = 0 as *mut i32;
     let mut cur_ncomments: i32 = 0;
     let mut size: crate::stddef_h::size_t = 0;
-    if (_ncomments >= 2147483647 as i32 as crate::stddef_h::size_t) as i32 as libc::c_long != 0 {
+    if (_ncomments >= 2147483647 as i32 as crate::stddef_h::size_t) as i32 as isize != 0 {
         return -(129 as i32);
     }
     size = (::std::mem::size_of::<i32>() as libc::c_ulong)
@@ -226,7 +226,7 @@ unsafe extern "C" fn op_tags_ensure_capacity(
     comment_lengths = (*_tags).comment_lengths;
     comment_lengths =
         crate::stdlib::realloc((*_tags).comment_lengths as *mut libc::c_void, size) as *mut i32;
-    if comment_lengths.is_null() as i32 as libc::c_long != 0 {
+    if comment_lengths.is_null() as i32 as isize != 0 {
         return -(129 as i32);
     }
     if (*_tags).comment_lengths.is_null() {
@@ -243,7 +243,7 @@ unsafe extern "C" fn op_tags_ensure_capacity(
     }
     user_comments = crate::stdlib::realloc((*_tags).user_comments as *mut libc::c_void, size)
         as *mut *mut libc::c_char;
-    if user_comments.is_null() as i32 as libc::c_long != 0 {
+    if user_comments.is_null() as i32 as isize != 0 {
         return -(129 as i32);
     }
     if (*_tags).user_comments.is_null() {
@@ -265,11 +265,11 @@ unsafe extern "C" fn op_strdup_with_len(
     let mut ret: *mut libc::c_char = 0 as *mut libc::c_char;
     size = (::std::mem::size_of::<libc::c_char>() as libc::c_ulong)
         .wrapping_mul(_len.wrapping_add(1 as i32 as libc::c_ulong));
-    if (size < _len) as i32 as libc::c_long != 0 {
+    if (size < _len) as i32 as isize != 0 {
         return 0 as *mut libc::c_char;
     }
     ret = crate::stdlib::malloc(size) as *mut libc::c_char;
-    if !ret.is_null() as i32 as libc::c_long != 0 {
+    if !ret.is_null() as i32 as isize != 0 {
         ret = crate::stdlib::memcpy(
             ret as *mut libc::c_void,
             _s as *const libc::c_void,
@@ -395,7 +395,7 @@ unsafe extern "C" fn opus_tags_parse_impl(
         if !_tags.is_null() {
             let ref mut fresh5 = *(*_tags).user_comments.offset(ncomments as isize);
             *fresh5 = crate::stdlib::malloc(len) as *mut libc::c_char;
-            if (*(*_tags).user_comments.offset(ncomments as isize)).is_null() as i32 as libc::c_long
+            if (*(*_tags).user_comments.offset(ncomments as isize)).is_null() as i32 as isize
                 != 0
             {
                 return -(129 as i32);
@@ -457,12 +457,12 @@ unsafe extern "C" fn opus_tags_copy_impl(
     let mut ci: i32 = 0;
     vendor = (*_src).vendor;
     (*_dst).vendor = op_strdup_with_len(vendor, crate::stdlib::strlen(vendor));
-    if (*_dst).vendor.is_null() as i32 as libc::c_long != 0 {
+    if (*_dst).vendor.is_null() as i32 as isize != 0 {
         return -(129 as i32);
     }
     ncomments = (*_src).comments;
     ret = op_tags_ensure_capacity(_dst, ncomments as crate::stddef_h::size_t);
-    if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+    if (ret < 0 as i32) as i32 as isize != 0 {
         return ret;
     }
     ci = 0 as i32;
@@ -474,7 +474,7 @@ unsafe extern "C" fn opus_tags_copy_impl(
             *(*_src).user_comments.offset(ci as isize),
             len as crate::stddef_h::size_t,
         );
-        if (*(*_dst).user_comments.offset(ci as isize)).is_null() as i32 as libc::c_long != 0 {
+        if (*(*_dst).user_comments.offset(ci as isize)).is_null() as i32 as isize != 0 {
             return -(129 as i32);
         }
         *(*_dst).comment_lengths.offset(ci as isize) = len;
@@ -487,7 +487,7 @@ unsafe extern "C" fn opus_tags_copy_impl(
         if len_0 > 0 as i32 {
             let ref mut fresh7 = *(*_dst).user_comments.offset(ncomments as isize);
             *fresh7 = crate::stdlib::malloc(len_0 as libc::c_ulong) as *mut libc::c_char;
-            if (*(*_dst).user_comments.offset(ncomments as isize)).is_null() as i32 as libc::c_long
+            if (*(*_dst).user_comments.offset(ncomments as isize)).is_null() as i32 as isize
                 != 0
             {
                 return -(129 as i32);
@@ -518,7 +518,7 @@ pub unsafe extern "C" fn opus_tags_copy(
     let mut ret: i32 = 0;
     opus_tags_init(&mut dst);
     ret = opus_tags_copy_impl(&mut dst, _src);
-    if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+    if (ret < 0 as i32) as i32 as isize != 0 {
         opus_tags_clear(&mut dst);
     } else {
         *_dst = dst
@@ -539,7 +539,7 @@ pub unsafe extern "C" fn opus_tags_add(
     let mut ret: i32 = 0;
     ncomments = (*_tags).comments;
     ret = op_tags_ensure_capacity(_tags, (ncomments + 1 as i32) as crate::stddef_h::size_t);
-    if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+    if (ret < 0 as i32) as i32 as isize != 0 {
         return ret;
     }
     tag_len = crate::stdlib::strlen(_tag);
@@ -560,7 +560,7 @@ pub unsafe extern "C" fn opus_tags_add(
                 .wrapping_add(2 as i32 as libc::c_ulong),
         ),
     ) as *mut libc::c_char;
-    if comment.is_null() as i32 as libc::c_long != 0 {
+    if comment.is_null() as i32 as isize != 0 {
         return -(129 as i32);
     }
     crate::stdlib::memcpy(
@@ -596,12 +596,12 @@ pub unsafe extern "C" fn opus_tags_add_comment(
     let mut ret: i32 = 0;
     ncomments = (*_tags).comments;
     ret = op_tags_ensure_capacity(_tags, (ncomments + 1 as i32) as crate::stddef_h::size_t);
-    if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+    if (ret < 0 as i32) as i32 as isize != 0 {
         return ret;
     }
     comment_len = crate::stdlib::strlen(_comment) as i32;
     comment = op_strdup_with_len(_comment, comment_len as crate::stddef_h::size_t);
-    if comment.is_null() as i32 as libc::c_long != 0 {
+    if comment.is_null() as i32 as isize != 0 {
         return -(129 as i32);
     }
     let ref mut fresh9 = *(*_tags).user_comments.offset(ncomments as isize);
@@ -628,14 +628,14 @@ pub unsafe extern "C" fn opus_tags_set_binary_suffix(
     }
     ncomments = (*_tags).comments;
     ret = op_tags_ensure_capacity(_tags, ncomments as crate::stddef_h::size_t);
-    if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+    if (ret < 0 as i32) as i32 as isize != 0 {
         return ret;
     }
     binary_suffix_data = crate::stdlib::realloc(
         *(*_tags).user_comments.offset(ncomments as isize) as *mut libc::c_void,
         _len as libc::c_ulong,
     ) as *mut u8;
-    if binary_suffix_data.is_null() as i32 as libc::c_long != 0 {
+    if binary_suffix_data.is_null() as i32 as isize != 0 {
         return -(129 as i32);
     }
     crate::stdlib::memcpy(
@@ -656,7 +656,7 @@ pub unsafe extern "C" fn opus_tagcompare(
 ) -> i32 {
     let mut tag_len: crate::stddef_h::size_t = 0;
     tag_len = crate::stdlib::strlen(_tag_name);
-    if (tag_len > 2147483647 as i32 as crate::stddef_h::size_t) as i32 as libc::c_long != 0 {
+    if (tag_len > 2147483647 as i32 as crate::stddef_h::size_t) as i32 as isize != 0 {
         return -(1 as i32);
     }
     return opus_tagncompare(_tag_name, tag_len as i32, _comment);
@@ -689,7 +689,7 @@ pub unsafe extern "C" fn opus_tags_query(
     let mut ncomments: i32 = 0;
     let mut ci: i32 = 0;
     tag_len = crate::stdlib::strlen(_tag);
-    if (tag_len > 2147483647 as i32 as crate::stddef_h::size_t) as i32 as libc::c_long != 0 {
+    if (tag_len > 2147483647 as i32 as crate::stddef_h::size_t) as i32 as isize != 0 {
         return 0 as *const libc::c_char;
     }
     ncomments = (*_tags).comments;
@@ -724,7 +724,7 @@ pub unsafe extern "C" fn opus_tags_query_count(
     let mut ncomments: i32 = 0;
     let mut ci: i32 = 0;
     tag_len = crate::stdlib::strlen(_tag);
-    if (tag_len > 2147483647 as i32 as crate::stddef_h::size_t) as i32 as libc::c_long != 0 {
+    if (tag_len > 2147483647 as i32 as crate::stddef_h::size_t) as i32 as isize != 0 {
         return 0 as i32;
     }
     ncomments = (*_tags).comments;

--- a/quake3-rs/ioquake3/src/opusfile_0_9/src/opusfile.rs
+++ b/quake3-rs/ioquake3/src/opusfile_0_9/src/opusfile.rs
@@ -202,8 +202,8 @@ pub unsafe extern "C" fn op_test(
     {
         return -(132 as i32);
     }
-    if (_initial_bytes > 9223372036854775807 as libc::c_long as crate::stddef_h::size_t) as i32
-        as libc::c_long
+    if (_initial_bytes > 9223372036854775807 as isize as crate::stddef_h::size_t) as i32
+        as isize
         != 0
     {
         return -(129 as i32);
@@ -213,7 +213,7 @@ pub unsafe extern "C" fn op_test(
     );
     data = crate::src::libogg_1_3_3::src::framing::ogg_sync_buffer(
         &mut oy as *mut _ as *mut crate::ogg_h::ogg_sync_state,
-        _initial_bytes as libc::c_long,
+        _initial_bytes as isize,
     );
     if !data.is_null() {
         let mut os: crate::ogg_h::ogg_stream_state = crate::ogg_h::ogg_stream_state {
@@ -250,7 +250,7 @@ pub unsafe extern "C" fn op_test(
         );
         crate::src::libogg_1_3_3::src::framing::ogg_sync_wrote(
             &mut oy as *mut _ as *mut crate::ogg_h::ogg_sync_state,
-            _initial_bytes as libc::c_long,
+            _initial_bytes as isize,
         );
         crate::src::libogg_1_3_3::src::framing::ogg_stream_init(
             &mut os as *mut _ as *mut crate::ogg_h::ogg_stream_state,
@@ -347,14 +347,14 @@ unsafe extern "C" fn op_get_data(
     let mut nbytes: i32 = 0;
     buffer = crate::src::libogg_1_3_3::src::framing::ogg_sync_buffer(
         &mut (*_of).oy as *mut _ as *mut crate::ogg_h::ogg_sync_state,
-        _nbytes as libc::c_long,
+        _nbytes as isize,
     ) as *mut u8;
     nbytes = Some((*_of).callbacks.read.expect("non-null function pointer"))
         .expect("non-null function pointer")((*_of).stream, buffer, _nbytes);
-    if (nbytes > 0 as i32) as i32 as libc::c_long != 0 {
+    if (nbytes > 0 as i32) as i32 as isize != 0 {
         crate::src::libogg_1_3_3::src::framing::ogg_sync_wrote(
             &mut (*_of).oy as *mut _ as *mut crate::ogg_h::ogg_sync_state,
-            nbytes as libc::c_long,
+            nbytes as isize,
         );
     }
     return nbytes;
@@ -413,7 +413,7 @@ unsafe extern "C" fn op_get_next_page(
             _og as *mut crate::ogg_h::ogg_page,
         ) as i32;
         /*Skipped (-more) bytes.*/
-        if (more < 0 as i32) as i32 as libc::c_long != 0 {
+        if (more < 0 as i32) as i32 as isize != 0 {
             (*_of).offset -= more as i64
         } else if more == 0 as i32 {
             let mut read_nbytes: i32 = 0;
@@ -437,14 +437,14 @@ unsafe extern "C" fn op_get_next_page(
                 } as i32
             }
             ret = op_get_data(_of, read_nbytes);
-            if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+            if (ret < 0 as i32) as i32 as isize != 0 {
                 return -(128 as i32) as i64;
             }
-            if (ret == 0 as i32) as i32 as libc::c_long != 0 {
+            if (ret == 0 as i32) as i32 as isize != 0 {
                 /*Only fail cleanly on EOF if we didn't have a known boundary.
                 Otherwise, we should have been able to reach that boundary, and this
                  is a fatal error.*/
-                return if (_boundary < 0 as i32 as i64) as i32 as libc::c_long != 0 {
+                return if (_boundary < 0 as i32 as i64) as i32 as isize != 0 {
                     -(1 as i32)
                 } else {
                     -(137 as i32)
@@ -480,13 +480,13 @@ unsafe extern "C" fn op_add_serialno(
     serialnos = *_serialnos;
     nserialnos = *_nserialnos;
     cserialnos = *_cserialnos;
-    if (nserialnos >= cserialnos) as i32 as libc::c_long != 0 {
+    if (nserialnos >= cserialnos) as i32 as isize != 0 {
         if (cserialnos
             > 2147483647 as i32
                 / ::std::mem::size_of::<crate::config_types_h::ogg_uint32_t>() as libc::c_ulong
                     as i32
                 - 1 as i32
-                >> 1 as i32) as i32 as libc::c_long
+                >> 1 as i32) as i32 as isize
             != 0
         {
             return -(129 as i32);
@@ -497,7 +497,7 @@ unsafe extern "C" fn op_add_serialno(
             (::std::mem::size_of::<crate::config_types_h::ogg_uint32_t>() as libc::c_ulong)
                 .wrapping_mul(cserialnos as libc::c_ulong),
         ) as *mut crate::config_types_h::ogg_uint32_t;
-        if serialnos.is_null() as i32 as libc::c_long != 0 {
+        if serialnos.is_null() as i32 as isize != 0 {
             return -(129 as i32);
         }
     }
@@ -606,7 +606,7 @@ unsafe extern "C" fn op_get_prev_page_serial(
             0 as i32 as i64
         };
         ret = op_seek_helper(_of, begin);
-        if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+        if (ret < 0 as i32) as i32 as isize != 0 {
             return ret;
         }
         search_start = begin;
@@ -614,7 +614,7 @@ unsafe extern "C" fn op_get_prev_page_serial(
             let mut llret: i64 = 0;
             let mut serialno: crate::config_types_h::ogg_uint32_t = 0;
             llret = op_get_next_page(_of, &mut og, end);
-            if (llret < -(1 as i32) as i64) as i32 as libc::c_long != 0 {
+            if (llret < -(1 as i32) as i64) as i32 as isize != 0 {
                 return llret as i32;
             } else {
                 if llret == -(1 as i32) as i64 {
@@ -651,8 +651,8 @@ unsafe extern "C" fn op_get_prev_page_serial(
         /*We started from the beginning of the stream and found nothing.
         This should be impossible unless the contents of the stream changed out
          from under us after we read from it.*/
-        if (begin == 0) as i32 as libc::c_long != 0
-            && (_offset < 0 as i32 as i64) as i32 as libc::c_long != 0
+        if (begin == 0) as i32 as isize != 0
+            && (_offset < 0 as i32 as i64) as i32 as isize != 0
         {
             return -(137 as i32);
         }
@@ -737,7 +737,7 @@ unsafe extern "C" fn op_get_last_page(
             0 as i32 as i64
         };
         ret = op_seek_helper(_of, begin);
-        if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+        if (ret < 0 as i32) as i32 as isize != 0 {
             return ret as i64;
         }
         left_link = 0 as i32;
@@ -745,7 +745,7 @@ unsafe extern "C" fn op_get_last_page(
             let mut llret: i64 = 0;
             let mut serialno: crate::config_types_h::ogg_uint32_t = 0;
             llret = op_get_next_page(_of, &mut og, end);
-            if (llret < -(1 as i32) as i64) as i32 as libc::c_long != 0 {
+            if (llret < -(1 as i32) as i64) as i32 as isize != 0 {
                 return llret;
             } else {
                 if llret == -(1 as i32) as i64 {
@@ -760,14 +760,14 @@ unsafe extern "C" fn op_get_last_page(
                     page_gp = crate::src::libogg_1_3_3::src::framing::ogg_page_granulepos(
                         &mut og as *mut _ as *const crate::ogg_h::ogg_page,
                     );
-                    if page_gp != -(1 as i32) as libc::c_long {
+                    if page_gp != -(1 as i32) as isize {
                         /*And has a valid granule position.
                         Let's remember it.*/
                         _offset = llret;
                         gp = page_gp
                     }
                 } else if (op_lookup_serialno(serialno, _serialnos, _nserialnos) == 0) as i32
-                    as libc::c_long
+                    as isize
                     != 0
                 {
                     /*We fell off the start of the link, which means we don't need to keep
@@ -779,9 +779,9 @@ unsafe extern "C" fn op_get_last_page(
         /*We started from at or before the beginning of the link and found nothing.
         This should be impossible unless the contents of the stream changed out
          from under us after we read from it.*/
-        if ((left_link != 0) as i32 as libc::c_long != 0
-            || (begin == 0) as i32 as libc::c_long != 0)
-            && (_offset < 0 as i32 as i64) as i32 as libc::c_long != 0
+        if ((left_link != 0) as i32 as isize != 0
+            || (begin == 0) as i32 as isize != 0)
+            && (_offset < 0 as i32 as i64) as i32 as isize != 0
         {
             return -(137 as i32) as i64;
         }
@@ -835,14 +835,14 @@ unsafe extern "C" fn op_fetch_headers_impl(
         != 0
     {
         if !_serialnos.is_null() {
-            if (op_lookup_page_serialno(_og, *_serialnos, *_nserialnos) != 0) as i32 as libc::c_long
+            if (op_lookup_page_serialno(_og, *_serialnos, *_nserialnos) != 0) as i32 as isize
                 != 0
             {
                 /*A dupe serialnumber in an initial header packet set==invalid stream.*/
                 return -(133 as i32);
             }
             ret = op_add_serialno(_og, _serialnos, _nserialnos, _cserialnos);
-            if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+            if (ret < 0 as i32) as i32 as isize != 0 {
                 return ret;
             }
         }
@@ -863,7 +863,7 @@ unsafe extern "C" fn op_fetch_headers_impl(
             if (crate::src::libogg_1_3_3::src::framing::ogg_stream_packetout(
                 &mut (*_of).os as *mut _ as *mut crate::ogg_h::ogg_stream_state,
                 &mut op as *mut _ as *mut crate::ogg_h::ogg_packet,
-            ) > 0 as i32) as i32 as libc::c_long
+            ) > 0 as i32) as i32 as isize
                 != 0
             {
                 ret = crate::src::opusfile_0_9::src::info::opus_head_parse(
@@ -874,7 +874,7 @@ unsafe extern "C" fn op_fetch_headers_impl(
                 /*TODO: Should a BOS page with no packets be an error?*/
                 /*Found a valid Opus header.
                 Continue setup.*/
-                if (ret >= 0 as i32) as i32 as libc::c_long != 0 {
+                if (ret >= 0 as i32) as i32 as isize != 0 {
                     (*_of).ready_state = 3 as i32
                 } else if ret != -(132 as i32) {
                     return ret;
@@ -890,21 +890,21 @@ unsafe extern "C" fn op_fetch_headers_impl(
             _of,
             _og,
             (if (*_of).offset
-                < ((2 as i32 as libc::c_long
+                < ((2 as i32 as isize
                     * (((1 as i32 as crate::config_types_h::ogg_int64_t) << 62 as i32)
-                        - 1 as i32 as libc::c_long)
-                    | 1 as i32 as libc::c_long)
-                    - 65536 as i32 as libc::c_long) as i64
+                        - 1 as i32 as isize)
+                    | 1 as i32 as isize)
+                    - 65536 as i32 as isize) as i64
             {
                 (*_of).offset
             } else {
-                ((2 as i32 as libc::c_long
+                ((2 as i32 as isize
                     * (((1 as i32 as crate::config_types_h::ogg_int64_t) << 62 as i32)
-                        - 1 as i32 as libc::c_long)
-                    | 1 as i32 as libc::c_long)
-                    - 65536 as i32 as libc::c_long) as i64
+                        - 1 as i32 as isize)
+                    | 1 as i32 as isize)
+                    - 65536 as i32 as isize) as i64
             }) + 65536 as i32 as i64,
-        ) < 0 as i32 as i64) as i32 as libc::c_long
+        ) < 0 as i32 as i64) as i32 as isize
             != 0
         {
             return if (*_of).ready_state < 3 as i32 {
@@ -914,14 +914,14 @@ unsafe extern "C" fn op_fetch_headers_impl(
             };
         }
     }
-    if ((*_of).ready_state != 3 as i32) as i32 as libc::c_long != 0 {
+    if ((*_of).ready_state != 3 as i32) as i32 as isize != 0 {
         return -(132 as i32);
     }
     /*If the first non-header page belonged to our Opus stream, submit it.*/
     if (*_of).os.serialno
         == crate::src::libogg_1_3_3::src::framing::ogg_page_serialno(
             _og as *const crate::ogg_h::ogg_page,
-        ) as libc::c_long
+        ) as isize
     {
         crate::src::libogg_1_3_3::src::framing::ogg_stream_pagein(
             &mut (*_of).os as *mut _ as *mut crate::ogg_h::ogg_stream_state,
@@ -945,23 +945,23 @@ unsafe extern "C" fn op_fetch_headers_impl(
                         _of,
                         _og,
                         (if (*_of).offset
-                            < ((2 as i32 as libc::c_long
+                            < ((2 as i32 as isize
                                 * (((1 as i32 as crate::config_types_h::ogg_int64_t)
                                     << 62 as i32)
-                                    - 1 as i32 as libc::c_long)
-                                | 1 as i32 as libc::c_long)
-                                - 65536 as i32 as libc::c_long) as i64
+                                    - 1 as i32 as isize)
+                                | 1 as i32 as isize)
+                                - 65536 as i32 as isize) as i64
                         {
                             (*_of).offset
                         } else {
-                            ((2 as i32 as libc::c_long
+                            ((2 as i32 as isize
                                 * (((1 as i32 as crate::config_types_h::ogg_int64_t)
                                     << 62 as i32)
-                                    - 1 as i32 as libc::c_long)
-                                | 1 as i32 as libc::c_long)
-                                - 65536 as i32 as libc::c_long) as i64
+                                    - 1 as i32 as isize)
+                                | 1 as i32 as isize)
+                                - 65536 as i32 as isize) as i64
                         }) + 65536 as i32 as i64,
-                    ) < 0 as i32 as i64) as i32 as libc::c_long
+                    ) < 0 as i32 as i64) as i32 as isize
                         != 0
                     {
                         return -(133 as i32);
@@ -970,7 +970,7 @@ unsafe extern "C" fn op_fetch_headers_impl(
                     if (*_of).os.serialno
                         == crate::src::libogg_1_3_3::src::framing::ogg_page_serialno(
                             _og as *const crate::ogg_h::ogg_page,
-                        ) as libc::c_long
+                        ) as isize
                     {
                         crate::src::libogg_1_3_3::src::framing::ogg_stream_pagein(
                             &mut (*_of).os as *mut _ as *mut crate::ogg_h::ogg_stream_state,
@@ -979,7 +979,7 @@ unsafe extern "C" fn op_fetch_headers_impl(
                         break;
                     } else if (crate::src::libogg_1_3_3::src::framing::ogg_page_bos(
                         _og as *const crate::ogg_h::ogg_page,
-                    ) != 0) as i32 as libc::c_long
+                    ) != 0) as i32 as isize
                         != 0
                     {
                         return -(133 as i32);
@@ -999,7 +999,7 @@ unsafe extern "C" fn op_fetch_headers_impl(
                     op.packet,
                     op.bytes as crate::stddef_h::size_t,
                 );
-                if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+                if (ret < 0 as i32) as i32 as isize != 0 {
                     return ret;
                 }
                 /*Make sure the page terminated at the end of the comment header.
@@ -1011,12 +1011,12 @@ unsafe extern "C" fn op_fetch_headers_impl(
                     &mut (*_of).os as *mut _ as *mut crate::ogg_h::ogg_stream_state,
                     &mut op as *mut _ as *mut crate::ogg_h::ogg_packet,
                 );
-                if (ret != 0 as i32) as i32 as libc::c_long != 0
+                if (ret != 0 as i32) as i32 as isize != 0
                     || (*(*_og)
                         .header
-                        .offset(((*_og).header_len - 1 as i32 as libc::c_long) as isize)
+                        .offset(((*_og).header_len - 1 as i32 as isize) as isize)
                         as i32
-                        == 255 as i32) as i32 as libc::c_long
+                        == 255 as i32) as i32 as isize
                         != 0
                 {
                     /*If we fail, the caller assumes our tags are uninitialized.*/
@@ -1054,21 +1054,21 @@ unsafe extern "C" fn op_fetch_headers(
             _of,
             &mut og,
             (if (*_of).offset
-                < ((2 as i32 as libc::c_long
+                < ((2 as i32 as isize
                     * (((1 as i32 as crate::config_types_h::ogg_int64_t) << 62 as i32)
-                        - 1 as i32 as libc::c_long)
-                    | 1 as i32 as libc::c_long)
-                    - 65536 as i32 as libc::c_long) as i64
+                        - 1 as i32 as isize)
+                    | 1 as i32 as isize)
+                    - 65536 as i32 as isize) as i64
             {
                 (*_of).offset
             } else {
-                ((2 as i32 as libc::c_long
+                ((2 as i32 as isize
                     * (((1 as i32 as crate::config_types_h::ogg_int64_t) << 62 as i32)
-                        - 1 as i32 as libc::c_long)
-                    | 1 as i32 as libc::c_long)
-                    - 65536 as i32 as libc::c_long) as i64
+                        - 1 as i32 as isize)
+                    | 1 as i32 as isize)
+                    - 65536 as i32 as isize) as i64
             }) + 65536 as i32 as i64,
-        ) < 0 as i32 as i64) as i32 as libc::c_long
+        ) < 0 as i32 as i64) as i32 as isize
             != 0
         {
             return -(132 as i32);
@@ -1079,7 +1079,7 @@ unsafe extern "C" fn op_fetch_headers(
     ret = op_fetch_headers_impl(_of, _head, _tags, _serialnos, _nserialnos, _cserialnos, _og);
     /*Revert back from OP_STREAMSET to OP_OPENED on failure, to prevent
     double-free of the tags in an unseekable stream.*/
-    if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+    if (ret < 0 as i32) as i32 as isize != 0 {
         (*_of).ready_state = 2 as i32
     }
     return ret;
@@ -1132,50 +1132,50 @@ unsafe extern "C" fn op_granpos_add(
     if _delta > 0 as i32 {
         /*Adding this amount to the granule position would overflow its 64-bit
         range.*/
-        if (_src_gp < 0 as i32 as libc::c_long) as i32 as libc::c_long != 0
-            && (_src_gp >= (-(1 as i32) - _delta) as libc::c_long) as i32 as libc::c_long != 0
+        if (_src_gp < 0 as i32 as isize) as i32 as isize != 0
+            && (_src_gp >= (-(1 as i32) - _delta) as isize) as i32 as isize != 0
         {
             return -(131 as i32);
         }
         if (_src_gp
-            > (2 as i32 as libc::c_long
+            > (2 as i32 as isize
                 * (((1 as i32 as crate::config_types_h::ogg_int64_t) << 62 as i32)
-                    - 1 as i32 as libc::c_long)
-                | 1 as i32 as libc::c_long)
-                - _delta as libc::c_long) as i32 as libc::c_long
+                    - 1 as i32 as isize)
+                | 1 as i32 as isize)
+                - _delta as isize) as i32 as isize
             != 0
         {
             /*Adding this amount to the granule position would overflow the positive
              half of its 64-bit range.
             Since signed overflow is undefined in C, do it in a way the compiler
              isn't allowed to screw up.*/
-            _delta -= ((2 as i32 as libc::c_long
+            _delta -= ((2 as i32 as isize
                 * (((1 as i32 as crate::config_types_h::ogg_int64_t) << 62 as i32)
-                    - 1 as i32 as libc::c_long)
-                | 1 as i32 as libc::c_long)
+                    - 1 as i32 as isize)
+                | 1 as i32 as isize)
                 - _src_gp) as crate::opus_types_h::opus_int32
                 + 1 as i32;
-            _src_gp = -(2 as i32 as libc::c_long
+            _src_gp = -(2 as i32 as isize
                 * (((1 as i32 as crate::config_types_h::ogg_int64_t) << 62 as i32)
-                    - 1 as i32 as libc::c_long)
-                | 1 as i32 as libc::c_long)
-                - 1 as i32 as libc::c_long
+                    - 1 as i32 as isize)
+                | 1 as i32 as isize)
+                - 1 as i32 as isize
         }
     } else if _delta < 0 as i32 {
         /*Subtracting this amount from the granule position would underflow its
         64-bit range.*/
-        if _src_gp >= 0 as i32 as libc::c_long
-            && (_src_gp < -_delta as libc::c_long) as i32 as libc::c_long != 0
+        if _src_gp >= 0 as i32 as isize
+            && (_src_gp < -_delta as isize) as i32 as isize != 0
         {
             return -(131 as i32);
         }
         if (_src_gp
-            < -(2 as i32 as libc::c_long
+            < -(2 as i32 as isize
                 * (((1 as i32 as crate::config_types_h::ogg_int64_t) << 62 as i32)
-                    - 1 as i32 as libc::c_long)
-                | 1 as i32 as libc::c_long)
-                - 1 as i32 as libc::c_long
-                - _delta as libc::c_long) as i32 as libc::c_long
+                    - 1 as i32 as isize)
+                | 1 as i32 as isize)
+                - 1 as i32 as isize
+                - _delta as isize) as i32 as isize
             != 0
         {
             /*Subtracting this amount from the granule position would underflow the
@@ -1183,20 +1183,20 @@ unsafe extern "C" fn op_granpos_add(
             Since signed underflow is undefined in C, do it in a way the compiler
              isn't allowed to screw up.*/
             _delta += (_src_gp
-                - (-(2 as i32 as libc::c_long
+                - (-(2 as i32 as isize
                     * (((1 as i32 as crate::config_types_h::ogg_int64_t) << 62 as i32)
-                        - 1 as i32 as libc::c_long)
-                    | 1 as i32 as libc::c_long)
-                    - 1 as i32 as libc::c_long))
+                        - 1 as i32 as isize)
+                    | 1 as i32 as isize)
+                    - 1 as i32 as isize))
                 as crate::opus_types_h::opus_int32
                 + 1 as i32;
-            _src_gp = 2 as i32 as libc::c_long
+            _src_gp = 2 as i32 as isize
                 * (((1 as i32 as crate::config_types_h::ogg_int64_t) << 62 as i32)
-                    - 1 as i32 as libc::c_long)
-                | 1 as i32 as libc::c_long
+                    - 1 as i32 as isize)
+                | 1 as i32 as isize
         }
     }
-    *_dst_gp = _src_gp + _delta as libc::c_long;
+    *_dst_gp = _src_gp + _delta as isize;
     return 0 as i32;
 }
 /*Safely computes the difference between two granule positions.
@@ -1221,9 +1221,9 @@ unsafe extern "C" fn op_granpos_diff(
     let mut gp_b_negative: i32 = 0;
     /*The code below handles these cases correctly, but there's no reason we
     should ever be called with these values, so make sure we aren't.*/
-    gp_a_negative = (_gp_a < 0 as i32 as libc::c_long) as i32 as libc::c_long as i32;
-    gp_b_negative = (_gp_b < 0 as i32 as libc::c_long) as i32 as libc::c_long as i32;
-    if (gp_a_negative ^ gp_b_negative != 0) as i32 as libc::c_long != 0 {
+    gp_a_negative = (_gp_a < 0 as i32 as isize) as i32 as isize as i32;
+    gp_b_negative = (_gp_b < 0 as i32 as isize) as i32 as isize as i32;
+    if (gp_a_negative ^ gp_b_negative != 0) as i32 as isize != 0 {
         let mut da: crate::config_types_h::ogg_int64_t = 0;
         let mut db: crate::config_types_h::ogg_int64_t = 0;
         if gp_a_negative != 0 {
@@ -1231,26 +1231,26 @@ unsafe extern "C" fn op_granpos_diff(
             should be positive.*/
             /*Step 1: Handle wrapping.*/
             /*_gp_a < 0 => da < 0.*/
-            da = -(2 as i32 as libc::c_long
+            da = -(2 as i32 as isize
                 * (((1 as i32 as crate::config_types_h::ogg_int64_t) << 62 as i32)
-                    - 1 as i32 as libc::c_long)
-                | 1 as i32 as libc::c_long)
-                - 1 as i32 as libc::c_long
+                    - 1 as i32 as isize)
+                | 1 as i32 as isize)
+                - 1 as i32 as isize
                 - _gp_a
-                - 1 as i32 as libc::c_long;
+                - 1 as i32 as isize;
             /*_gp_b >= 0  => db >= 0.*/
-            db = (2 as i32 as libc::c_long
+            db = (2 as i32 as isize
                 * (((1 as i32 as crate::config_types_h::ogg_int64_t) << 62 as i32)
-                    - 1 as i32 as libc::c_long)
-                | 1 as i32 as libc::c_long)
+                    - 1 as i32 as isize)
+                | 1 as i32 as isize)
                 - _gp_b;
             /*Step 2: Check for overflow.*/
-            if ((2 as i32 as libc::c_long
+            if ((2 as i32 as isize
                 * (((1 as i32 as crate::config_types_h::ogg_int64_t) << 62 as i32)
-                    - 1 as i32 as libc::c_long)
-                | 1 as i32 as libc::c_long)
+                    - 1 as i32 as isize)
+                | 1 as i32 as isize)
                 + da
-                < db) as i32 as libc::c_long
+                < db) as i32 as isize
                 != 0
             {
                 return -(131 as i32);
@@ -1262,26 +1262,26 @@ unsafe extern "C" fn op_granpos_diff(
             /*Step 1: Handle wrapping.*/
             /*_gp_a >= 0 => da <= 0*/
             da = _gp_a
-                + (-(2 as i32 as libc::c_long
+                + (-(2 as i32 as isize
                     * (((1 as i32 as crate::config_types_h::ogg_int64_t) << 62 as i32)
-                        - 1 as i32 as libc::c_long)
-                    | 1 as i32 as libc::c_long)
-                    - 1 as i32 as libc::c_long);
+                        - 1 as i32 as isize)
+                    | 1 as i32 as isize)
+                    - 1 as i32 as isize);
             /*_gp_b < 0 => db <= 0*/
-            db = -(2 as i32 as libc::c_long
+            db = -(2 as i32 as isize
                 * (((1 as i32 as crate::config_types_h::ogg_int64_t) << 62 as i32)
-                    - 1 as i32 as libc::c_long)
-                | 1 as i32 as libc::c_long)
-                - 1 as i32 as libc::c_long
+                    - 1 as i32 as isize)
+                | 1 as i32 as isize)
+                - 1 as i32 as isize
                 - _gp_b;
             /*Step 2: Check for overflow.*/
             if (da
-                < -(2 as i32 as libc::c_long
+                < -(2 as i32 as isize
                     * (((1 as i32 as crate::config_types_h::ogg_int64_t) << 62 as i32)
-                        - 1 as i32 as libc::c_long)
-                    | 1 as i32 as libc::c_long)
-                    - 1 as i32 as libc::c_long
-                    - db) as i32 as libc::c_long
+                        - 1 as i32 as isize)
+                    | 1 as i32 as isize)
+                    - 1 as i32 as isize
+                    - db) as i32 as isize
                 != 0
             {
                 return -(131 as i32);
@@ -1304,12 +1304,12 @@ unsafe extern "C" fn op_granpos_cmp(
     However, that means there isn't anything we could sensibly return from this
      function for it.*/
     /*Handle the wrapping cases.*/
-    if (_gp_a < 0 as i32 as libc::c_long) as i32 as libc::c_long != 0 {
-        if _gp_b >= 0 as i32 as libc::c_long {
+    if (_gp_a < 0 as i32 as isize) as i32 as isize != 0 {
+        if _gp_b >= 0 as i32 as isize {
             return 1 as i32;
         }
     /*Else fall through.*/
-    } else if (_gp_b < 0 as i32 as libc::c_long) as i32 as libc::c_long != 0 {
+    } else if (_gp_b < 0 as i32 as isize) as i32 as isize != 0 {
         return -(1 as i32);
     }
     /*No wrapping case.*/
@@ -1323,13 +1323,13 @@ unsafe extern "C" fn op_get_packet_duration(mut _data: *const u8, mut _len: i32)
     let mut frame_size: i32 = 0;
     let mut nsamples: i32 = 0;
     nframes = crate::src::opus_1_2_1::src::opus_decoder::opus_packet_get_nb_frames(_data, _len);
-    if (nframes < 0 as i32) as i32 as libc::c_long != 0 {
+    if (nframes < 0 as i32) as i32 as isize != 0 {
         return -(136 as i32);
     }
     frame_size =
         crate::src::opus_1_2_1::src::opus::opus_packet_get_samples_per_frame(_data, 48000 as i32);
     nsamples = nframes * frame_size;
-    if (nsamples > 120 as i32 * 48 as i32) as i32 as libc::c_long != 0 {
+    if (nsamples > 120 as i32 * 48 as i32) as i32 as isize != 0 {
         return -(136 as i32);
     }
     return nsamples;
@@ -1344,7 +1344,7 @@ pub unsafe extern "C" fn opus_granule_sample(
 ) -> crate::config_types_h::ogg_int64_t {
     let mut _pre_skip: crate::opus_types_h::opus_int32 = 0;
     _pre_skip = (*_head).pre_skip as crate::opus_types_h::opus_int32;
-    if _gp != -(1 as i32) as libc::c_long && op_granpos_add(&mut _gp, _gp, -_pre_skip) != 0 {
+    if _gp != -(1 as i32) as isize && op_granpos_add(&mut _gp, _gp, -_pre_skip) != 0 {
         _gp = -(1 as i32) as crate::config_types_h::ogg_int64_t
     }
     return _gp;
@@ -1379,7 +1379,7 @@ unsafe extern "C" fn op_collect_audio_packets(
         if ret == 0 {
             break;
         }
-        if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+        if (ret < 0 as i32) as i32 as isize != 0 {
             /*We shouldn't get holes in the middle of pages.*/
             /*Set the return value and break out of the loop.
             We want to make sure op_count gets set to 0, because we've ingested a
@@ -1393,7 +1393,7 @@ unsafe extern "C" fn op_collect_audio_packets(
                 (*_of).op[op_count as usize].packet,
                 (*_of).op[op_count as usize].bytes as i32,
             );
-            if (*_durations.offset(op_count as isize) > 0 as i32) as i32 as libc::c_long != 0 {
+            if (*_durations.offset(op_count as isize) > 0 as i32) as i32 as isize != 0 {
                 /*With at most 255 packets on a page, this can't overflow.*/
                 let fresh1 = op_count;
                 op_count = op_count + 1;
@@ -1463,7 +1463,7 @@ unsafe extern "C" fn op_find_initial_pcm_offset(
         page_offset = op_get_next_page(_of, _og, (*_of).end);
         /*We should get a page unless the file is truncated or mangled.
         Otherwise there are no audio data packets in the whole logical stream.*/
-        if (page_offset < 0 as i32 as i64) as i32 as libc::c_long != 0 {
+        if (page_offset < 0 as i32 as i64) as i32 as isize != 0 {
             /*Fail if there was a read error.*/
             if page_offset < -(1 as i32) as i64 {
                 return page_offset as i32;
@@ -1484,7 +1484,7 @@ unsafe extern "C" fn op_find_initial_pcm_offset(
         /*Similarly, if we hit the next link in the chain, we've gone too far.*/
         if (crate::src::libogg_1_3_3::src::framing::ogg_page_bos(
             _og as *const crate::ogg_h::ogg_page,
-        ) != 0) as i32 as libc::c_long
+        ) != 0) as i32 as isize
             != 0
         {
             if (*_link).head.pre_skip > 0 as i32 as u32 {
@@ -1517,7 +1517,7 @@ unsafe extern "C" fn op_find_initial_pcm_offset(
             /*Count the durations of all packets in the page.*/
             {
                 total_duration = op_collect_audio_packets(_of, durations.as_mut_ptr());
-                if !((total_duration < 0 as i32) as i32 as libc::c_long != 0) {
+                if !((total_duration < 0 as i32) as i32 as isize != 0) {
                     break;
                 }
             }
@@ -1540,16 +1540,16 @@ unsafe extern "C" fn op_find_initial_pcm_offset(
     cur_page_gp = (*_of).op[(op_count - 1 as i32) as usize].granulepos;
     /*But getting a packet without a valid granule position on the page is not
     okay.*/
-    if cur_page_gp == -(1 as i32) as libc::c_long {
+    if cur_page_gp == -(1 as i32) as isize {
         return -(139 as i32);
     }
     cur_page_eos = (*_of).op[(op_count - 1 as i32) as usize].e_o_s as i32;
-    if (cur_page_eos == 0) as i32 as libc::c_long != 0 {
+    if (cur_page_eos == 0) as i32 as isize != 0 {
         /*The EOS flag wasn't set.
         Work backwards from the provided granule position to get the starting PCM
          offset.*/
         if (op_granpos_add(&mut pcm_start, cur_page_gp, -total_duration) < 0 as i32) as i32
-            as libc::c_long
+            as isize
             != 0
         {
             /*The starting granule position MUST not be smaller than the amount of
@@ -1557,7 +1557,7 @@ unsafe extern "C" fn op_find_initial_pcm_offset(
             return -(139 as i32);
         }
     } else if (op_granpos_add(&mut pcm_start, cur_page_gp, -total_duration) < 0 as i32) as i32
-        as libc::c_long
+        as isize
         != 0
     {
         /*The first page with completed packets was also the last.*/
@@ -1570,7 +1570,7 @@ unsafe extern "C" fn op_find_initial_pcm_offset(
         if (op_granpos_cmp(
             cur_page_gp,
             (*_link).head.pre_skip as crate::config_types_h::ogg_int64_t,
-        ) < 0 as i32) as i32 as libc::c_long
+        ) < 0 as i32) as i32 as isize
             != 0
         {
             return -(139 as i32);
@@ -1584,19 +1584,19 @@ unsafe extern "C" fn op_find_initial_pcm_offset(
         if cur_page_eos != 0 {
             let mut diff: crate::config_types_h::ogg_int64_t =
                 0 as i32 as crate::config_types_h::ogg_int64_t;
-            diff = durations[pi as usize] as libc::c_long - diff;
+            diff = durations[pi as usize] as isize - diff;
             /*If we have samples to trim...*/
-            if diff > 0 as i32 as libc::c_long {
+            if diff > 0 as i32 as isize {
                 /*If we trimmed the entire packet, stop (the spec says encoders
                 shouldn't do this, but we support it anyway).*/
-                if (diff > durations[pi as usize] as libc::c_long) as i32 as libc::c_long != 0 {
+                if (diff > durations[pi as usize] as isize) as i32 as isize != 0 {
                     break;
                 }
                 prev_packet_gp = cur_page_gp;
                 (*_of).op[pi as usize].granulepos = prev_packet_gp;
                 /*Move the EOS flag to this packet, if necessary, so we'll trim the
                 samples.*/
-                (*_of).op[pi as usize].e_o_s = 1 as i32 as libc::c_long;
+                (*_of).op[pi as usize].e_o_s = 1 as i32 as isize;
                 current_block_53 = 16738040538446813684;
             } else {
                 current_block_53 = 2116367355679836638;
@@ -1648,7 +1648,7 @@ unsafe extern "C" fn op_find_final_pcm_offset(
     let mut cur_serialno: crate::config_types_h::ogg_uint32_t = 0;
     /*For the time being, fetch end PCM offset the simple way.*/
     cur_serialno = (*_link).serialno;
-    if _end_serialno != cur_serialno || _end_gp == -(1 as i32) as libc::c_long {
+    if _end_serialno != cur_serialno || _end_gp == -(1 as i32) as isize {
         _offset = op_get_last_page(
             _of,
             &mut _end_gp,
@@ -1657,12 +1657,12 @@ unsafe extern "C" fn op_find_final_pcm_offset(
             _serialnos,
             _nserialnos,
         );
-        if (_offset < 0 as i32 as i64) as i32 as libc::c_long != 0 {
+        if (_offset < 0 as i32 as i64) as i32 as isize != 0 {
             return _offset as i32;
         }
     }
     /*At worst we should have found the first page with completed packets.*/
-    if (_offset < (*_link).data_offset) as i32 as libc::c_long != 0 {
+    if (_offset < (*_link).data_offset) as i32 as isize != 0 {
         return -(137 as i32);
     }
     /*This implementation requires that the difference between the first and last
@@ -1670,22 +1670,22 @@ unsafe extern "C" fn op_find_final_pcm_offset(
     number, and that each link also have at least as many samples as the
     pre-skip requires.*/
     if (op_granpos_diff(&mut duration, _end_gp, (*_link).pcm_start) < 0 as i32) as i32
-        as libc::c_long
+        as isize
         != 0
-        || (duration < (*_link).head.pre_skip as libc::c_long) as i32 as libc::c_long != 0
+        || (duration < (*_link).head.pre_skip as isize) as i32 as isize != 0
     {
         return -(139 as i32);
     }
     /*We also require that the total duration be representable in a signed,
     64-bit number.*/
-    duration -= (*_link).head.pre_skip as libc::c_long;
+    duration -= (*_link).head.pre_skip as isize;
     total_duration = *_total_duration;
-    if ((2 as i32 as libc::c_long
+    if ((2 as i32 as isize
         * (((1 as i32 as crate::config_types_h::ogg_int64_t) << 62 as i32)
-            - 1 as i32 as libc::c_long)
-        | 1 as i32 as libc::c_long)
+            - 1 as i32 as isize)
+        | 1 as i32 as isize)
         - duration
-        < total_duration) as i32 as libc::c_long
+        < total_duration) as i32 as isize
         != 0
     {
         return -(139 as i32);
@@ -1768,7 +1768,7 @@ unsafe extern "C" fn op_predict_link_start(
         /*If the granule position is negative, either it's invalid or we'd cause
         overflow.*/
         gp1 = (*_sr.offset(sri as isize)).gp;
-        if !(gp1 < 0 as i32 as libc::c_long) {
+        if !(gp1 < 0 as i32 as isize) {
             /*We require some minimum distance between granule positions to make an
              estimate.
             We don't actually know what granule position scheme is being used,
@@ -1777,7 +1777,7 @@ unsafe extern "C" fn op_predict_link_start(
              expectation that while bitrates and granule position increments might
              vary locally in quite complex ways, they are globally smooth.*/
             if !((op_granpos_add(&mut gp2_min, gp1, 48000 as i32) < 0 as i32) as i32
-                as libc::c_long
+                as isize
                 != 0)
             {
                 offset1 = (*_sr.offset(sri as isize)).offset;
@@ -1807,7 +1807,7 @@ unsafe extern "C" fn op_predict_link_start(
                     den = gp2 - gp1;
                     ipart = gp2 / den;
                     num = offset2 - offset1;
-                    if ipart > 0 as i32 as libc::c_long
+                    if ipart > 0 as i32 as isize
                         && ((offset2 - _searched) / ipart as i64) < num
                     {
                         continue;
@@ -1881,8 +1881,8 @@ unsafe extern "C" fn op_bisect_forward_serialno(
         let mut sri: i32 = 0;
         serialnos = *_serialnos;
         nserialnos = *_nserialnos;
-        if (nlinks >= clinks) as i32 as libc::c_long != 0 {
-            if (clinks > 2147483647 as i32 - 1 as i32 >> 1 as i32) as i32 as libc::c_long != 0 {
+        if (nlinks >= clinks) as i32 as isize != 0 {
+            if (clinks > 2147483647 as i32 - 1 as i32 >> 1 as i32) as i32 as isize != 0 {
                 return -(129 as i32);
             }
             clinks = 2 as i32 * clinks + 1 as i32;
@@ -1891,7 +1891,7 @@ unsafe extern "C" fn op_bisect_forward_serialno(
                 (::std::mem::size_of::<crate::internal_h::OggOpusLink>() as libc::c_ulong)
                     .wrapping_mul(clinks as libc::c_ulong),
             ) as *mut crate::internal_h::OggOpusLink;
-            if links.is_null() as i32 as libc::c_long != 0 {
+            if links.is_null() as i32 as isize != 0 {
                 return -(129 as i32);
             }
             (*_of).links = links
@@ -1943,11 +1943,11 @@ unsafe extern "C" fn op_bisect_forward_serialno(
             last_offset = (*links.offset((nlinks - 1 as i32) as isize)).offset;
             avg_link_size = last_offset / (nlinks - 1 as i32) as i64;
             upper_limit = end_searched - 65536 as i32 as i64 - avg_link_size;
-            if (last_offset > _searched - avg_link_size) as i32 as libc::c_long != 0
-                && (last_offset < upper_limit) as i32 as libc::c_long != 0
+            if (last_offset > _searched - avg_link_size) as i32 as isize != 0
+                && (last_offset < upper_limit) as i32 as isize != 0
             {
                 bisect = last_offset + avg_link_size;
-                if (bisect < upper_limit) as i32 as libc::c_long != 0 {
+                if (bisect < upper_limit) as i32 as isize != 0 {
                     bisect += avg_link_size
                 }
             }
@@ -1969,7 +1969,7 @@ unsafe extern "C" fn op_bisect_forward_serialno(
                 end_gp = -(1 as i32) as crate::config_types_h::ogg_int64_t
             }
             ret = op_seek_helper(_of, bisect);
-            if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+            if (ret < 0 as i32) as i32 as isize != 0 {
                 return ret;
             }
             last = op_get_next_page(
@@ -1977,7 +1977,7 @@ unsafe extern "C" fn op_bisect_forward_serialno(
                 &mut og,
                 (*_sr.offset((nsr - 1 as i32) as isize)).offset,
             );
-            if (last < -(1 as i32) as i64) as i32 as libc::c_long != 0 {
+            if (last < -(1 as i32) as i64) as i32 as isize != 0 {
                 return last as i32;
             }
             next_bias = 0 as i32;
@@ -1996,7 +1996,7 @@ unsafe extern "C" fn op_bisect_forward_serialno(
                     end_searched = bisect;
                     next = last;
                     /*In reality we should always have enough room, but be paranoid.*/
-                    if (nsr < _csr) as i32 as libc::c_long != 0 {
+                    if (nsr < _csr) as i32 as isize != 0 {
                         (*_sr.offset(nsr as isize)).search_start = bisect;
                         (*_sr.offset(nsr as isize)).offset = last;
                         (*_sr.offset(nsr as isize)).size =
@@ -2023,11 +2023,11 @@ unsafe extern "C" fn op_bisect_forward_serialno(
         Get the final granule position of the previous link, assuming
          op_find_initial_pcm_offset() didn't already determine the link was
          empty.*/
-        if ((*links.offset((nlinks - 1 as i32) as isize)).pcm_end == -(1 as i32) as libc::c_long)
-            as i32 as libc::c_long
+        if ((*links.offset((nlinks - 1 as i32) as isize)).pcm_end == -(1 as i32) as isize)
+            as i32 as isize
             != 0
         {
-            if end_gp == -(1 as i32) as libc::c_long {
+            if end_gp == -(1 as i32) as isize {
                 /*If we don't know where the end page is, we'll have to seek back and
                 look for it, starting from the end of the link.*/
                 end_offset = next as crate::config_types_h::ogg_int64_t;
@@ -2045,7 +2045,7 @@ unsafe extern "C" fn op_bisect_forward_serialno(
                 end_gp,
                 &mut total_duration,
             );
-            if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+            if (ret < 0 as i32) as i32 as isize != 0 {
                 return ret;
             }
         }
@@ -2056,7 +2056,7 @@ unsafe extern "C" fn op_bisect_forward_serialno(
              does not start at the end of the last page from the current Opus
              stream with a valid granule position.*/
             ret = op_seek_helper(_of, next);
-            if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+            if (ret < 0 as i32) as i32 as isize != 0 {
                 return ret;
             }
         }
@@ -2073,7 +2073,7 @@ unsafe extern "C" fn op_bisect_forward_serialno(
                 &mut og
             },
         );
-        if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+        if (ret < 0 as i32) as i32 as isize != 0 {
             return ret;
         }
         (*links.offset(nlinks as isize)).offset = next;
@@ -2089,7 +2089,7 @@ unsafe extern "C" fn op_bisect_forward_serialno(
             links.offset(nlinks as isize),
             0 as *mut crate::ogg_h::ogg_page,
         );
-        if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+        if (ret < 0 as i32) as i32 as isize != 0 {
             return ret;
         }
         (*links.offset(nlinks as isize)).pcm_file_offset = total_duration;
@@ -2102,8 +2102,8 @@ unsafe extern "C" fn op_bisect_forward_serialno(
     Now find the last granule position for it (if we didn't the first time we
      looked at the end of the stream, and if op_find_initial_pcm_offset()
      didn't already determine the link was empty).*/
-    if ((*links.offset((nlinks - 1 as i32) as isize)).pcm_end == -(1 as i32) as libc::c_long) as i32
-        as libc::c_long
+    if ((*links.offset((nlinks - 1 as i32) as isize)).pcm_end == -(1 as i32) as isize) as i32
+        as isize
         != 0
     {
         ret = op_find_final_pcm_offset(
@@ -2116,7 +2116,7 @@ unsafe extern "C" fn op_bisect_forward_serialno(
             (*_sr.offset(0 as i32 as isize)).gp,
             &mut total_duration,
         );
-        if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+        if (ret < 0 as i32) as i32 as isize != 0 {
             return ret;
         }
     }
@@ -2126,7 +2126,7 @@ unsafe extern "C" fn op_bisect_forward_serialno(
         (::std::mem::size_of::<crate::internal_h::OggOpusLink>() as libc::c_ulong)
             .wrapping_mul(nlinks as libc::c_ulong),
     ) as *mut crate::internal_h::OggOpusLink;
-    if !links.is_null() as i32 as libc::c_long != 0 {
+    if !links.is_null() as i32 as isize != 0 {
         (*_of).links = links
     }
     /*We also don't need these anymore.*/
@@ -2212,7 +2212,7 @@ unsafe extern "C" fn op_make_decode_ready(mut _of: *mut crate::internal_h::OggOp
     if (*_of).ready_state > 3 as i32 {
         return 0 as i32;
     }
-    if ((*_of).ready_state < 3 as i32) as i32 as libc::c_long != 0 {
+    if ((*_of).ready_state < 3 as i32) as i32 as isize != 0 {
         return -(129 as i32);
     }
     li = if (*_of).seekable != 0 {
@@ -2297,11 +2297,11 @@ unsafe extern "C" fn op_open_seekable2_impl(mut _of: *mut crate::internal_h::Ogg
     (*_of).end = Some((*_of).callbacks.tell.expect("non-null function pointer"))
         .expect("non-null function pointer")((*_of).stream);
     (*_of).offset = (*_of).end;
-    if ((*_of).end < 0 as i32 as i64) as i32 as libc::c_long != 0 {
+    if ((*_of).end < 0 as i32 as i64) as i32 as isize != 0 {
         return -(128 as i32);
     }
     data_offset = (*(*_of).links.offset(0 as i32 as isize)).data_offset;
-    if ((*_of).end < data_offset) as i32 as libc::c_long != 0 {
+    if ((*_of).end < data_offset) as i32 as isize != 0 {
         return -(137 as i32);
     }
     /*Get the offset of the last page of the physical bitstream, or, if we're
@@ -2315,12 +2315,12 @@ unsafe extern "C" fn op_open_seekable2_impl(mut _of: *mut crate::internal_h::Ogg
         (*_of).serialnos,
         (*_of).nserialnos,
     );
-    if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+    if (ret < 0 as i32) as i32 as isize != 0 {
         return ret;
     }
     /*If there's any trailing junk, forget about it.*/
     (*_of).end = sr[0 as i32 as usize].offset + sr[0 as i32 as usize].size as i64;
-    if ((*_of).end < data_offset) as i32 as libc::c_long != 0 {
+    if ((*_of).end < data_offset) as i32 as isize != 0 {
         return -(137 as i32);
     }
     /*Now enumerate the bitstream structure.*/
@@ -2430,13 +2430,13 @@ unsafe extern "C" fn op_open_seekable2(mut _of: *mut crate::internal_h::OggOpusF
     (*_of).prev_page_offset = prev_page_offset;
     (*_of).cur_discard_count =
         (*(*_of).links.offset(0 as i32 as isize)).head.pre_skip as crate::opus_types_h::opus_int32;
-    if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+    if (ret < 0 as i32) as i32 as isize != 0 {
         return ret;
     }
     /*And restore the position indicator.*/
     ret = Some((*_of).callbacks.seek.expect("non-null function pointer"))
         .expect("non-null function pointer")((*_of).stream, op_position(_of), 0 as i32);
-    return if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+    return if (ret < 0 as i32) as i32 as isize != 0 {
         -(128 as i32)
     } else {
         0 as i32
@@ -2476,7 +2476,7 @@ unsafe extern "C" fn op_clear(mut _of: *mut crate::internal_h::OggOpusFile) {
                     as *mut crate::src::opusfile_0_9::src::opusfile::OpusTags,
             );
         }
-    } else if !links.is_null() as i32 as libc::c_long != 0 {
+    } else if !links.is_null() as i32 as isize != 0 {
         let mut nlinks: i32 = 0;
         let mut link: i32 = 0;
         nlinks = (*_of).nlinks;
@@ -2524,8 +2524,8 @@ unsafe extern "C" fn op_open1(
         0 as i32,
         ::std::mem::size_of::<crate::internal_h::OggOpusFile>() as libc::c_ulong,
     );
-    if (_initial_bytes > 9223372036854775807 as libc::c_long as crate::stddef_h::size_t) as i32
-        as libc::c_long
+    if (_initial_bytes > 9223372036854775807 as isize as crate::stddef_h::size_t) as i32
+        as isize
         != 0
     {
         return -(129 as i32);
@@ -2534,7 +2534,7 @@ unsafe extern "C" fn op_open1(
     (*_of).stream = _stream;
     (*_of).callbacks = *_cb;
     /*At a minimum, we need to be able to read data.*/
-    if (*_of).callbacks.read.is_none() as i32 as libc::c_long != 0 {
+    if (*_of).callbacks.read.is_none() as i32 as isize != 0 {
         return -(128 as i32);
     }
     /*Initialize the framing state.*/
@@ -2552,7 +2552,7 @@ unsafe extern "C" fn op_open1(
         let mut buffer: *mut libc::c_char = 0 as *mut libc::c_char;
         buffer = crate::src::libogg_1_3_3::src::framing::ogg_sync_buffer(
             &mut (*_of).oy as *mut _ as *mut crate::ogg_h::ogg_sync_state,
-            _initial_bytes as libc::c_long,
+            _initial_bytes as isize,
         );
         crate::stdlib::memcpy(
             buffer as *mut libc::c_void,
@@ -2561,7 +2561,7 @@ unsafe extern "C" fn op_open1(
         );
         crate::src::libogg_1_3_3::src::framing::ogg_sync_wrote(
             &mut (*_of).oy as *mut _ as *mut crate::ogg_h::ogg_sync_state,
-            _initial_bytes as libc::c_long,
+            _initial_bytes as isize,
         );
     }
     /*Can we seek?
@@ -2573,14 +2573,14 @@ unsafe extern "C" fn op_open1(
     /*If seek is implemented, tell must also be implemented.*/
     if seekable != 0 {
         let mut pos: i64 = 0;
-        if (*_of).callbacks.tell.is_none() as i32 as libc::c_long != 0 {
+        if (*_of).callbacks.tell.is_none() as i32 as isize != 0 {
             return -(131 as i32);
         }
         pos = Some((*_of).callbacks.tell.expect("non-null function pointer"))
             .expect("non-null function pointer")((*_of).stream);
         /*If the current position is not equal to the initial bytes consumed,
         absolute seeking will not work.*/
-        if (pos != _initial_bytes as i64) as i32 as libc::c_long != 0 {
+        if (pos != _initial_bytes as i64) as i32 as isize != 0 {
             return -(131 as i32);
         }
     }
@@ -2608,7 +2608,7 @@ unsafe extern "C" fn op_open1(
             &mut (*_of).cserialnos,
             pog,
         );
-        if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+        if (ret < 0 as i32) as i32 as isize != 0 {
             break;
         }
         (*_of).nlinks = 1 as i32;
@@ -2620,7 +2620,7 @@ unsafe extern "C" fn op_open1(
             (*_of).os.serialno as crate::config_types_h::ogg_uint32_t;
         /*Fetch the initial PCM offset.*/
         ret = op_find_initial_pcm_offset(_of, (*_of).links, &mut og);
-        if seekable != 0 || (ret <= 0 as i32) as i32 as libc::c_long != 0 {
+        if seekable != 0 || (ret <= 0 as i32) as i32 as isize != 0 {
             break;
         }
         /*This link was empty, but we already have the BOS page for the next one in
@@ -2636,7 +2636,7 @@ unsafe extern "C" fn op_open1(
         }
         pog = &mut og
     }
-    if (ret >= 0 as i32) as i32 as libc::c_long != 0 {
+    if (ret >= 0 as i32) as i32 as isize != 0 {
         (*_of).ready_state = 1 as i32
     }
     return ret;
@@ -2650,12 +2650,12 @@ unsafe extern "C" fn op_open2(mut _of: *mut crate::internal_h::OggOpusFile) -> i
     } else {
         ret = 0 as i32
     }
-    if (ret >= 0 as i32) as i32 as libc::c_long != 0 {
+    if (ret >= 0 as i32) as i32 as isize != 0 {
         /*We have buffered packets from op_find_initial_pcm_offset().
         Move to OP_INITSET so we can use them.*/
         (*_of).ready_state = 3 as i32;
         ret = op_make_decode_ready(_of);
-        if (ret >= 0 as i32) as i32 as libc::c_long != 0 {
+        if (ret >= 0 as i32) as i32 as isize != 0 {
             return 0 as i32;
         }
     }
@@ -2679,9 +2679,9 @@ pub unsafe extern "C" fn op_test_callbacks(
         ::std::mem::size_of::<crate::internal_h::OggOpusFile>() as libc::c_ulong
     ) as *mut crate::internal_h::OggOpusFile;
     ret = -(129 as i32);
-    if !of.is_null() as i32 as libc::c_long != 0 {
+    if !of.is_null() as i32 as isize != 0 {
         ret = op_open1(of, _stream, _cb, _initial_data, _initial_bytes);
-        if (ret >= 0 as i32) as i32 as libc::c_long != 0 {
+        if (ret >= 0 as i32) as i32 as isize != 0 {
             if !_error.is_null() {
                 *_error = 0 as i32
             }
@@ -2708,10 +2708,10 @@ pub unsafe extern "C" fn op_open_callbacks(
 ) -> *mut crate::internal_h::OggOpusFile {
     let mut of: *mut crate::internal_h::OggOpusFile = 0 as *mut crate::internal_h::OggOpusFile;
     of = op_test_callbacks(_stream, _cb, _initial_data, _initial_bytes, _error);
-    if !of.is_null() as i32 as libc::c_long != 0 {
+    if !of.is_null() as i32 as isize != 0 {
         let mut ret: i32 = 0;
         ret = op_open2(of);
-        if (ret >= 0 as i32) as i32 as libc::c_long != 0 {
+        if (ret >= 0 as i32) as i32 as isize != 0 {
             return of;
         }
         if !_error.is_null() {
@@ -2730,7 +2730,7 @@ unsafe extern "C" fn op_open_close_on_failure(
     mut _error: *mut i32,
 ) -> *mut crate::internal_h::OggOpusFile {
     let mut of: *mut crate::internal_h::OggOpusFile = 0 as *mut crate::internal_h::OggOpusFile;
-    if _stream.is_null() as i32 as libc::c_long != 0 {
+    if _stream.is_null() as i32 as isize != 0 {
         if !_error.is_null() {
             *_error = -(129 as i32)
         }
@@ -2743,7 +2743,7 @@ unsafe extern "C" fn op_open_close_on_failure(
         0 as i32 as crate::stddef_h::size_t,
         _error,
     );
-    if of.is_null() as i32 as libc::c_long != 0 {
+    if of.is_null() as i32 as isize != 0 {
         Some((*_cb).close.expect("non-null function pointer")).expect("non-null function pointer")(
             _stream,
         );
@@ -2806,7 +2806,7 @@ unsafe extern "C" fn op_test_close_on_failure(
     mut _error: *mut i32,
 ) -> *mut crate::internal_h::OggOpusFile {
     let mut of: *mut crate::internal_h::OggOpusFile = 0 as *mut crate::internal_h::OggOpusFile;
-    if _stream.is_null() as i32 as libc::c_long != 0 {
+    if _stream.is_null() as i32 as isize != 0 {
         if !_error.is_null() {
             *_error = -(129 as i32)
         }
@@ -2819,7 +2819,7 @@ unsafe extern "C" fn op_test_close_on_failure(
         0 as i32 as crate::stddef_h::size_t,
         _error,
     );
-    if of.is_null() as i32 as libc::c_long != 0 {
+    if of.is_null() as i32 as isize != 0 {
         Some((*_cb).close.expect("non-null function pointer")).expect("non-null function pointer")(
             _stream,
         );
@@ -2877,13 +2877,13 @@ pub unsafe extern "C" fn op_test_memory(
 
 pub unsafe extern "C" fn op_test_open(mut _of: *mut crate::internal_h::OggOpusFile) -> i32 {
     let mut ret: i32 = 0;
-    if ((*_of).ready_state != 1 as i32) as i32 as libc::c_long != 0 {
+    if ((*_of).ready_state != 1 as i32) as i32 as isize != 0 {
         return -(131 as i32);
     }
     ret = op_open2(_of);
     /*op_open2() will clear this structure on failure.
     Reset its contents to prevent double-frees in op_free().*/
-    if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+    if (ret < 0 as i32) as i32 as isize != 0 {
         crate::stdlib::memset(
             _of as *mut libc::c_void,
             0 as i32,
@@ -2895,7 +2895,7 @@ pub unsafe extern "C" fn op_test_open(mut _of: *mut crate::internal_h::OggOpusFi
 #[no_mangle]
 
 pub unsafe extern "C" fn op_free(mut _of: *mut crate::internal_h::OggOpusFile) {
-    if !_of.is_null() as i32 as libc::c_long != 0 {
+    if !_of.is_null() as i32 as isize != 0 {
         op_clear(_of);
         ::libc::free(_of as *mut libc::c_void);
     };
@@ -2916,7 +2916,7 @@ pub unsafe extern "C" fn op_serialno(
     mut _of: *const crate::internal_h::OggOpusFile,
     mut _li: i32,
 ) -> crate::opus_types_h::opus_uint32 {
-    if (_li >= (*_of).nlinks) as i32 as libc::c_long != 0 {
+    if (_li >= (*_of).nlinks) as i32 as isize != 0 {
         _li = (*_of).nlinks - 1 as i32
     }
     if (*_of).seekable == 0 {
@@ -2941,9 +2941,9 @@ pub unsafe extern "C" fn op_raw_total(
     mut _of: *const crate::internal_h::OggOpusFile,
     mut _li: i32,
 ) -> i64 {
-    if ((*_of).ready_state < 2 as i32) as i32 as libc::c_long != 0
-        || ((*_of).seekable == 0) as i32 as libc::c_long != 0
-        || (_li >= (*_of).nlinks) as i32 as libc::c_long != 0
+    if ((*_of).ready_state < 2 as i32) as i32 as isize != 0
+        || ((*_of).seekable == 0) as i32 as isize != 0
+        || (_li >= (*_of).nlinks) as i32 as isize != 0
     {
         return -(131 as i32) as i64;
     }
@@ -2972,9 +2972,9 @@ pub unsafe extern "C" fn op_pcm_total(
         0 as i32 as crate::config_types_h::ogg_int64_t;
     let mut nlinks: i32 = 0;
     nlinks = (*_of).nlinks;
-    if ((*_of).ready_state < 2 as i32) as i32 as libc::c_long != 0
-        || ((*_of).seekable == 0) as i32 as libc::c_long != 0
-        || (_li >= nlinks) as i32 as libc::c_long != 0
+    if ((*_of).ready_state < 2 as i32) as i32 as isize != 0
+        || ((*_of).seekable == 0) as i32 as isize != 0
+        || (_li >= nlinks) as i32 as isize != 0
     {
         return -(131 as i32) as crate::config_types_h::ogg_int64_t;
     }
@@ -2987,7 +2987,7 @@ pub unsafe extern "C" fn op_pcm_total(
         pcm_total = (*links.offset((nlinks - 1 as i32) as isize)).pcm_file_offset;
         _li = nlinks - 1 as i32
     }
-    return pcm_total + diff - (*links.offset(_li as isize)).head.pre_skip as libc::c_long;
+    return pcm_total + diff - (*links.offset(_li as isize)).head.pre_skip as isize;
 }
 #[no_mangle]
 
@@ -2995,7 +2995,7 @@ pub unsafe extern "C" fn op_head(
     mut _of: *const crate::internal_h::OggOpusFile,
     mut _li: i32,
 ) -> *const crate::src::opusfile_0_9::src::opusfile::OpusHead {
-    if (_li >= (*_of).nlinks) as i32 as libc::c_long != 0 {
+    if (_li >= (*_of).nlinks) as i32 as isize != 0 {
         _li = (*_of).nlinks - 1 as i32
     }
     if (*_of).seekable == 0 {
@@ -3012,7 +3012,7 @@ pub unsafe extern "C" fn op_tags(
     mut _of: *const crate::internal_h::OggOpusFile,
     mut _li: i32,
 ) -> *const crate::src::opusfile_0_9::src::opusfile::OpusTags {
-    if (_li >= (*_of).nlinks) as i32 as libc::c_long != 0 {
+    if (_li >= (*_of).nlinks) as i32 as isize != 0 {
         _li = (*_of).nlinks - 1 as i32
     }
     if (*_of).seekable == 0 {
@@ -3032,7 +3032,7 @@ pub unsafe extern "C" fn op_tags(
 #[no_mangle]
 
 pub unsafe extern "C" fn op_current_link(mut _of: *const crate::internal_h::OggOpusFile) -> i32 {
-    if ((*_of).ready_state < 2 as i32) as i32 as libc::c_long != 0 {
+    if ((*_of).ready_state < 2 as i32) as i32 as isize != 0 {
         return -(131 as i32);
     }
     return (*_of).cur_link;
@@ -3046,28 +3046,28 @@ unsafe extern "C" fn op_calc_bitrate(
 ) -> crate::opus_types_h::opus_int32 {
     /*These rates are absurd, but let's handle them anyway.*/
     if (_bytes
-        > (((2 as i32 as libc::c_long
+        > (((2 as i32 as isize
             * (((1 as i32 as crate::config_types_h::ogg_int64_t) << 62 as i32)
-                - 1 as i32 as libc::c_long)
-            | 1 as i32 as libc::c_long)
+                - 1 as i32 as isize)
+            | 1 as i32 as isize)
             - (_samples >> 1 as i32))
-            / (48000 as i32 * 8 as i32) as libc::c_long) as i64) as i32 as libc::c_long
+            / (48000 as i32 * 8 as i32) as isize) as i64) as i32 as isize
         != 0
     {
         let mut den: crate::config_types_h::ogg_int64_t = 0;
         if (_bytes
             / ((2 as i32 * (((1 as i32) << 30 as i32) - 1 as i32) | 1 as i32)
                 / (48000 as i32 * 8 as i32)) as i64
-            >= _samples as i64) as i32 as libc::c_long
+            >= _samples as i64) as i32 as isize
             != 0
         {
             return 2 as i32 * (((1 as i32) << 30 as i32) - 1 as i32) | 1 as i32;
         }
-        den = _samples / (48000 as i32 * 8 as i32) as libc::c_long;
+        den = _samples / (48000 as i32 * 8 as i32) as isize;
         return ((_bytes + (den >> 1 as i32) as i64) / den as i64)
             as crate::opus_types_h::opus_int32;
     }
-    if (_samples <= 0 as i32 as libc::c_long) as i32 as libc::c_long != 0 {
+    if (_samples <= 0 as i32 as isize) as i32 as isize != 0 {
         return 2 as i32 * (((1 as i32) << 30 as i32) - 1 as i32) | 1 as i32;
     }
     /*This can't actually overflow in normal operation: even with a pre-skip of
@@ -3093,9 +3093,9 @@ pub unsafe extern "C" fn op_bitrate(
     mut _of: *const crate::internal_h::OggOpusFile,
     mut _li: i32,
 ) -> crate::opus_types_h::opus_int32 {
-    if ((*_of).ready_state < 2 as i32) as i32 as libc::c_long != 0
-        || ((*_of).seekable == 0) as i32 as libc::c_long != 0
-        || (_li >= (*_of).nlinks) as i32 as libc::c_long != 0
+    if ((*_of).ready_state < 2 as i32) as i32 as isize != 0
+        || ((*_of).seekable == 0) as i32 as isize != 0
+        || (_li >= (*_of).nlinks) as i32 as isize != 0
     {
         return -(131 as i32);
     }
@@ -3108,11 +3108,11 @@ pub unsafe extern "C" fn op_bitrate_instant(
 ) -> crate::opus_types_h::opus_int32 {
     let mut samples_tracked: crate::config_types_h::ogg_int64_t = 0;
     let mut ret: crate::opus_types_h::opus_int32 = 0;
-    if ((*_of).ready_state < 2 as i32) as i32 as libc::c_long != 0 {
+    if ((*_of).ready_state < 2 as i32) as i32 as isize != 0 {
         return -(131 as i32);
     }
     samples_tracked = (*_of).samples_tracked;
-    if (samples_tracked == 0 as i32 as libc::c_long) as i32 as libc::c_long != 0 {
+    if (samples_tracked == 0 as i32 as isize) as i32 as isize != 0 {
         return -(1 as i32);
     }
     ret = op_calc_bitrate((*_of).bytes_tracked, samples_tracked);
@@ -3218,7 +3218,7 @@ unsafe extern "C" fn op_fetch_and_process_page(
                 -(2 as i32)
             };
         }
-        if ((*_of).ready_state >= 3 as i32) as i32 as libc::c_long != 0
+        if ((*_of).ready_state >= 3 as i32) as i32 as isize != 0
             && cur_serialno
                 != crate::src::libogg_1_3_3::src::framing::ogg_page_serialno(
                     &mut og as *mut _ as *const crate::ogg_h::ogg_page,
@@ -3228,7 +3228,7 @@ unsafe extern "C" fn op_fetch_and_process_page(
             1) Another stream is multiplexed into this logical section, or*/
             if (crate::src::libogg_1_3_3::src::framing::ogg_page_bos(
                 &mut og as *mut _ as *const crate::ogg_h::ogg_page,
-            ) == 0) as i32 as libc::c_long
+            ) == 0) as i32 as isize
                 != 0
             {
                 continue;
@@ -3237,7 +3237,7 @@ unsafe extern "C" fn op_fetch_and_process_page(
             if _spanp == 0 {
                 return -(2 as i32);
             }
-            if ((*_of).ready_state >= 4 as i32) as i32 as libc::c_long != 0 {
+            if ((*_of).ready_state >= 4 as i32) as i32 as isize != 0 {
                 op_decode_clear(_of);
             }
         } else {
@@ -3253,7 +3253,7 @@ unsafe extern "C" fn op_fetch_and_process_page(
         In the non-seekable (streaming) case, we'll only be at a boundary if we
          just left the previous logical bitstream, and we're now nominally at the
          header of the next bitstream.*/
-        if ((*_of).ready_state < 3 as i32) as i32 as libc::c_long != 0 {
+        if ((*_of).ready_state < 3 as i32) as i32 as isize != 0 {
             if seekable != 0 {
                 let mut serialno: crate::config_types_h::ogg_uint32_t = 0;
                 serialno = crate::src::libogg_1_3_3::src::framing::ogg_page_serialno(
@@ -3265,7 +3265,7 @@ unsafe extern "C" fn op_fetch_and_process_page(
                     Is it from the next one?*/
                     if ((cur_link + 1 as i32) < (*_of).nlinks
                         && (*links.offset((cur_link + 1 as i32) as isize)).serialno == serialno)
-                        as i32 as libc::c_long
+                        as i32 as isize
                         != 0
                     {
                         cur_link += 1
@@ -3311,19 +3311,19 @@ unsafe extern "C" fn op_fetch_and_process_page(
                         0 as *mut i32,
                         &mut og,
                     );
-                    if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+                    if (ret < 0 as i32) as i32 as isize != 0 {
                         return ret;
                     }
                     /*op_find_initial_pcm_offset() will suppress any initial hole for us,
                     so no need to set _ignore_holes.*/
                     ret = op_find_initial_pcm_offset(_of, links, &mut og);
-                    if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+                    if (ret < 0 as i32) as i32 as isize != 0 {
                         return ret;
                     }
                     cur_serialno = (*_of).os.serialno as crate::config_types_h::ogg_uint32_t;
                     (*(*_of).links.offset(0 as i32 as isize)).serialno = cur_serialno;
                     (*_of).cur_link += 1;
-                    if !((ret > 0 as i32) as i32 as libc::c_long != 0) {
+                    if !((ret > 0 as i32) as i32 as isize != 0) {
                         break;
                     }
                 }
@@ -3336,7 +3336,7 @@ unsafe extern "C" fn op_fetch_and_process_page(
                 TODO: This resets bytes_tracked, which misses the header bytes
                  already processed by op_find_initial_pcm_offset().*/
                 ret = op_make_decode_ready(_of);
-                if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+                if (ret < 0 as i32) as i32 as isize != 0 {
                     return ret;
                 }
                 return 0 as i32;
@@ -3344,9 +3344,9 @@ unsafe extern "C" fn op_fetch_and_process_page(
         }
         /*The buffered page is the data we want, and we're ready for it.
         Add it to the stream state.*/
-        if ((*_of).ready_state == 3 as i32) as i32 as libc::c_long != 0 {
+        if ((*_of).ready_state == 3 as i32) as i32 as isize != 0 {
             ret = op_make_decode_ready(_of);
-            if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+            if (ret < 0 as i32) as i32 as isize != 0 {
                 return ret;
             }
         }
@@ -3355,7 +3355,7 @@ unsafe extern "C" fn op_fetch_and_process_page(
             &mut (*_of).os as *mut _ as *mut crate::ogg_h::ogg_stream_state,
             &mut og as *mut _ as *mut crate::ogg_h::ogg_page,
         );
-        if !(((*_of).ready_state >= 4 as i32) as i32 as libc::c_long != 0) {
+        if !(((*_of).ready_state >= 4 as i32) as i32 as isize != 0) {
             continue;
         }
         let mut total_duration: crate::opus_types_h::opus_int32 = 0;
@@ -3364,7 +3364,7 @@ unsafe extern "C" fn op_fetch_and_process_page(
         let mut report_hole: i32 = 0;
         report_hole = 0 as i32;
         total_duration = op_collect_audio_packets(_of, durations.as_mut_ptr());
-        if (total_duration < 0 as i32) as i32 as libc::c_long != 0 {
+        if (total_duration < 0 as i32) as i32 as isize != 0 {
             /*libogg reported a hole (a gap in the page sequence numbers).
             Drain the packets from the page anyway.
             If we don't, they'll still be there when we fetch the next page.
@@ -3400,11 +3400,11 @@ unsafe extern "C" fn op_fetch_and_process_page(
             cur_page_gp = (*_of).op[(op_count - 1 as i32) as usize].granulepos;
             cur_page_eos = (*_of).op[(op_count - 1 as i32) as usize].e_o_s as i32;
             prev_packet_gp = (*_of).prev_packet_gp;
-            if (prev_packet_gp == -(1 as i32) as libc::c_long) as i32 as libc::c_long != 0 {
+            if (prev_packet_gp == -(1 as i32) as isize) as i32 as isize != 0 {
                 let mut cur_discard_count: crate::opus_types_h::opus_int32 = 0;
                 /*This is the first call after a raw seek.
                 Try to reconstruct prev_packet_gp from scratch.*/
-                if (cur_page_eos != 0) as i32 as libc::c_long != 0 {
+                if (cur_page_eos != 0) as i32 as isize != 0 {
                     /*If the first page we hit after our seek was the EOS page, and
                      we didn't start from data_offset or before, we don't have
                      enough information to do end-trimming.
@@ -3425,14 +3425,14 @@ unsafe extern "C" fn op_fetch_and_process_page(
                      position, or the granule position it had was too small (both
                      illegal), just use the starting granule position for the link.*/
                     prev_packet_gp = (*links.offset(cur_link as isize)).pcm_start;
-                    if (cur_page_gp != -(1 as i32) as libc::c_long) as i32 as libc::c_long != 0 {
+                    if (cur_page_gp != -(1 as i32) as isize) as i32 as isize != 0 {
                         op_granpos_add(&mut prev_packet_gp, cur_page_gp, -total_duration);
                     }
                     if (op_granpos_diff(
                         &mut diff,
                         prev_packet_gp,
                         (*links.offset(cur_link as isize)).pcm_start,
-                    ) == 0) as i32 as libc::c_long
+                    ) == 0) as i32 as isize
                         != 0
                     {
                         let mut pre_skip: crate::opus_types_h::opus_int32 = 0;
@@ -3443,13 +3443,13 @@ unsafe extern "C" fn op_fetch_and_process_page(
                          past the end of the pre-skip region.*/
                         pre_skip = (*links.offset(cur_link as isize)).head.pre_skip
                             as crate::opus_types_h::opus_int32;
-                        if diff >= 0 as i32 as libc::c_long
+                        if diff >= 0 as i32 as isize
                             && diff
                                 <= (if 0 as i32 > pre_skip - 80 as i32 * 48 as i32 {
                                     0 as i32
                                 } else {
                                     (pre_skip) - 80 as i32 * 48 as i32
-                                }) as libc::c_long
+                                }) as isize
                         {
                             cur_discard_count = pre_skip - diff as i32
                         }
@@ -3457,7 +3457,7 @@ unsafe extern "C" fn op_fetch_and_process_page(
                     (*_of).cur_discard_count = cur_discard_count
                 }
             }
-            if (cur_page_gp == -(1 as i32) as libc::c_long) as i32 as libc::c_long != 0 {
+            if (cur_page_gp == -(1 as i32) as isize) as i32 as isize != 0 {
                 /*This page had completed packets but didn't have a valid granule
                  position.
                 This is illegal, but we'll try to handle it by continuing to count
@@ -3468,21 +3468,21 @@ unsafe extern "C" fn op_fetch_and_process_page(
                 }
             }
             /*If we hit the last page, handle end-trimming.*/
-            if (cur_page_eos != 0) as i32 as libc::c_long != 0
+            if (cur_page_eos != 0) as i32 as isize != 0
                 && (op_granpos_diff(&mut diff, cur_page_gp, prev_packet_gp) == 0) as i32
-                    as libc::c_long
+                    as isize
                     != 0
-                && (diff < total_duration as libc::c_long) as i32 as libc::c_long != 0
+                && (diff < total_duration as isize) as i32 as isize != 0
             {
                 cur_packet_gp = prev_packet_gp;
                 pi = 0 as i32;
                 while pi < op_count {
-                    diff = durations[pi as usize] as libc::c_long - diff;
+                    diff = durations[pi as usize] as isize - diff;
                     /*If we have samples to trim...*/
-                    if diff > 0 as i32 as libc::c_long {
+                    if diff > 0 as i32 as isize {
                         /*If we trimmed the entire packet, stop (the spec says encoders
                         shouldn't do this, but we support it anyway).*/
-                        if (diff > durations[pi as usize] as libc::c_long) as i32 as libc::c_long
+                        if (diff > durations[pi as usize] as isize) as i32 as isize
                             != 0
                         {
                             break;
@@ -3490,7 +3490,7 @@ unsafe extern "C" fn op_fetch_and_process_page(
                         cur_packet_gp = cur_page_gp;
                         /*Move the EOS flag to this packet, if necessary, so we'll trim
                         the samples during decode.*/
-                        (*_of).op[pi as usize].e_o_s = 1 as i32 as libc::c_long
+                        (*_of).op[pi as usize].e_o_s = 1 as i32 as isize
                     }
                     /*Update the granule position as normal.*/
                     (*_of).op[pi as usize].granulepos = cur_packet_gp;
@@ -3509,7 +3509,7 @@ unsafe extern "C" fn op_fetch_and_process_page(
                 They might be completely out of range for this link (we'll check
                  that elsewhere), or non-monotonic between pages.*/
                 if (op_granpos_add(&mut prev_packet_gp, cur_page_gp, -total_duration) < 0 as i32)
-                    as i32 as libc::c_long
+                    as i32 as isize
                     != 0
                 {
                     /*The starting timestamp for the first packet on this page
@@ -3520,7 +3520,7 @@ unsafe extern "C" fn op_fetch_and_process_page(
                 pi = 0 as i32;
                 while pi < op_count {
                     if (op_granpos_add(&mut cur_packet_gp, cur_page_gp, -total_duration) < 0 as i32)
-                        as i32 as libc::c_long
+                        as i32 as isize
                         != 0
                     {
                         /*The start timestamp for this packet underflowed.
@@ -3553,15 +3553,15 @@ pub unsafe extern "C" fn op_raw_seek(
     mut _pos: i64,
 ) -> i32 {
     let mut ret: i32 = 0;
-    if ((*_of).ready_state < 2 as i32) as i32 as libc::c_long != 0 {
+    if ((*_of).ready_state < 2 as i32) as i32 as isize != 0 {
         return -(131 as i32);
     }
     /*Don't dump the decoder state if we can't seek.*/
-    if ((*_of).seekable == 0) as i32 as libc::c_long != 0 {
+    if ((*_of).seekable == 0) as i32 as isize != 0 {
         return -(138 as i32);
     }
-    if (_pos < 0 as i32 as i64) as i32 as libc::c_long != 0
-        || (_pos > (*_of).end) as i32 as libc::c_long != 0
+    if (_pos < 0 as i32 as i64) as i32 as isize != 0
+        || (_pos > (*_of).end) as i32 as isize != 0
     {
         return -(131 as i32);
     }
@@ -3570,7 +3570,7 @@ pub unsafe extern "C" fn op_raw_seek(
     (*_of).bytes_tracked = 0 as i32 as i64;
     (*_of).samples_tracked = 0 as i32 as crate::config_types_h::ogg_int64_t;
     ret = op_seek_helper(_of, _pos);
-    if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+    if (ret < 0 as i32) as i32 as isize != 0 {
         return -(128 as i32);
     }
     ret = op_fetch_and_process_page(
@@ -3629,34 +3629,34 @@ unsafe extern "C" fn op_get_granulepos(
     _pcm_offset -= (*links.offset(li_lo as isize)).pcm_file_offset;
     pcm_start = (*links.offset(li_lo as isize)).pcm_start;
     _pre_skip = (*links.offset(li_lo as isize)).head.pre_skip as crate::opus_types_h::opus_int32;
-    duration -= _pre_skip as libc::c_long;
+    duration -= _pre_skip as isize;
     if _pcm_offset >= duration {
         return -(1 as i32) as crate::config_types_h::ogg_int64_t;
     }
-    _pcm_offset += _pre_skip as libc::c_long;
+    _pcm_offset += _pre_skip as isize;
     if (pcm_start
-        > (2 as i32 as libc::c_long
+        > (2 as i32 as isize
             * (((1 as i32 as crate::config_types_h::ogg_int64_t) << 62 as i32)
-                - 1 as i32 as libc::c_long)
-            | 1 as i32 as libc::c_long)
-            - _pcm_offset) as i32 as libc::c_long
+                - 1 as i32 as isize)
+            | 1 as i32 as isize)
+            - _pcm_offset) as i32 as isize
         != 0
     {
         /*Adding this amount to the granule position would overflow the positive
          half of its 64-bit range.
         Since signed overflow is undefined in C, do it in a way the compiler
          isn't allowed to screw up.*/
-        _pcm_offset -= (2 as i32 as libc::c_long
+        _pcm_offset -= (2 as i32 as isize
             * (((1 as i32 as crate::config_types_h::ogg_int64_t) << 62 as i32)
-                - 1 as i32 as libc::c_long)
-            | 1 as i32 as libc::c_long)
+                - 1 as i32 as isize)
+            | 1 as i32 as isize)
             - pcm_start
-            + 1 as i32 as libc::c_long;
-        pcm_start = -(2 as i32 as libc::c_long
+            + 1 as i32 as isize;
+        pcm_start = -(2 as i32 as isize
             * (((1 as i32 as crate::config_types_h::ogg_int64_t) << 62 as i32)
-                - 1 as i32 as libc::c_long)
-            | 1 as i32 as libc::c_long)
-            - 1 as i32 as libc::c_long
+                - 1 as i32 as isize)
+            | 1 as i32 as isize)
+            - 1 as i32 as isize
     }
     pcm_start += _pcm_offset;
     *_li = li_lo;
@@ -3761,9 +3761,9 @@ unsafe extern "C" fn op_pcm_seek_page(
      farther.
     If we can't, simply seek to the beginning of the link.*/
     if (op_granpos_add(&mut _target_gp, _target_gp, -(80 as i32) * 48 as i32) < 0 as i32) as i32
-        as libc::c_long
+        as isize
         != 0
-        || (op_granpos_cmp(_target_gp, pcm_start) < 0 as i32) as i32 as libc::c_long != 0
+        || (op_granpos_cmp(_target_gp, pcm_start) < 0 as i32) as i32 as isize != 0
     {
         _target_gp = pcm_start
     }
@@ -3786,15 +3786,15 @@ unsafe extern "C" fn op_pcm_seek_page(
             We'd be within our rights to just return OP_EBADLINK in that case, but
              we'll simply ignore the current position instead.*/
             offset = (*_of).offset;
-            if op_count > 0 as i32 && (offset <= end) as i32 as libc::c_long != 0 {
+            if op_count > 0 as i32 && (offset <= end) as i32 as isize != 0 {
                 let mut gp: crate::config_types_h::ogg_int64_t = 0;
                 /*Make sure the timestamp is valid.
                 The granule position might be -1 if we collected the packets from a
                  page without a granule position after reporting a hole.*/
                 gp = (*_of).op[(op_count - 1 as i32) as usize].granulepos;
-                if (gp != -(1 as i32) as libc::c_long) as i32 as libc::c_long != 0
-                    && (op_granpos_cmp(pcm_start, gp) < 0 as i32) as i32 as libc::c_long != 0
-                    && (op_granpos_cmp(pcm_end, gp) > 0 as i32) as i32 as libc::c_long != 0
+                if (gp != -(1 as i32) as isize) as i32 as isize != 0
+                    && (op_granpos_cmp(pcm_start, gp) < 0 as i32) as i32 as isize != 0
+                    && (op_granpos_cmp(pcm_end, gp) > 0 as i32) as i32 as isize != 0
                 {
                     /*We only actually use the current time if either
                     a) We can cut off at least half the range, or
@@ -3802,9 +3802,9 @@ unsafe extern "C" fn op_pcm_seek_page(
                         it's likely to be informative.
                     Otherwise it appears using the whole link range to estimate the
                      first seek location gives better results, on average.*/
-                    if diff < 0 as i32 as libc::c_long {
+                    if diff < 0 as i32 as isize {
                         if offset - begin >= end - begin >> 1 as i32
-                            || diff > -(120 as i32 * 48 as i32 * 1000 as i32) as libc::c_long
+                            || diff > -(120 as i32 * 48 as i32 * 1000 as i32) as isize
                         {
                             begin = offset;
                             best = begin;
@@ -3847,7 +3847,7 @@ unsafe extern "C" fn op_pcm_seek_page(
                         /*No such luck.
                         Check if we can cut off at least half the range, though.*/
                         if offset - begin <= end - begin >> 1 as i32
-                            || diff < (120 as i32 * 48 as i32 * 1000 as i32) as libc::c_long
+                            || diff < (120 as i32 * 48 as i32 * 1000 as i32) as isize
                         {
                             /*We really want the page start here, but this will do.*/
                             boundary = offset;
@@ -3910,7 +3910,7 @@ unsafe extern "C" fn op_pcm_seek_page(
             buffering = 0 as i32;
             page_offset = -(1 as i32) as i64;
             ret = op_seek_helper(_of, bisect);
-            if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+            if (ret < 0 as i32) as i32 as isize != 0 {
                 return ret;
             }
         }
@@ -3950,7 +3950,7 @@ unsafe extern "C" fn op_pcm_seek_page(
                         begin
                     };
                     ret = op_seek_helper(_of, bisect);
-                    if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+                    if (ret < 0 as i32) as i32 as isize != 0 {
                         return ret;
                     }
                     /*Bump up the chunk size.*/
@@ -3992,11 +3992,11 @@ unsafe extern "C" fn op_pcm_seek_page(
                         &mut og as *mut _ as *const crate::ogg_h::ogg_page,
                     )
                 } else {
-                    -(1 as i32) as libc::c_long
+                    -(1 as i32) as isize
                 };
-                if gp_0 == -(1 as i32) as libc::c_long {
+                if gp_0 == -(1 as i32) as isize {
                     if buffering != 0 {
-                        if (has_packets == 0) as i32 as libc::c_long != 0 {
+                        if (has_packets == 0) as i32 as isize != 0 {
                             crate::src::libogg_1_3_3::src::framing::ogg_stream_pagein(
                                 &mut (*_of).os as *mut _ as *mut crate::ogg_h::ogg_stream_state,
                                 &mut og as *mut _ as *mut crate::ogg_h::ogg_page,
@@ -4017,8 +4017,8 @@ unsafe extern "C" fn op_pcm_seek_page(
                     /*We found a page that ends before our target.
                     Advance to the raw offset of the next page.*/
                     begin = (*_of).offset;
-                    if (op_granpos_cmp(pcm_start, gp_0) > 0 as i32) as i32 as libc::c_long != 0
-                        || (op_granpos_cmp(pcm_end, gp_0) < 0 as i32) as i32 as libc::c_long != 0
+                    if (op_granpos_cmp(pcm_start, gp_0) > 0 as i32) as i32 as isize != 0
+                        || (op_granpos_cmp(pcm_end, gp_0) < 0 as i32) as i32 as isize != 0
                     {
                         break;
                     }
@@ -4049,7 +4049,7 @@ unsafe extern "C" fn op_pcm_seek_page(
                     best_gp = pcm_start;
                     /*If we're more than a second away from our target, break out and
                     do another bisection.*/
-                    if diff > 48000 as i32 as libc::c_long {
+                    if diff > 48000 as i32 as isize {
                         break;
                     }
                     /*Otherwise, keep scanning forward (do NOT use begin+1).*/
@@ -4067,8 +4067,8 @@ unsafe extern "C" fn op_pcm_seek_page(
                     force_bisect = (end - begin > d0 * 2 as i32 as i64) as i32;
                     /*Don't let pcm_end get out of range!
                     That could happen with an invalid timestamp.*/
-                    if (op_granpos_cmp(pcm_end, gp_0) > 0 as i32) as i32 as libc::c_long != 0
-                        && (op_granpos_cmp(pcm_start, gp_0) <= 0 as i32) as i32 as libc::c_long != 0
+                    if (op_granpos_cmp(pcm_end, gp_0) > 0 as i32) as i32 as isize != 0
+                        && (op_granpos_cmp(pcm_start, gp_0) <= 0 as i32) as i32 as isize != 0
                     {
                         pcm_end = gp_0
                     }
@@ -4087,7 +4087,7 @@ unsafe extern "C" fn op_pcm_seek_page(
         if best_start != page_offset {
             page_offset = -(1 as i32) as i64;
             ret = op_seek_helper(_of, best_start);
-            if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+            if (ret < 0 as i32) as i32 as isize != 0 {
                 return ret;
             }
         }
@@ -4095,10 +4095,10 @@ unsafe extern "C" fn op_pcm_seek_page(
             /*Retrieve the page at best_start, if we do not already have it.*/
             if page_offset < 0 as i32 as i64 {
                 page_offset = op_get_next_page(_of, &mut og, (*link).end_offset);
-                if (page_offset < -(1 as i32) as i64) as i32 as libc::c_long != 0 {
+                if (page_offset < -(1 as i32) as i64) as i32 as isize != 0 {
                     return page_offset as i32;
                 }
-                if (page_offset != best_start) as i32 as libc::c_long != 0 {
+                if (page_offset != best_start) as i32 as isize != 0 {
                     return -(137 as i32);
                 }
             }
@@ -4120,11 +4120,11 @@ unsafe extern "C" fn op_pcm_seek_page(
         0 as i32,
         1 as i32,
     );
-    if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+    if (ret < 0 as i32) as i32 as isize != 0 {
         return -(137 as i32);
     }
     /*Verify result.*/
-    if (op_granpos_cmp((*_of).prev_packet_gp, _target_gp) > 0 as i32) as i32 as libc::c_long != 0 {
+    if (op_granpos_cmp((*_of).prev_packet_gp, _target_gp) > 0 as i32) as i32 as isize != 0 {
         return -(137 as i32);
     }
     /*Our caller will set cur_discard_count to handle pre-roll.*/
@@ -4147,17 +4147,17 @@ pub unsafe extern "C" fn op_pcm_seek(
     let mut op_pos: i32 = 0;
     let mut ret: i32 = 0;
     let mut li: i32 = 0;
-    if ((*_of).ready_state < 2 as i32) as i32 as libc::c_long != 0 {
+    if ((*_of).ready_state < 2 as i32) as i32 as isize != 0 {
         return -(131 as i32);
     }
-    if ((*_of).seekable == 0) as i32 as libc::c_long != 0 {
+    if ((*_of).seekable == 0) as i32 as isize != 0 {
         return -(138 as i32);
     }
-    if (_pcm_offset < 0 as i32 as libc::c_long) as i32 as libc::c_long != 0 {
+    if (_pcm_offset < 0 as i32 as isize) as i32 as isize != 0 {
         return -(131 as i32);
     }
     target_gp = op_get_granulepos(_of, _pcm_offset, &mut li);
-    if (target_gp == -(1 as i32) as libc::c_long) as i32 as libc::c_long != 0 {
+    if (target_gp == -(1 as i32) as isize) as i32 as isize != 0 {
         return -(131 as i32);
     }
     link = (*_of).links.offset(li as isize);
@@ -4168,7 +4168,7 @@ pub unsafe extern "C" fn op_pcm_seek(
     if li == (*_of).cur_link && (*_of).ready_state >= 4 as i32 {
         let mut gp: crate::config_types_h::ogg_int64_t = 0;
         gp = (*_of).prev_packet_gp;
-        if (gp != -(1 as i32) as libc::c_long) as i32 as libc::c_long != 0 {
+        if (gp != -(1 as i32) as isize) as i32 as isize != 0 {
             let mut _nbuffered: i32 = 0;
             _nbuffered = if (*_of).od_buffer_size - (*_of).od_buffer_pos > 0 as i32 {
                 ((*_of).od_buffer_size) - (*_of).od_buffer_pos
@@ -4178,15 +4178,15 @@ pub unsafe extern "C" fn op_pcm_seek(
             /*We do _not_ add cur_discard_count to gp.
             Otherwise the total amount to discard could grow without bound, and it
              would be better just to do a full seek.*/
-            if (op_granpos_diff(&mut diff, gp, pcm_start) == 0) as i32 as libc::c_long != 0 {
+            if (op_granpos_diff(&mut diff, gp, pcm_start) == 0) as i32 as isize != 0 {
                 let mut discard_count: crate::config_types_h::ogg_int64_t = 0;
                 discard_count = _pcm_offset - diff;
                 /*We use a threshold of 90 ms instead of 80, since 80 ms is the
                  _minimum_ we would have discarded after a full seek.
                 Assuming 20 ms frames (the default), we'd discard 90 ms on average.*/
-                if discard_count >= 0 as i32 as libc::c_long
-                    && (discard_count < (90 as i32 * 48 as i32) as libc::c_long) as i32
-                        as libc::c_long
+                if discard_count >= 0 as i32 as isize
+                    && (discard_count < (90 as i32 * 48 as i32) as isize) as i32
+                        as isize
                         != 0
                 {
                     (*_of).cur_discard_count = discard_count as crate::opus_types_h::opus_int32;
@@ -4196,18 +4196,18 @@ pub unsafe extern "C" fn op_pcm_seek(
         }
     }
     ret = op_pcm_seek_page(_of, target_gp, li);
-    if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+    if (ret < 0 as i32) as i32 as isize != 0 {
         return ret;
     }
     /*Now skip samples until we actually get to our target.*/
     /*Figure out where we should skip to.*/
-    if _pcm_offset <= (*link).head.pre_skip as libc::c_long {
+    if _pcm_offset <= (*link).head.pre_skip as isize {
         skip = 0 as i32 as crate::config_types_h::ogg_int64_t
     } else {
-        skip = if _pcm_offset - (80 as i32 * 48 as i32) as libc::c_long > 0 as i32 as libc::c_long {
-            (_pcm_offset) - (80 as i32 * 48 as i32) as libc::c_long
+        skip = if _pcm_offset - (80 as i32 * 48 as i32) as isize > 0 as i32 as isize {
+            (_pcm_offset) - (80 as i32 * 48 as i32) as isize
         } else {
-            0 as i32 as libc::c_long
+            0 as i32 as isize
         }
     }
     loop
@@ -4219,7 +4219,7 @@ pub unsafe extern "C" fn op_pcm_seek(
         while op_pos < op_count {
             let mut cur_packet_gp: crate::config_types_h::ogg_int64_t = 0;
             cur_packet_gp = (*_of).op[op_pos as usize].granulepos;
-            if (op_granpos_diff(&mut diff, cur_packet_gp, pcm_start) == 0) as i32 as libc::c_long
+            if (op_granpos_diff(&mut diff, cur_packet_gp, pcm_start) == 0) as i32 as isize
                 != 0
                 && diff > skip
             {
@@ -4242,7 +4242,7 @@ pub unsafe extern "C" fn op_pcm_seek(
             0 as i32,
             1 as i32,
         );
-        if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+        if (ret < 0 as i32) as i32 as isize != 0 {
             return -(137 as i32);
         }
     }
@@ -4261,7 +4261,7 @@ pub unsafe extern "C" fn op_pcm_seek(
 #[no_mangle]
 
 pub unsafe extern "C" fn op_raw_tell(mut _of: *const crate::internal_h::OggOpusFile) -> i64 {
-    if ((*_of).ready_state < 2 as i32) as i32 as libc::c_long != 0 {
+    if ((*_of).ready_state < 2 as i32) as i32 as isize != 0 {
         return -(131 as i32) as i64;
     }
     return (*_of).offset;
@@ -4282,31 +4282,31 @@ unsafe extern "C" fn op_get_pcm_offset(
     pcm_offset = (*links.offset(_li as isize)).pcm_file_offset;
     if (*_of).seekable != 0
         && (op_granpos_cmp(_gp, (*links.offset(_li as isize)).pcm_end) > 0 as i32) as i32
-            as libc::c_long
+            as isize
             != 0
     {
         _gp = (*links.offset(_li as isize)).pcm_end
     }
     if (op_granpos_cmp(_gp, (*links.offset(_li as isize)).pcm_start) > 0 as i32) as i32
-        as libc::c_long
+        as isize
         != 0
     {
         let mut delta: crate::config_types_h::ogg_int64_t = 0;
         if (op_granpos_diff(&mut delta, _gp, (*links.offset(_li as isize)).pcm_start) < 0 as i32)
-            as i32 as libc::c_long
+            as i32 as isize
             != 0
         {
             /*This means an unseekable stream claimed to have a page from more than
             2 billion days after we joined.*/
-            return 2 as i32 as libc::c_long
+            return 2 as i32 as isize
                 * (((1 as i32 as crate::config_types_h::ogg_int64_t) << 62 as i32)
-                    - 1 as i32 as libc::c_long)
-                | 1 as i32 as libc::c_long;
+                    - 1 as i32 as isize)
+                | 1 as i32 as isize;
         }
-        if delta < (*links.offset(_li as isize)).head.pre_skip as libc::c_long {
+        if delta < (*links.offset(_li as isize)).head.pre_skip as isize {
             delta = 0 as i32 as crate::config_types_h::ogg_int64_t
         } else {
-            delta -= (*links.offset(_li as isize)).head.pre_skip as libc::c_long
+            delta -= (*links.offset(_li as isize)).head.pre_skip as isize
         }
         /*In the seekable case, _gp was limited by pcm_end.
         In the unseekable case, pcm_offset should be 0.*/
@@ -4322,11 +4322,11 @@ pub unsafe extern "C" fn op_pcm_tell(
     let mut gp: crate::config_types_h::ogg_int64_t = 0;
     let mut _nbuffered: i32 = 0;
     let mut li: i32 = 0;
-    if ((*_of).ready_state < 2 as i32) as i32 as libc::c_long != 0 {
+    if ((*_of).ready_state < 2 as i32) as i32 as isize != 0 {
         return -(131 as i32) as crate::config_types_h::ogg_int64_t;
     }
     gp = (*_of).prev_packet_gp;
-    if gp == -(1 as i32) as libc::c_long {
+    if gp == -(1 as i32) as isize {
         return 0 as i32 as crate::config_types_h::ogg_int64_t;
     }
     _nbuffered = if (*_of).od_buffer_size - (*_of).od_buffer_pos > 0 as i32 {
@@ -4471,10 +4471,10 @@ unsafe extern "C" fn op_decode(
             _nsamples,
             0 as i32,
         )
-    } else if (ret > 0 as i32) as i32 as libc::c_long != 0 {
+    } else if (ret > 0 as i32) as i32 as isize != 0 {
         return -(136 as i32);
     }
-    if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+    if (ret < 0 as i32) as i32 as isize != 0 {
         return -(136 as i32);
     }
     return ret;
@@ -4490,7 +4490,7 @@ unsafe extern "C" fn op_read_native(
     mut _buf_size: i32,
     mut _li: *mut i32,
 ) -> i32 {
-    if ((*_of).ready_state < 2 as i32) as i32 as libc::c_long != 0 {
+    if ((*_of).ready_state < 2 as i32) as i32 as isize != 0 {
         return -(131 as i32);
     }
     loop
@@ -4498,7 +4498,7 @@ unsafe extern "C" fn op_read_native(
     This one might have more packets, or might have buffered data now.*/
     {
         let mut ret: i32 = 0;
-        if ((*_of).ready_state >= 4 as i32) as i32 as libc::c_long != 0 {
+        if ((*_of).ready_state >= 4 as i32) as i32 as isize != 0 {
             let mut nchannels: i32 = 0;
             let mut od_buffer_pos: i32 = 0;
             let mut nsamples: i32 = 0;
@@ -4536,7 +4536,7 @@ unsafe extern "C" fn op_read_native(
             }
             /*If we have buffered packets, decode one.*/
             op_pos = (*_of).op_pos;
-            if (op_pos < (*_of).op_count) as i32 as libc::c_long != 0 {
+            if (op_pos < (*_of).op_count) as i32 as isize != 0 {
                 let mut pop: *const crate::ogg_h::ogg_packet = 0 as *const crate::ogg_h::ogg_packet;
                 let mut diff: crate::config_types_h::ogg_int64_t = 0;
                 let mut cur_discard_count: crate::opus_types_h::opus_int32 = 0;
@@ -4551,38 +4551,38 @@ unsafe extern "C" fn op_read_native(
                 /*We don't buffer packets with an invalid TOC sequence.*/
                 trimmed_duration = duration;
                 /*Perform end-trimming.*/
-                if ((*pop).e_o_s != 0) as i32 as libc::c_long != 0 {
+                if ((*pop).e_o_s != 0) as i32 as isize != 0 {
                     if (op_granpos_cmp((*pop).granulepos, (*_of).prev_packet_gp) <= 0 as i32) as i32
-                        as libc::c_long
+                        as isize
                         != 0
                     {
                         trimmed_duration = 0 as i32
                     } else if (op_granpos_diff(&mut diff, (*pop).granulepos, (*_of).prev_packet_gp)
-                        == 0) as i32 as libc::c_long
+                        == 0) as i32 as isize
                         != 0
                     {
-                        trimmed_duration = if diff < trimmed_duration as libc::c_long {
+                        trimmed_duration = if diff < trimmed_duration as isize {
                             diff
                         } else {
-                            trimmed_duration as libc::c_long
+                            trimmed_duration as isize
                         } as i32
                     }
                 }
                 (*_of).prev_packet_gp = (*pop).granulepos;
-                if (duration * nchannels > _buf_size) as i32 as libc::c_long != 0 {
+                if (duration * nchannels > _buf_size) as i32 as isize != 0 {
                     let mut buf: *mut crate::internal_h::op_sample =
                         0 as *mut crate::internal_h::op_sample;
                     /*If the user's buffer is too small, decode into a scratch buffer.*/
                     buf = (*_of).od_buffer;
-                    if buf.is_null() as i32 as libc::c_long != 0 {
+                    if buf.is_null() as i32 as isize != 0 {
                         ret = op_init_buffer(_of);
-                        if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+                        if (ret < 0 as i32) as i32 as isize != 0 {
                             return ret;
                         }
                         buf = (*_of).od_buffer
                     }
                     ret = op_decode(_of, buf, pop, duration, nchannels);
-                    if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+                    if (ret < 0 as i32) as i32 as isize != 0 {
                         return ret;
                     }
                     /*Perform pre-skip/pre-roll.*/
@@ -4598,14 +4598,14 @@ unsafe extern "C" fn op_read_native(
                     /*Update bitrate tracking based on the actual samples we used from
                     what was decoded.*/
                     (*_of).bytes_tracked += (*pop).bytes as i64;
-                    (*_of).samples_tracked += (trimmed_duration - od_buffer_pos) as libc::c_long
+                    (*_of).samples_tracked += (trimmed_duration - od_buffer_pos) as isize
                 } else {
                     /*Otherwise decode directly into the user's buffer.*/
                     ret = op_decode(_of, _pcm, pop, duration, nchannels);
-                    if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+                    if (ret < 0 as i32) as i32 as isize != 0 {
                         return ret;
                     }
-                    if (trimmed_duration > 0 as i32) as i32 as libc::c_long != 0 {
+                    if (trimmed_duration > 0 as i32) as i32 as isize != 0 {
                         /*Perform pre-skip/pre-roll.*/
                         od_buffer_pos = if trimmed_duration < cur_discard_count {
                             trimmed_duration
@@ -4615,8 +4615,8 @@ unsafe extern "C" fn op_read_native(
                         cur_discard_count -= od_buffer_pos;
                         (*_of).cur_discard_count = cur_discard_count;
                         trimmed_duration -= od_buffer_pos;
-                        if (trimmed_duration > 0 as i32) as i32 as libc::c_long != 0
-                            && (od_buffer_pos > 0 as i32) as i32 as libc::c_long != 0
+                        if (trimmed_duration > 0 as i32) as i32 as isize != 0
+                            && (od_buffer_pos > 0 as i32) as i32 as isize != 0
                         {
                             crate::stdlib::memmove(
                                 _pcm as *mut libc::c_void,
@@ -4631,8 +4631,8 @@ unsafe extern "C" fn op_read_native(
                         /*Update bitrate tracking based on the actual samples we used from
                         what was decoded.*/
                         (*_of).bytes_tracked += (*pop).bytes as i64;
-                        (*_of).samples_tracked += trimmed_duration as libc::c_long;
-                        if (trimmed_duration > 0 as i32) as i32 as libc::c_long != 0 {
+                        (*_of).samples_tracked += trimmed_duration as isize;
+                        if (trimmed_duration > 0 as i32) as i32 as isize != 0 {
                             if !_li.is_null() {
                                 *_li = (*_of).cur_link
                             }
@@ -4651,13 +4651,13 @@ unsafe extern "C" fn op_read_native(
             1 as i32,
             0 as i32,
         );
-        if (ret == -(2 as i32)) as i32 as libc::c_long != 0 {
+        if (ret == -(2 as i32)) as i32 as isize != 0 {
             if !_li.is_null() {
                 *_li = (*_of).cur_link
             }
             return 0 as i32;
         }
-        if (ret < 0 as i32) as i32 as libc::c_long != 0 {
+        if (ret < 0 as i32) as i32 as isize != 0 {
             return ret;
         }
     }
@@ -4676,13 +4676,13 @@ unsafe extern "C" fn op_filter_read_native(
     /*Ensure we have some decoded samples in our buffer.*/
     ret = op_read_native(_of, 0 as *mut crate::internal_h::op_sample, 0 as i32, _li);
     /*Now apply the filter to them.*/
-    if (ret >= 0 as i32) as i32 as libc::c_long != 0
-        && ((*_of).ready_state >= 4 as i32) as i32 as libc::c_long != 0
+    if (ret >= 0 as i32) as i32 as isize != 0
+        && ((*_of).ready_state >= 4 as i32) as i32 as isize != 0
     {
         let mut od_buffer_pos: i32 = 0;
         od_buffer_pos = (*_of).od_buffer_pos;
         ret = (*_of).od_buffer_size - od_buffer_pos;
-        if (ret > 0 as i32) as i32 as libc::c_long != 0 {
+        if (ret > 0 as i32) as i32 as isize != 0 {
             let mut nchannels: i32 = 0;
             nchannels = (*(*_of).links.offset(if (*_of).seekable != 0 {
                 (*_of).cur_link
@@ -4804,7 +4804,7 @@ unsafe extern "C" fn op_float2short_filter(
     let mut ci: i32 = 0;
     let mut i: i32 = 0;
     dst = _dst as *mut crate::opus_types_h::opus_int16;
-    if (_nsamples * _nchannels > _dst_sz) as i32 as libc::c_long != 0 {
+    if (_nsamples * _nchannels > _dst_sz) as i32 as isize != 0 {
         _nsamples = _dst_sz / _nchannels
     }
     if (*_of).state_channel_count != _nchannels {

--- a/quake3-rs/ioquake3/src/opusfile_0_9/src/stream.rs
+++ b/quake3-rs/ioquake3/src/opusfile_0_9/src/stream.rs
@@ -162,17 +162,17 @@ unsafe extern "C" fn op_mem_read(
         return 0 as i32;
     }
     /*Check for a short read.*/
-    _buf_size = if size - pos < _buf_size as libc::c_long {
+    _buf_size = if size - pos < _buf_size as isize {
         (size) - pos
     } else {
-        _buf_size as libc::c_long
+        _buf_size as isize
     } as i32;
     crate::stdlib::memcpy(
         _ptr as *mut libc::c_void,
         (*stream).data.offset(pos as isize) as *const libc::c_void,
         _buf_size as libc::c_ulong,
     );
-    pos += _buf_size as libc::c_long;
+    pos += _buf_size as isize;
     (*stream).pos = pos;
     return _buf_size;
 }

--- a/quake3-rs/ioquake3/src/qcommon/cm_load.rs
+++ b/quake3-rs/ioquake3/src/qcommon/cm_load.rs
@@ -282,7 +282,7 @@ pub unsafe extern "C" fn CMod_LoadSubmodels(mut l: *mut crate::qfiles_h::lump_t)
                 (*out).leaf.numLeafBrushes * 4 as i32,
                 crate::src::qcommon::q_shared::h_high,
             ) as *mut i32;
-            (*out).leaf.firstLeafBrush = indexes.offset_from(cm.leafbrushes) as libc::c_long as i32;
+            (*out).leaf.firstLeafBrush = indexes.offset_from(cm.leafbrushes) as isize as i32;
             j = 0 as i32;
             while j < (*out).leaf.numLeafBrushes {
                 *indexes.offset(j as isize) = (*in_0).firstBrush + j;
@@ -294,7 +294,7 @@ pub unsafe extern "C" fn CMod_LoadSubmodels(mut l: *mut crate::qfiles_h::lump_t)
                 crate::src::qcommon::q_shared::h_high,
             ) as *mut i32;
             (*out).leaf.firstLeafSurface =
-                indexes.offset_from(cm.leafsurfaces) as libc::c_long as i32;
+                indexes.offset_from(cm.leafsurfaces) as isize as i32;
             j = 0 as i32;
             while j < (*out).leaf.numLeafSurfaces {
                 *indexes.offset(j as isize) = (*in_0).firstSurface + j;

--- a/quake3-rs/ioquake3/src/qcommon/common.rs
+++ b/quake3-rs/ioquake3/src/qcommon/common.rs
@@ -645,8 +645,8 @@ pub unsafe extern "C" fn Com_Printf(mut fmt: *const libc::c_char, mut args: ...)
             let mut newtime: *mut ::libc::tm = 0 as *mut ::libc::tm;
             let mut aclock: crate::stdlib::time_t = 0;
             opening_qconsole = crate::src::qcommon::q_shared::qtrue;
-            ::libc::time(&mut aclock);
-            newtime = ::libc::localtime(&mut aclock) as *mut ::libc::tm;
+            ::libc::time(&mut aclock as *mut crate::stdlib::time_t as *mut libc::c_long);
+            newtime = ::libc::localtime(&mut aclock as *mut crate::stdlib::time_t as *mut libc::c_long) as *mut ::libc::tm;
             logfile = crate::src::qcommon::files::FS_FOpenFileWrite(
                 b"qconsole.log\x00" as *const u8 as *const libc::c_char,
             );
@@ -1091,7 +1091,7 @@ pub unsafe extern "C" fn Info_Print(mut s: *const libc::c_char) {
             o = o.offset(1);
             *fresh1 = *fresh0
         }
-        l = o.offset_from(key.as_mut_ptr()) as libc::c_long as i32;
+        l = o.offset_from(key.as_mut_ptr()) as isize as i32;
         if l < 20 as i32 {
             crate::stdlib::memset(
                 o as *mut libc::c_void,
@@ -1526,11 +1526,11 @@ pub unsafe extern "C" fn Com_RealTime(
 ) -> i32 {
     let mut t: crate::stdlib::time_t = 0;
     let mut tms: *mut ::libc::tm = 0 as *mut ::libc::tm;
-    t = ::libc::time(0 as *mut crate::stdlib::time_t);
+    t = ::libc::time(0 as *mut libc::c_long) as crate::stdlib::time_t;
     if qtime.is_null() {
         return t as i32;
     }
-    tms = ::libc::localtime(&mut t) as *mut ::libc::tm;
+    tms = ::libc::localtime(&mut t as *mut crate::stdlib::time_t as *mut libc::c_long) as *mut ::libc::tm;
     if !tms.is_null() {
         (*qtime).tm_sec = (*tms).tm_sec;
         (*qtime).tm_min = (*tms).tm_min;
@@ -2512,8 +2512,8 @@ pub unsafe extern "C" fn Com_InitHunkMemory() {
         );
     }
     // cacheline align
-    s_hunkData = (s_hunkData as crate::stdlib::intptr_t + 31 as i32 as libc::c_long
-        & !(31 as i32) as libc::c_long)
+    s_hunkData = (s_hunkData as crate::stdlib::intptr_t + 31 as i32 as isize
+        & !(31 as i32) as isize)
         as *mut crate::src::qcommon::q_shared::byte;
     Hunk_Clear();
     crate::src::qcommon::cmd::Cmd_AddCommand(
@@ -3695,7 +3695,7 @@ unsafe extern "C" fn Com_InitRand() {
     {
         ::libc::srand(seed);
     } else {
-        ::libc::srand(::libc::time(0 as *mut crate::stdlib::time_t) as u32);
+        ::libc::srand(::libc::time(0 as *mut libc::c_long) as u32);
     };
 }
 // commandLine should not include the executable name (argv[0])
@@ -4130,7 +4130,7 @@ pub unsafe extern "C" fn Com_ReadFromPipe() {
             );
             *brk = tmp;
             accu =
-                (accu as libc::c_long - brk.offset_from(buf.as_mut_ptr()) as libc::c_long) as i32;
+                (accu as isize - brk.offset_from(buf.as_mut_ptr()) as isize) as i32;
             crate::stdlib::memmove(
                 buf.as_mut_ptr() as *mut libc::c_void,
                 brk as *const libc::c_void,

--- a/quake3-rs/ioquake3/src/qcommon/cvar.rs
+++ b/quake3-rs/ioquake3/src/qcommon/cvar.rs
@@ -154,11 +154,11 @@ return a hash value for the filename
 ================
 */
 
-unsafe extern "C" fn generateHashValue(mut fname: *const libc::c_char) -> libc::c_long {
+unsafe extern "C" fn generateHashValue(mut fname: *const libc::c_char) -> isize {
     let mut i: i32 = 0;
-    let mut hash: libc::c_long = 0;
+    let mut hash: isize = 0;
     let mut letter: libc::c_char = 0;
-    hash = 0 as i32 as libc::c_long;
+    hash = 0 as i32 as isize;
     i = 0 as i32;
     while *fname.offset(i as isize) as i32 != '\u{0}' as i32 {
         letter = ({
@@ -180,10 +180,10 @@ unsafe extern "C" fn generateHashValue(mut fname: *const libc::c_char) -> libc::
             }
             __res
         }) as libc::c_char;
-        hash += letter as libc::c_long * (i + 119 as i32) as libc::c_long;
+        hash += letter as isize * (i + 119 as i32) as isize;
         i += 1
     }
-    hash &= (256 as i32 - 1 as i32) as libc::c_long;
+    hash &= (256 as i32 - 1 as i32) as isize;
     return hash;
 }
 /*
@@ -220,7 +220,7 @@ unsafe extern "C" fn Cvar_FindVar(
 ) -> *mut crate::src::qcommon::q_shared::cvar_t {
     let mut var: *mut crate::src::qcommon::q_shared::cvar_t =
         0 as *mut crate::src::qcommon::q_shared::cvar_t;
-    let mut hash: libc::c_long = 0;
+    let mut hash: isize = 0;
     hash = generateHashValue(var_name);
     var = hashTable[hash as usize];
     while !var.is_null() {
@@ -521,7 +521,7 @@ pub unsafe extern "C" fn Cvar_Get(
 ) -> *mut crate::src::qcommon::q_shared::cvar_t {
     let mut var: *mut crate::src::qcommon::q_shared::cvar_t =
         0 as *mut crate::src::qcommon::q_shared::cvar_t;
-    let mut hash: libc::c_long = 0;
+    let mut hash: isize = 0;
     let mut index: i32 = 0;
     if var_name.is_null() || var_value.is_null() {
         crate::src::qcommon::common::Com_Error(
@@ -1855,7 +1855,7 @@ pub unsafe extern "C" fn Cvar_Register(
     if vmCvar.is_null() {
         return;
     }
-    (*vmCvar).handle = cv.offset_from(cvar_indexes.as_mut_ptr()) as libc::c_long
+    (*vmCvar).handle = cv.offset_from(cvar_indexes.as_mut_ptr()) as isize
         as crate::src::qcommon::q_shared::cvarHandle_t;
     (*vmCvar).modificationCount = -(1 as i32);
     Cvar_Update(vmCvar);

--- a/quake3-rs/ioquake3/src/qcommon/files.rs
+++ b/quake3-rs/ioquake3/src/qcommon/files.rs
@@ -421,11 +421,11 @@ return a hash value for the filename
 unsafe extern "C" fn FS_HashFileName(
     mut fname: *const libc::c_char,
     mut hashSize: i32,
-) -> libc::c_long {
+) -> isize {
     let mut i: i32 = 0; // don't include extension
-    let mut hash: libc::c_long = 0; // damn path names
+    let mut hash: isize = 0; // damn path names
     let mut letter: libc::c_char = 0; // damn path names
-    hash = 0 as i32 as libc::c_long;
+    hash = 0 as i32 as isize;
     i = 0 as i32;
     while *fname.offset(i as isize) as i32 != '\u{0}' as i32 {
         letter = ({
@@ -456,11 +456,11 @@ unsafe extern "C" fn FS_HashFileName(
         if letter as i32 == '/' as i32 {
             letter = '/' as i32 as libc::c_char
         }
-        hash += letter as libc::c_long * (i + 119 as i32) as libc::c_long;
+        hash += letter as isize * (i + 119 as i32) as isize;
         i += 1
     }
     hash = hash ^ hash >> 10 as i32 ^ hash >> 20 as i32;
-    hash &= (hashSize - 1 as i32) as libc::c_long;
+    hash &= (hashSize - 1 as i32) as isize;
     return hash;
 }
 
@@ -522,11 +522,11 @@ FS_fplength
 */
 #[no_mangle]
 
-pub unsafe extern "C" fn FS_fplength(mut h: *mut crate::stdlib::FILE) -> libc::c_long {
-    let mut pos: libc::c_long = 0;
-    let mut end: libc::c_long = 0;
+pub unsafe extern "C" fn FS_fplength(mut h: *mut crate::stdlib::FILE) -> isize {
+    let mut pos: isize = 0;
+    let mut end: isize = 0;
     pos = crate::stdlib::ftell(h);
-    crate::stdlib::fseek(h, 0 as i32 as libc::c_long, 2 as i32);
+    crate::stdlib::fseek(h, 0 as i32 as isize, 2 as i32);
     end = crate::stdlib::ftell(h);
     crate::stdlib::fseek(h, pos, 0 as i32);
     return end;
@@ -544,11 +544,11 @@ size of the file.
 
 pub unsafe extern "C" fn FS_filelength(
     mut f: crate::src::qcommon::q_shared::fileHandle_t,
-) -> libc::c_long {
+) -> isize {
     let mut h: *mut crate::stdlib::FILE = 0 as *mut crate::stdlib::FILE;
     h = FS_FileForHandle(f);
     if h.is_null() {
-        return -(1 as i32) as libc::c_long;
+        return -(1 as i32) as isize;
     } else {
         return FS_fplength(h);
     };
@@ -887,7 +887,7 @@ in that order
 pub unsafe extern "C" fn FS_SV_FOpenFileRead(
     mut filename: *const libc::c_char,
     mut fp: *mut crate::src::qcommon::q_shared::fileHandle_t,
-) -> libc::c_long {
+) -> isize {
     let mut ospath: *mut libc::c_char = 0 as *mut libc::c_char;
     let mut f: crate::src::qcommon::q_shared::fileHandle_t = 0 as i32;
     if fs_searchpaths.is_null() {
@@ -1010,7 +1010,7 @@ pub unsafe extern "C" fn FS_SV_FOpenFileRead(
     if f != 0 {
         return FS_filelength(f);
     }
-    return -(1 as i32) as libc::c_long;
+    return -(1 as i32) as isize;
 }
 /*
 ===========
@@ -1440,8 +1440,8 @@ pub unsafe extern "C" fn FS_FOpenFileReadDir(
     mut file: *mut crate::src::qcommon::q_shared::fileHandle_t,
     mut uniqueFILE: crate::src::qcommon::q_shared::qboolean,
     mut unpure: crate::src::qcommon::q_shared::qboolean,
-) -> libc::c_long {
-    let mut hash: libc::c_long = 0;
+) -> isize {
+    let mut hash: isize = 0;
     let mut pak: *mut pack_t = 0 as *mut pack_t;
     let mut pakFile: *mut fileInPack_t = 0 as *mut fileInPack_t;
     let mut dir: *mut directory_t = 0 as *mut directory_t;
@@ -1468,10 +1468,10 @@ pub unsafe extern "C" fn FS_FOpenFileReadDir(
         || !::libc::strstr(filename, b"::\x00" as *const u8 as *const libc::c_char).is_null()
     {
         if file.is_null() {
-            return crate::src::qcommon::q_shared::qfalse as i32 as libc::c_long;
+            return crate::src::qcommon::q_shared::qfalse as i32 as isize;
         }
         *file = 0 as i32;
-        return -(1 as i32) as libc::c_long;
+        return -(1 as i32) as isize;
     }
     // make sure the q3key file is only readable by the quake3.exe at initialization
     // any other time the key should only be accessed in memory using the provided functions
@@ -1479,10 +1479,10 @@ pub unsafe extern "C" fn FS_FOpenFileReadDir(
         && !::libc::strstr(filename, b"q3key\x00" as *const u8 as *const libc::c_char).is_null()
     {
         if file.is_null() {
-            return crate::src::qcommon::q_shared::qfalse as i32 as libc::c_long;
+            return crate::src::qcommon::q_shared::qfalse as i32 as isize;
         }
         *file = 0 as i32;
-        return -(1 as i32) as libc::c_long;
+        return -(1 as i32) as isize;
     }
     if file.is_null() {
         // just wants to see if file is there
@@ -1498,12 +1498,12 @@ pub unsafe extern "C" fn FS_FOpenFileReadDir(
                     if FS_FilenameCompare((*pakFile).name, filename) as u64 == 0 {
                         // found it!
                         if (*pakFile).len != 0 {
-                            return (*pakFile).len as libc::c_long;
+                            return (*pakFile).len as isize;
                         } else {
                             // It's not nice, but legacy code depends
                             // on positive value if file exists no matter
                             // what size
-                            return 1 as i32 as libc::c_long;
+                            return 1 as i32 as isize;
                         }
                     }
                     pakFile = (*pakFile).next;
@@ -1527,13 +1527,13 @@ pub unsafe extern "C" fn FS_FOpenFileReadDir(
                 len = FS_fplength(filep) as i32;
                 crate::stdlib::fclose(filep);
                 if len != 0 {
-                    return len as libc::c_long;
+                    return len as isize;
                 } else {
-                    return 1 as i32 as libc::c_long;
+                    return 1 as i32 as isize;
                 }
             }
         }
-        return 0 as i32 as libc::c_long;
+        return 0 as i32 as isize;
     }
     *file = FS_HandleForFile();
     fsh[*file as usize].handleFiles.unique = uniqueFILE;
@@ -1544,7 +1544,7 @@ pub unsafe extern "C" fn FS_FOpenFileReadDir(
             // disregard if it doesn't match one of the allowed pure pak files
             if unpure as u64 == 0 && FS_PakIsPure((*search).pack) as u64 == 0 {
                 *file = 0 as i32;
-                return -(1 as i32) as libc::c_long;
+                return -(1 as i32) as isize;
             }
             // look through all the pak file elements
             pak = (*search).pack;
@@ -1666,7 +1666,7 @@ pub unsafe extern "C" fn FS_FOpenFileReadDir(
                             (*pak).pakFilename.as_mut_ptr(),
                         );
                     }
-                    return (*pakFile).len as libc::c_long;
+                    return (*pakFile).len as isize;
                 }
                 pakFile = (*pakFile).next;
                 if pakFile.is_null() {
@@ -1713,7 +1713,7 @@ pub unsafe extern "C" fn FS_FOpenFileReadDir(
             {
                 // demos
                 *file = 0 as i32;
-                return -(1 as i32) as libc::c_long;
+                return -(1 as i32) as isize;
             }
         }
         dir = (*search).dir;
@@ -1728,7 +1728,7 @@ pub unsafe extern "C" fn FS_FOpenFileReadDir(
         ) as *mut crate::stdlib::_IO_FILE;
         if filep.is_null() {
             *file = 0 as i32;
-            return -(1 as i32) as libc::c_long;
+            return -(1 as i32) as isize;
         }
         crate::src::qcommon::q_shared::Q_strncpyz(
             fsh[*file as usize].name.as_mut_ptr(),
@@ -1750,7 +1750,7 @@ pub unsafe extern "C" fn FS_FOpenFileReadDir(
         return FS_fplength(filep);
     }
     *file = 0 as i32;
-    return -(1 as i32) as libc::c_long;
+    return -(1 as i32) as isize;
 }
 /*
 ===========
@@ -1768,9 +1768,9 @@ pub unsafe extern "C" fn FS_FOpenFileRead(
     mut filename: *const libc::c_char,
     mut file: *mut crate::src::qcommon::q_shared::fileHandle_t,
     mut uniqueFILE: crate::src::qcommon::q_shared::qboolean,
-) -> libc::c_long {
+) -> isize {
     let mut search: *mut searchpath_t = 0 as *mut searchpath_t;
-    let mut len: libc::c_long = 0;
+    let mut len: isize = 0;
     let mut isLocalConfig: crate::src::qcommon::q_shared::qboolean =
         crate::src::qcommon::q_shared::qfalse;
     if fs_searchpaths.is_null() {
@@ -1799,10 +1799,10 @@ pub unsafe extern "C" fn FS_FOpenFileRead(
                 crate::src::qcommon::q_shared::qfalse,
             );
             if file.is_null() {
-                if len > 0 as i32 as libc::c_long {
+                if len > 0 as i32 as isize {
                     return len;
                 }
-            } else if len >= 0 as i32 as libc::c_long && *file != 0 {
+            } else if len >= 0 as i32 as isize && *file != 0 {
                 return len;
             }
         }
@@ -1810,11 +1810,11 @@ pub unsafe extern "C" fn FS_FOpenFileRead(
     }
     if !file.is_null() {
         *file = 0 as i32;
-        return -(1 as i32) as libc::c_long;
+        return -(1 as i32) as isize;
     } else {
         // When file is NULL, we're querying the existence of the file
         // If we've got here, it doesn't exist
-        return 0 as i32 as libc::c_long;
+        return 0 as i32 as isize;
     };
 }
 /*
@@ -1896,7 +1896,7 @@ pub unsafe extern "C" fn FS_FindVM(
                 0 as *mut crate::src::qcommon::q_shared::fileHandle_t,
                 crate::src::qcommon::q_shared::qfalse,
                 crate::src::qcommon::q_shared::qfalse,
-            ) > 0 as i32 as libc::c_long
+            ) > 0 as i32 as isize
             {
                 *startSearch = search as *mut libc::c_void;
                 return crate::qcommon_h::VMI_COMPILED as i32;
@@ -1922,7 +1922,7 @@ pub unsafe extern "C" fn FS_FindVM(
                 0 as *mut crate::src::qcommon::q_shared::fileHandle_t,
                 crate::src::qcommon::q_shared::qfalse,
                 crate::src::qcommon::q_shared::qfalse,
-            ) > 0 as i32 as libc::c_long
+            ) > 0 as i32 as isize
             {
                 *startSearch = search as *mut libc::c_void;
                 return crate::qcommon_h::VMI_COMPILED as i32;
@@ -2100,7 +2100,7 @@ FS_Seek
 
 pub unsafe extern "C" fn FS_Seek(
     mut f: crate::src::qcommon::q_shared::fileHandle_t,
-    mut offset: libc::c_long,
+    mut offset: isize,
     mut origin: i32,
 ) -> i32 {
     let mut _origin: i32 = 0;
@@ -2117,10 +2117,10 @@ pub unsafe extern "C" fn FS_Seek(
         let mut remainder: i32 = 0;
         let mut currentPosition: i32 = FS_FTell(f);
         // change negative offsets into FS_SEEK_SET
-        if offset < 0 as i32 as libc::c_long {
+        if offset < 0 as i32 as isize {
             match origin {
-                1 => remainder = (fsh[f as usize].zipFileLen as libc::c_long + offset) as i32,
-                0 => remainder = (currentPosition as libc::c_long + offset) as i32,
+                1 => remainder = (fsh[f as usize].zipFileLen as isize + offset) as i32,
+                0 => remainder = (currentPosition as isize + offset) as i32,
                 2 | _ => remainder = 0 as i32,
             }
             if remainder < 0 as i32 {
@@ -2129,7 +2129,7 @@ pub unsafe extern "C" fn FS_Seek(
             origin = crate::src::qcommon::q_shared::FS_SEEK_SET as i32
         } else if origin == crate::src::qcommon::q_shared::FS_SEEK_END as i32 {
             remainder =
-                ((fsh[f as usize].zipFileLen - currentPosition) as libc::c_long + offset) as i32
+                ((fsh[f as usize].zipFileLen - currentPosition) as isize + offset) as i32
         } else {
             remainder = offset as i32
         }
@@ -2192,7 +2192,7 @@ pub unsafe extern "C" fn FS_FileIsInPAK(
     let mut search: *mut searchpath_t = 0 as *mut searchpath_t;
     let mut pak: *mut pack_t = 0 as *mut pack_t;
     let mut pakFile: *mut fileInPack_t = 0 as *mut fileInPack_t;
-    let mut hash: libc::c_long = 0 as i32 as libc::c_long;
+    let mut hash: isize = 0 as i32 as isize;
     if fs_searchpaths.is_null() {
         crate::src::qcommon::common::Com_Error(
             crate::src::qcommon::q_shared::ERR_FATAL as i32,
@@ -2273,14 +2273,14 @@ pub unsafe extern "C" fn FS_ReadFileDir(
     mut searchPath: *mut libc::c_void,
     mut unpure: crate::src::qcommon::q_shared::qboolean,
     mut buffer: *mut *mut libc::c_void,
-) -> libc::c_long {
+) -> isize {
     let mut h: crate::src::qcommon::q_shared::fileHandle_t = 0; // quiet compiler warning
     let mut search: *mut searchpath_t = 0 as *mut searchpath_t;
     let mut buf: *mut crate::src::qcommon::q_shared::byte =
         0 as *mut crate::src::qcommon::q_shared::byte;
     let mut isConfig: crate::src::qcommon::q_shared::qboolean =
         crate::src::qcommon::q_shared::qfalse;
-    let mut len: libc::c_long = 0;
+    let mut len: isize = 0;
     if fs_searchpaths.is_null() {
         crate::src::qcommon::common::Com_Error(
             crate::src::qcommon::q_shared::ERR_FATAL as i32,
@@ -2307,30 +2307,30 @@ pub unsafe extern "C" fn FS_ReadFileDir(
                 qpath,
             );
             r = FS_Read(
-                &mut len as *mut libc::c_long as *mut libc::c_void,
-                ::std::mem::size_of::<libc::c_long>() as libc::c_ulong as i32,
+                &mut len as *mut isize as *mut libc::c_void,
+                ::std::mem::size_of::<isize>() as libc::c_ulong as i32,
                 crate::src::qcommon::common::com_journalDataFile,
             );
-            if r as libc::c_ulong != ::std::mem::size_of::<libc::c_long>() as libc::c_ulong {
+            if r as libc::c_ulong != ::std::mem::size_of::<isize>() as libc::c_ulong {
                 if !buffer.is_null() {
                     *buffer = 0 as *mut libc::c_void
                 }
-                return -(1 as i32) as libc::c_long;
+                return -(1 as i32) as isize;
             }
             // if the file didn't exist when the journal was created
             if len == 0 {
                 if buffer.is_null() {
-                    return 1 as i32 as libc::c_long;
+                    return 1 as i32 as isize;
                     // hack for old journal files
                 }
                 *buffer = 0 as *mut libc::c_void;
-                return -(1 as i32) as libc::c_long;
+                return -(1 as i32) as isize;
             }
             if buffer.is_null() {
                 return len;
             }
             buf = crate::src::qcommon::common::Hunk_AllocateTempMemory(
-                (len + 1 as i32 as libc::c_long) as i32,
+                (len + 1 as i32 as isize) as i32,
             ) as *mut crate::src::qcommon::q_shared::byte;
             *buffer = buf as *mut libc::c_void;
             r = FS_Read(
@@ -2338,7 +2338,7 @@ pub unsafe extern "C" fn FS_ReadFileDir(
                 len as i32,
                 crate::src::qcommon::common::com_journalDataFile,
             );
-            if r as libc::c_long != len {
+            if r as isize != len {
                 crate::src::qcommon::common::Com_Error(
                     crate::src::qcommon::q_shared::ERR_FATAL as i32,
                     b"Read from journalDataFile failed\x00" as *const u8 as *const libc::c_char,
@@ -2380,15 +2380,15 @@ pub unsafe extern "C" fn FS_ReadFileDir(
                 b"Writing zero for %s to journal file.\n\x00" as *const u8 as *const libc::c_char,
                 qpath,
             );
-            len = 0 as i32 as libc::c_long;
+            len = 0 as i32 as isize;
             FS_Write(
-                &mut len as *mut libc::c_long as *const libc::c_void,
-                ::std::mem::size_of::<libc::c_long>() as libc::c_ulong as i32,
+                &mut len as *mut isize as *const libc::c_void,
+                ::std::mem::size_of::<isize>() as libc::c_ulong as i32,
                 crate::src::qcommon::common::com_journalDataFile,
             );
             FS_Flush(crate::src::qcommon::common::com_journalDataFile);
         }
-        return -(1 as i32) as libc::c_long;
+        return -(1 as i32) as isize;
     }
     if buffer.is_null() {
         if isConfig as u32 != 0
@@ -2400,8 +2400,8 @@ pub unsafe extern "C" fn FS_ReadFileDir(
                 qpath,
             );
             FS_Write(
-                &mut len as *mut libc::c_long as *const libc::c_void,
-                ::std::mem::size_of::<libc::c_long>() as libc::c_ulong as i32,
+                &mut len as *mut isize as *const libc::c_void,
+                ::std::mem::size_of::<isize>() as libc::c_ulong as i32,
                 crate::src::qcommon::common::com_journalDataFile,
             );
             FS_Flush(crate::src::qcommon::common::com_journalDataFile);
@@ -2412,7 +2412,7 @@ pub unsafe extern "C" fn FS_ReadFileDir(
     fs_loadCount += 1;
     fs_loadStack += 1;
     buf = crate::src::qcommon::common::Hunk_AllocateTempMemory(
-        (len + 1 as i32 as libc::c_long) as i32,
+        (len + 1 as i32 as isize) as i32,
     ) as *mut crate::src::qcommon::q_shared::byte;
     *buffer = buf as *mut libc::c_void;
     FS_Read(buf as *mut libc::c_void, len as i32, h);
@@ -2429,8 +2429,8 @@ pub unsafe extern "C" fn FS_ReadFileDir(
             qpath,
         );
         FS_Write(
-            &mut len as *mut libc::c_long as *const libc::c_void,
-            ::std::mem::size_of::<libc::c_long>() as libc::c_ulong as i32,
+            &mut len as *mut isize as *const libc::c_void,
+            ::std::mem::size_of::<isize>() as libc::c_ulong as i32,
             crate::src::qcommon::common::com_journalDataFile,
         );
         FS_Write(
@@ -2455,7 +2455,7 @@ a null buffer will just return the file length without loading
 pub unsafe extern "C" fn FS_ReadFile(
     mut qpath: *const libc::c_char,
     mut buffer: *mut *mut libc::c_void,
-) -> libc::c_long {
+) -> isize {
     return FS_ReadFileDir(
         qpath,
         0 as *mut libc::c_void,
@@ -2585,7 +2585,7 @@ unsafe extern "C" fn FS_LoadZipFile(
         };
     let mut i: i32 = 0;
     let mut len: i32 = 0;
-    let mut hash: libc::c_long = 0;
+    let mut hash: isize = 0;
     let mut fs_numHeaderLongs: i32 = 0;
     let mut fs_headerLongs: *mut i32 = 0 as *mut i32;
     let mut namePtr: *mut libc::c_char = 0 as *mut libc::c_char;
@@ -3700,7 +3700,7 @@ pub unsafe extern "C" fn FS_Which(
         0 as *mut crate::src::qcommon::q_shared::fileHandle_t,
         crate::src::qcommon::q_shared::qfalse,
         crate::src::qcommon::q_shared::qfalse,
-    ) > 0 as i32 as libc::c_long
+    ) > 0 as i32 as isize
     {
         if !(*search).pack.is_null() {
             crate::src::qcommon::common::Com_Printf(
@@ -4207,7 +4207,7 @@ pub unsafe extern "C" fn FS_ComparePaks(
                         // Find out whether it might have overflowed the buffer and don't add this file to the
                         // list if that is the case.
                         if crate::stdlib::strlen(origpos).wrapping_add(
-                            origpos.offset_from(neededpaks) as libc::c_long as libc::c_ulong,
+                            origpos.offset_from(neededpaks) as isize as libc::c_ulong,
                         ) >= (len - 1 as i32) as libc::c_ulong
                         {
                             *origpos = '\u{0}' as i32 as libc::c_char;
@@ -5213,7 +5213,7 @@ pub unsafe extern "C" fn FS_InitFilesystem() {
     if FS_ReadFile(
         b"default.cfg\x00" as *const u8 as *const libc::c_char,
         0 as *mut *mut libc::c_void,
-    ) <= 0 as i32 as libc::c_long
+    ) <= 0 as i32 as isize
     {
         crate::src::qcommon::common::Com_Error(
             crate::src::qcommon::q_shared::ERR_FATAL as i32,
@@ -5265,7 +5265,7 @@ pub unsafe extern "C" fn FS_Restart(mut checksumFeed: i32) {
     if FS_ReadFile(
         b"default.cfg\x00" as *const u8 as *const libc::c_char,
         0 as *mut *mut libc::c_void,
-    ) <= 0 as i32 as libc::c_long
+    ) <= 0 as i32 as isize
     {
         // this might happen when connecting to a pure server not using BASEGAME/pak0.pk3
         // (for instance a TA demo server)

--- a/quake3-rs/ioquake3/src/qcommon/ioapi.rs
+++ b/quake3-rs/ioquake3/src/qcommon/ioapi.rs
@@ -26,7 +26,7 @@ pub type write_file_func = Option<
 >;
 
 pub type tell_file_func = Option<
-    unsafe extern "C" fn(_: crate::zconf_h::voidpf, _: crate::zconf_h::voidpf) -> libc::c_long,
+    unsafe extern "C" fn(_: crate::zconf_h::voidpf, _: crate::zconf_h::voidpf) -> isize,
 >;
 
 pub type seek_file_func = Option<
@@ -35,7 +35,7 @@ pub type seek_file_func = Option<
         _: crate::zconf_h::voidpf,
         _: crate::zconf_h::uLong,
         _: i32,
-    ) -> libc::c_long,
+    ) -> isize,
 >;
 
 pub type close_file_func =
@@ -141,8 +141,8 @@ pub unsafe extern "C" fn fwrite_file_func(
 pub unsafe extern "C" fn ftell_file_func(
     mut _opaque: crate::zconf_h::voidpf,
     mut stream: crate::zconf_h::voidpf,
-) -> libc::c_long {
-    let mut ret: libc::c_long = 0;
+) -> isize {
+    let mut ret: isize = 0;
     ret = crate::stdlib::ftell(stream as *mut crate::stdlib::FILE);
     return ret;
 }
@@ -153,19 +153,19 @@ pub unsafe extern "C" fn fseek_file_func(
     mut stream: crate::zconf_h::voidpf,
     mut offset: crate::zconf_h::uLong,
     mut origin: i32,
-) -> libc::c_long {
+) -> isize {
     let mut fseek_origin: i32 = 0 as i32;
-    let mut ret: libc::c_long = 0;
+    let mut ret: isize = 0;
     match origin {
         1 => fseek_origin = 1 as i32,
         2 => fseek_origin = 2 as i32,
         0 => fseek_origin = 0 as i32,
-        _ => return -(1 as i32) as libc::c_long,
+        _ => return -(1 as i32) as isize,
     }
-    ret = 0 as i32 as libc::c_long;
+    ret = 0 as i32 as isize;
     crate::stdlib::fseek(
         stream as *mut crate::stdlib::FILE,
-        offset as libc::c_long,
+        offset as isize,
         fseek_origin,
     );
     return ret;
@@ -231,14 +231,14 @@ pub unsafe extern "C" fn fill_fopen_filefunc(
         unsafe extern "C" fn() -> crate::zconf_h::uLong,
     >(fwrite_file_func)));
     (*pzlib_filefunc_def).ztell_file = ::std::mem::transmute::<
-        Option<unsafe extern "C" fn() -> libc::c_long>,
+        Option<unsafe extern "C" fn() -> isize>,
         crate::src::qcommon::ioapi::tell_file_func,
     >(Some(::std::mem::transmute::<
-        unsafe extern "C" fn(_: crate::zconf_h::voidpf, _: crate::zconf_h::voidpf) -> libc::c_long,
-        unsafe extern "C" fn() -> libc::c_long,
+        unsafe extern "C" fn(_: crate::zconf_h::voidpf, _: crate::zconf_h::voidpf) -> isize,
+        unsafe extern "C" fn() -> isize,
     >(ftell_file_func)));
     (*pzlib_filefunc_def).zseek_file = ::std::mem::transmute::<
-        Option<unsafe extern "C" fn() -> libc::c_long>,
+        Option<unsafe extern "C" fn() -> isize>,
         crate::src::qcommon::ioapi::seek_file_func,
     >(Some(::std::mem::transmute::<
         unsafe extern "C" fn(
@@ -246,8 +246,8 @@ pub unsafe extern "C" fn fill_fopen_filefunc(
             _: crate::zconf_h::voidpf,
             _: crate::zconf_h::uLong,
             _: i32,
-        ) -> libc::c_long,
-        unsafe extern "C" fn() -> libc::c_long,
+        ) -> isize,
+        unsafe extern "C" fn() -> isize,
     >(fseek_file_func)));
     (*pzlib_filefunc_def).zclose_file = ::std::mem::transmute::<
         Option<unsafe extern "C" fn() -> i32>,

--- a/quake3-rs/ioquake3/src/qcommon/net_ip.rs
+++ b/quake3-rs/ioquake3/src/qcommon/net_ip.rs
@@ -755,7 +755,7 @@ pub unsafe extern "C" fn NET_GetPacket(
                     % (8 as i32
                         * ::std::mem::size_of::<crate::stdlib::__fd_mask>() as libc::c_ulong
                             as i32)) as crate::stdlib::__fd_mask
-            != 0 as i32 as libc::c_long
+            != 0 as i32 as isize
     {
         fromlen = ::std::mem::size_of::<crate::stdlib::sockaddr_storage>() as libc::c_ulong
             as crate::stdlib::socklen_t;
@@ -835,7 +835,7 @@ pub unsafe extern "C" fn NET_GetPacket(
                     % (8 as i32
                         * ::std::mem::size_of::<crate::stdlib::__fd_mask>() as libc::c_ulong
                             as i32)) as crate::stdlib::__fd_mask
-            != 0 as i32 as libc::c_long
+            != 0 as i32 as isize
     {
         fromlen = ::std::mem::size_of::<crate::stdlib::sockaddr_storage>() as libc::c_ulong
             as crate::stdlib::socklen_t;
@@ -883,7 +883,7 @@ pub unsafe extern "C" fn NET_GetPacket(
                     % (8 as i32
                         * ::std::mem::size_of::<crate::stdlib::__fd_mask>() as libc::c_ulong
                             as i32)) as crate::stdlib::__fd_mask
-            != 0 as i32 as libc::c_long
+            != 0 as i32 as isize
     {
         fromlen = ::std::mem::size_of::<crate::stdlib::sockaddr_storage>() as libc::c_ulong
             as crate::stdlib::socklen_t;
@@ -1735,7 +1735,7 @@ pub unsafe extern "C" fn NET_OpenSocks(mut port: i32) {
         buf.as_mut_ptr() as *mut libc::c_void,
         len as crate::stddef_h::size_t,
         0 as i32,
-    ) == -(1 as i32) as libc::c_long
+    ) == -(1 as i32) as isize
     {
         crate::src::qcommon::common::Com_Printf(
             b"NET_OpenSocks: send: %s\n\x00" as *const u8 as *const libc::c_char,
@@ -1804,7 +1804,7 @@ pub unsafe extern "C" fn NET_OpenSocks(mut port: i32) {
             buf.as_mut_ptr() as *mut libc::c_void,
             (3 as i32 + ulen + plen) as crate::stddef_h::size_t,
             0 as i32,
-        ) == -(1 as i32) as libc::c_long
+        ) == -(1 as i32) as isize
         {
             crate::src::qcommon::common::Com_Printf(
                 b"NET_OpenSocks: send: %s\n\x00" as *const u8 as *const libc::c_char,
@@ -1853,7 +1853,7 @@ pub unsafe extern "C" fn NET_OpenSocks(mut port: i32) {
         buf.as_mut_ptr() as *mut libc::c_void,
         10 as i32 as crate::stddef_h::size_t,
         0 as i32,
-    ) == -(1 as i32) as libc::c_long
+    ) == -(1 as i32) as isize
     {
         crate::src::qcommon::common::Com_Printf(
             b"NET_OpenSocks: send: %s\n\x00" as *const u8 as *const libc::c_char,
@@ -2394,8 +2394,8 @@ pub unsafe extern "C" fn NET_Sleep(mut msec: i32) {
             highestfd = ip6_socket
         }
     }
-    timeout.tv_sec = (msec / 1000 as i32) as crate::stdlib::__time_t;
-    timeout.tv_usec = (msec % 1000 as i32 * 1000 as i32) as crate::stdlib::__suseconds_t;
+    timeout.tv_sec = ((msec / 1000 as i32) as crate::stdlib::__time_t) as libc::time_t;
+    timeout.tv_usec = ((msec % 1000 as i32 * 1000 as i32) as crate::stdlib::__suseconds_t) as libc::suseconds_t;
     retval = crate::stdlib::select(
         highestfd + 1 as i32,
         &mut fdr,

--- a/quake3-rs/ioquake3/src/qcommon/puff.rs
+++ b/quake3-rs/ioquake3/src/qcommon/puff.rs
@@ -77,7 +77,7 @@ unsafe extern "C" fn bits(
     (*s).bitbuf = val >> need;
     (*s).bitcnt -= need;
     /* return need bits, zeroing the bits above that */
-    return (val as libc::c_long & ((1 as libc::c_long) << need) - 1 as i32 as libc::c_long)
+    return (val as isize & ((1 as isize) << need) - 1 as i32 as isize)
         as crate::stdlib::int32_t;
 }
 /*

--- a/quake3-rs/ioquake3/src/qcommon/q_shared.rs
+++ b/quake3-rs/ioquake3/src/qcommon/q_shared.rs
@@ -585,12 +585,12 @@ pub unsafe extern "C" fn COM_StripExtension(
         slash = ::libc::strrchr(in_0, '/' as i32);
         (slash.is_null()) || slash < dot
     } {
-        destsize = if (destsize as libc::c_long)
-            < dot.offset_from(in_0) as libc::c_long + 1 as i32 as libc::c_long
+        destsize = if (destsize as isize)
+            < dot.offset_from(in_0) as isize + 1 as i32 as isize
         {
-            destsize as libc::c_long
+            destsize as isize
         } else {
-            (dot.offset_from(in_0) as libc::c_long) + 1 as i32 as libc::c_long
+            (dot.offset_from(in_0) as isize) + 1 as i32 as isize
         } as i32
     }
     if in_0 == out as *const libc::c_char && destsize > 1 as i32 {
@@ -1052,7 +1052,7 @@ pub unsafe extern "C" fn COM_Compress(mut data_p: *mut libc::c_char) -> i32 {
         }
         *out = 0 as i32 as libc::c_char
     }
-    return out.offset_from(data_p) as libc::c_long as i32;
+    return out.offset_from(data_p) as isize as i32;
 }
 #[no_mangle]
 

--- a/quake3-rs/ioquake3/src/qcommon/unzip.rs
+++ b/quake3-rs/ioquake3/src/qcommon/unzip.rs
@@ -326,7 +326,7 @@ unsafe extern "C" fn unzlocal_SearchCentralDir(
         filestream,
         0 as i32 as crate::zconf_h::uLong,
         2 as i32,
-    ) != 0 as i32 as libc::c_long
+    ) != 0 as i32 as isize
     {
         return 0 as i32 as crate::zconf_h::uLong;
     }
@@ -372,7 +372,7 @@ unsafe extern "C" fn unzlocal_SearchCentralDir(
             filestream,
             uReadPos,
             0 as i32,
-        ) != 0 as i32 as libc::c_long
+        ) != 0 as i32 as isize
         {
             break;
         }
@@ -520,7 +520,7 @@ pub unsafe extern "C" fn unzOpen2(
         us.filestream,
         central_pos,
         0 as i32,
-    ) != 0 as i32 as libc::c_long
+    ) != 0 as i32 as isize
     {
         err = -(1 as i32)
     }
@@ -716,7 +716,7 @@ unsafe extern "C" fn unzlocal_GetCurrentFileInfoInternal(
         unz_file_info_internal { offset_curfile: 0 };
     let mut err: i32 = 0 as i32;
     let mut uMagic: crate::zconf_h::uLong = 0;
-    let mut lSeek: libc::c_long = 0 as i32 as libc::c_long;
+    let mut lSeek: isize = 0 as i32 as isize;
     if file.is_null() {
         return -(102 as i32);
     }
@@ -732,7 +732,7 @@ unsafe extern "C" fn unzlocal_GetCurrentFileInfoInternal(
         (*s).pos_in_central_dir
             .wrapping_add((*s).byte_before_the_zipfile),
         0 as i32,
-    ) != 0 as i32 as libc::c_long
+    ) != 0 as i32 as isize
     {
         err = -(1 as i32)
     }
@@ -855,8 +855,8 @@ unsafe extern "C" fn unzlocal_GetCurrentFileInfoInternal(
     {
         err = -(1 as i32)
     }
-    lSeek = (lSeek as libc::c_ulong).wrapping_add(file_info.size_filename) as libc::c_long
-        as libc::c_long;
+    lSeek = (lSeek as libc::c_ulong).wrapping_add(file_info.size_filename) as isize
+        as isize;
     if err == 0 as i32 && !szFileName.is_null() {
         let mut uSizeRead: crate::zconf_h::uLong = 0;
         if file_info.size_filename < fileNameBufferSize {
@@ -883,7 +883,7 @@ unsafe extern "C" fn unzlocal_GetCurrentFileInfoInternal(
                 err = -(1 as i32)
             }
         }
-        lSeek = (lSeek as libc::c_ulong).wrapping_sub(uSizeRead) as libc::c_long as libc::c_long
+        lSeek = (lSeek as libc::c_ulong).wrapping_sub(uSizeRead) as isize as isize
     }
     if err == 0 as i32 && !extraField.is_null() {
         let mut uSizeRead_0: crate::zconf_h::uLong = 0;
@@ -892,7 +892,7 @@ unsafe extern "C" fn unzlocal_GetCurrentFileInfoInternal(
         } else {
             uSizeRead_0 = extraFieldBufferSize
         }
-        if lSeek != 0 as i32 as libc::c_long {
+        if lSeek != 0 as i32 as isize {
             if Some(
                 (*s).z_filefunc
                     .zseek_file
@@ -903,9 +903,9 @@ unsafe extern "C" fn unzlocal_GetCurrentFileInfoInternal(
                 (*s).filestream,
                 lSeek as crate::zconf_h::uLong,
                 1 as i32,
-            ) == 0 as i32 as libc::c_long
+            ) == 0 as i32 as isize
             {
-                lSeek = 0 as i32 as libc::c_long
+                lSeek = 0 as i32 as isize
             } else {
                 err = -(1 as i32)
             }
@@ -930,10 +930,10 @@ unsafe extern "C" fn unzlocal_GetCurrentFileInfoInternal(
         }
         lSeek = (lSeek as libc::c_ulong)
             .wrapping_add(file_info.size_file_extra.wrapping_sub(uSizeRead_0))
-            as libc::c_long as libc::c_long
+            as isize as isize
     } else {
-        lSeek = (lSeek as libc::c_ulong).wrapping_add(file_info.size_file_extra) as libc::c_long
-            as libc::c_long
+        lSeek = (lSeek as libc::c_ulong).wrapping_add(file_info.size_file_extra) as isize
+            as isize
     }
     if err == 0 as i32 && !szComment.is_null() {
         let mut uSizeRead_1: crate::zconf_h::uLong = 0;
@@ -944,7 +944,7 @@ unsafe extern "C" fn unzlocal_GetCurrentFileInfoInternal(
         } else {
             uSizeRead_1 = commentBufferSize
         }
-        if lSeek != 0 as i32 as libc::c_long {
+        if lSeek != 0 as i32 as isize {
             if Some(
                 (*s).z_filefunc
                     .zseek_file
@@ -955,7 +955,7 @@ unsafe extern "C" fn unzlocal_GetCurrentFileInfoInternal(
                 (*s).filestream,
                 lSeek as crate::zconf_h::uLong,
                 1 as i32,
-            ) != 0 as i32 as libc::c_long
+            ) != 0 as i32 as isize
             {
                 err = -(1 as i32)
             }
@@ -1292,7 +1292,7 @@ unsafe extern "C" fn unzlocal_CheckCurrentFileCoherencyHeader(
             .offset_curfile
             .wrapping_add((*s).byte_before_the_zipfile),
         0 as i32,
-    ) != 0 as i32 as libc::c_long
+    ) != 0 as i32 as isize
     {
         return -(1 as i32);
     }
@@ -1606,7 +1606,7 @@ pub unsafe extern "C" fn unzReadCurrentFile(
                     .pos_in_zipfile
                     .wrapping_add((*pfile_in_zip_read_info).byte_before_the_zipfile),
                 0 as i32,
-            ) != 0 as i32 as libc::c_long
+            ) != 0 as i32 as isize
             {
                 return -(1 as i32);
             }
@@ -1847,7 +1847,7 @@ pub unsafe extern "C" fn unzGetLocalExtrafield(
             .offset_local_extrafield
             .wrapping_add((*pfile_in_zip_read_info).pos_local_extrafield),
         0 as i32,
-    ) != 0 as i32 as libc::c_long
+    ) != 0 as i32 as isize
     {
         return -(1 as i32);
     }
@@ -1944,7 +1944,7 @@ pub unsafe extern "C" fn unzGetGlobalComment(
         (*s).filestream,
         (*s).central_pos.wrapping_add(22 as i32 as libc::c_ulong),
         0 as i32,
-    ) != 0 as i32 as libc::c_long
+    ) != 0 as i32 as isize
     {
         return -(1 as i32);
     }

--- a/quake3-rs/ioquake3/src/qcommon/vm.rs
+++ b/quake3-rs/ioquake3/src/qcommon/vm.rs
@@ -1004,7 +1004,7 @@ pub unsafe extern "C" fn VM_ArgPtr(mut intValue: crate::stdlib::intptr_t) -> *mu
     } else {
         return (*currentVM)
             .dataBase
-            .offset((intValue & (*currentVM).dataMask as libc::c_long) as isize)
+            .offset((intValue & (*currentVM).dataMask as isize) as isize)
             as *mut libc::c_void;
     };
 }
@@ -1027,7 +1027,7 @@ pub unsafe extern "C" fn VM_ExplicitArgPtr(
     } else {
         return (*vm)
             .dataBase
-            .offset((intValue & (*vm).dataMask as libc::c_long) as isize)
+            .offset((intValue & (*vm).dataMask as isize) as isize)
             as *mut libc::c_void;
     };
 }
@@ -1411,7 +1411,7 @@ pub unsafe extern "C" fn VM_LogSyscalls(mut args: *mut i32) {
         f,
         b"%i: %p (%i) = %i %i %i %i\n\x00" as *const u8 as *const libc::c_char,
         callnum,
-        args.offset_from((*currentVM).dataBase as *mut i32) as libc::c_long as *mut libc::c_void,
+        args.offset_from((*currentVM).dataBase as *mut i32) as isize as *mut libc::c_void,
         *args.offset(0 as i32 as isize),
         *args.offset(1 as i32 as isize),
         *args.offset(2 as i32 as isize),

--- a/quake3-rs/ioquake3/src/qcommon/vm_interpreted.rs
+++ b/quake3-rs/ioquake3/src/qcommon/vm_interpreted.rs
@@ -376,9 +376,9 @@ pub unsafe extern "C" fn VM_CallInterpreted(
     // leave a free spot at start of stack so
     // that as long as opStack is valid, opStack-1 will
     // not corrupt anything
-    opStack = (stack.as_mut_ptr() as crate::stdlib::intptr_t + 16 as i32 as libc::c_long
-        - 1 as i32 as libc::c_long
-        & !(16 as i32 - 1 as i32) as libc::c_long) as *mut libc::c_void as *mut i32;
+    opStack = (stack.as_mut_ptr() as crate::stdlib::intptr_t + 16 as i32 as isize
+        - 1 as i32 as isize
+        & !(16 as i32 - 1 as i32) as isize) as *mut libc::c_void as *mut i32;
     *opStack = 0xdeadbeef as u32 as i32;
     opStackOfs = 0 as i32 as crate::stdlib::uint8_t;
     's_105: loop

--- a/quake3-rs/ioquake3/src/qcommon/vm_x86.rs
+++ b/quake3-rs/ioquake3/src/qcommon/vm_x86.rs
@@ -199,10 +199,10 @@ unsafe extern "C" fn Emit4(mut v: i32) {
 unsafe extern "C" fn EmitPtr(mut ptr: *mut libc::c_void) {
     let mut v: crate::stdlib::intptr_t = ptr as crate::stdlib::intptr_t;
     Emit4(v as i32);
-    Emit1((v >> 32 as i32 & 0xff as i32 as libc::c_long) as i32);
-    Emit1((v >> 40 as i32 & 0xff as i32 as libc::c_long) as i32);
-    Emit1((v >> 48 as i32 & 0xff as i32 as libc::c_long) as i32);
-    Emit1((v >> 56 as i32 & 0xff as i32 as libc::c_long) as i32);
+    Emit1((v >> 32 as i32 & 0xff as i32 as isize) as i32);
+    Emit1((v >> 40 as i32 & 0xff as i32 as isize) as i32);
+    Emit1((v >> 48 as i32 & 0xff as i32 as isize) as i32);
+    Emit1((v >> 56 as i32 & 0xff as i32 as isize) as i32);
 }
 
 unsafe extern "C" fn Hex(mut c: i32) -> i32 {
@@ -714,8 +714,8 @@ pub unsafe extern "C" fn EmitJumpIns(
     if pass == 2 as i32 {
         Emit4(
             (*(*vm).instructionPointers.offset(cdest as isize)
-                - compiledOfs as libc::c_long
-                - 4 as i32 as libc::c_long) as i32,
+                - compiledOfs as isize
+                - 4 as i32 as isize) as i32,
         );
     } else {
         compiledOfs += 4 as i32
@@ -746,8 +746,8 @@ pub unsafe extern "C" fn EmitCallIns(mut vm: *mut crate::qcommon_h::vm_t, mut cd
     if pass == 2 as i32 {
         Emit4(
             (*(*vm).instructionPointers.offset(cdest as isize)
-                - compiledOfs as libc::c_long
-                - 4 as i32 as libc::c_long) as i32,
+                - compiledOfs as isize
+                - 4 as i32 as isize) as i32,
         );
     } else {
         compiledOfs += 4 as i32
@@ -1959,9 +1959,9 @@ pub unsafe extern "C" fn VM_CallCompiled(
         as *mut i32) = -(1 as i32);
     // off we go into generated code...
     entryPoint = (*vm).codeBase.offset((*vm).entryOfs as isize) as *mut libc::c_void;
-    opStack = (stack.as_mut_ptr() as crate::stdlib::intptr_t + 16 as i32 as libc::c_long
-        - 1 as i32 as libc::c_long
-        & !(16 as i32 - 1 as i32) as libc::c_long) as *mut libc::c_void as *mut i32;
+    opStack = (stack.as_mut_ptr() as crate::stdlib::intptr_t + 16 as i32 as isize
+        - 1 as i32 as isize
+        & !(16 as i32 - 1 as i32) as isize) as *mut libc::c_void as *mut i32;
     *opStack = 0xdeadbeef as u32 as i32;
     opStackOfs = 0 as i32;
     asm!("movq $5, %rax\nmovq $3, %r8\nmovq $4, %r9\npush %r15\npush %r14\npush %r13\npush %r12\ncallq *%rax\npop %r12\npop %r13\npop %r14\npop %r15\n"

--- a/quake3-rs/ioquake3/src/server/sv_bot.rs
+++ b/quake3-rs/ioquake3/src/server/sv_bot.rs
@@ -1551,7 +1551,7 @@ pub unsafe extern "C" fn SV_BotInitBotLib() {
         crate::src::qcommon::files::FS_Seek
             as unsafe extern "C" fn(
                 _: crate::src::qcommon::q_shared::fileHandle_t,
-                _: libc::c_long,
+                _: isize,
                 _: i32,
             ) -> i32,
     );

--- a/quake3-rs/ioquake3/src/server/sv_ccmds.rs
+++ b/quake3-rs/ioquake3/src/server/sv_ccmds.rs
@@ -360,7 +360,7 @@ unsafe extern "C" fn SV_Map_f() {
         map,
     );
     if crate::src::qcommon::files::FS_ReadFile(expanded.as_mut_ptr(), 0 as *mut *mut libc::c_void)
-        == -(1 as i32) as libc::c_long
+        == -(1 as i32) as isize
     {
         crate::src::qcommon::common::Com_Printf(
             b"Can\'t find map %s\n\x00" as *const u8 as *const libc::c_char,

--- a/quake3-rs/ioquake3/src/server/sv_client.rs
+++ b/quake3-rs/ioquake3/src/server/sv_client.rs
@@ -1151,7 +1151,7 @@ pub unsafe extern "C" fn SV_DirectConnect(mut from: crate::qcommon_h::netadr_t) 
     // accept the new client
     // this is the only place a client_t is ever initialized
     *newcl = temp;
-    clientNum = newcl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long as i32;
+    clientNum = newcl.offset_from(crate::src::server::sv_main::svs.clients) as isize as i32;
     ent = crate::src::server::sv_game::SV_GentityNum(clientNum)
         as *mut crate::g_public_h::sharedEntity_t;
     (*newcl).gentity = ent;
@@ -1332,7 +1332,7 @@ pub unsafe extern "C" fn SV_DropClient(
     crate::src::qcommon::vm::VM_Call(
         crate::src::server::sv_main::gvm,
         crate::g_public_h::GAME_CLIENT_DISCONNECT as i32,
-        drop_0.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long,
+        drop_0.offset_from(crate::src::server::sv_main::svs.clients) as isize,
     );
     // add the disconnect command
     crate::src::server::sv_main::SV_SendServerCommand(
@@ -1342,7 +1342,7 @@ pub unsafe extern "C" fn SV_DropClient(
     );
     if isBot as u64 != 0 {
         crate::src::server::sv_bot::SV_BotFreeClient(
-            drop_0.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long as i32,
+            drop_0.offset_from(crate::src::server::sv_main::svs.clients) as isize as i32,
         );
         // bots shouldn't go zombie, as there's no real net connection.
         (*drop_0).state = crate::server_h::CS_FREE
@@ -1356,7 +1356,7 @@ pub unsafe extern "C" fn SV_DropClient(
     }
     // nuke user info
     crate::src::server::sv_init::SV_SetUserinfo(
-        drop_0.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long as i32,
+        drop_0.offset_from(crate::src::server::sv_main::svs.clients) as isize as i32,
         b"\x00" as *const u8 as *const libc::c_char,
     );
     // if this was the last client on the server, send a heartbeat
@@ -1544,7 +1544,7 @@ unsafe extern "C" fn SV_SendClientGameState(mut client: *mut crate::server_h::cl
     );
     crate::src::qcommon::msg::MSG_WriteLong(
         &mut msg as *mut _ as *mut crate::qcommon_h::msg_t,
-        client.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long as i32,
+        client.offset_from(crate::src::server::sv_main::svs.clients) as isize as i32,
     );
     // write the checksum feed
     crate::src::qcommon::msg::MSG_WriteLong(
@@ -1580,7 +1580,7 @@ pub unsafe extern "C" fn SV_ClientEnterWorld(
     // no longer sent when the client is CS_PRIMED
     crate::src::server::sv_init::SV_UpdateConfigstrings(client as *mut crate::server_h::client_s);
     // set up the entity for the client
-    clientNum = client.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long as i32; // generate a snapshot immediately
+    clientNum = client.offset_from(crate::src::server::sv_main::svs.clients) as isize as i32; // generate a snapshot immediately
     ent = crate::src::server::sv_game::SV_GentityNum(clientNum)
         as *mut crate::g_public_h::sharedEntity_t;
     (*ent).s.number = clientNum;
@@ -1606,7 +1606,7 @@ pub unsafe extern "C" fn SV_ClientEnterWorld(
     crate::src::qcommon::vm::VM_Call(
         crate::src::server::sv_main::gvm,
         crate::g_public_h::GAME_CLIENT_BEGIN as i32,
-        client.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long,
+        client.offset_from(crate::src::server::sv_main::svs.clients) as isize,
     );
 }
 /*
@@ -1678,7 +1678,7 @@ unsafe extern "C" fn SV_StopDownload_f(mut cl: *mut crate::server_h::client_t) {
     if *(*cl).downloadName.as_mut_ptr() != 0 {
         crate::src::qcommon::common::Com_DPrintf(
             b"clientDownload: %d : file \"%s\" aborted\n\x00" as *const u8 as *const libc::c_char,
-            cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long as i32,
+            cl.offset_from(crate::src::server::sv_main::svs.clients) as isize as i32,
             (*cl).downloadName.as_mut_ptr(),
         );
     }
@@ -1718,7 +1718,7 @@ unsafe extern "C" fn SV_NextDownload_f(mut cl: *mut crate::server_h::client_t) {
         crate::src::qcommon::common::Com_DPrintf(
             b"clientDownload: %d : client acknowledge of block %d\n\x00" as *const u8
                 as *const libc::c_char,
-            cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long as i32,
+            cl.offset_from(crate::src::server::sv_main::svs.clients) as isize as i32,
             block,
         );
         // Find out if we are done.  A zero-length block indicates EOF
@@ -1726,7 +1726,7 @@ unsafe extern "C" fn SV_NextDownload_f(mut cl: *mut crate::server_h::client_t) {
             crate::src::qcommon::common::Com_Printf(
                 b"clientDownload: %d : file \"%s\" completed\n\x00" as *const u8
                     as *const libc::c_char,
-                cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long as i32,
+                cl.offset_from(crate::src::server::sv_main::svs.clients) as isize as i32,
                 (*cl).downloadName.as_mut_ptr(),
             );
             SV_CloseDownload(cl);
@@ -1864,7 +1864,7 @@ pub unsafe extern "C" fn SV_WriteDownloadToClient(
                 crate::src::qcommon::common::Com_Printf(
                     b"clientDownload: %d : \"%s\" is not referenced and cannot be downloaded.\n\x00"
                         as *const u8 as *const libc::c_char,
-                    cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long as i32,
+                    cl.offset_from(crate::src::server::sv_main::svs.clients) as isize as i32,
                     (*cl).downloadName.as_mut_ptr(),
                 );
                 crate::src::qcommon::q_shared::Com_sprintf(
@@ -1878,7 +1878,7 @@ pub unsafe extern "C" fn SV_WriteDownloadToClient(
                 crate::src::qcommon::common::Com_Printf(
                     b"clientDownload: %d : \"%s\" cannot download id pk3 files\n\x00" as *const u8
                         as *const libc::c_char,
-                    cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long as i32,
+                    cl.offset_from(crate::src::server::sv_main::svs.clients) as isize as i32,
                     (*cl).downloadName.as_mut_ptr(),
                 );
                 if missionPack as u64 != 0 {
@@ -1903,7 +1903,7 @@ pub unsafe extern "C" fn SV_WriteDownloadToClient(
                 crate::src::qcommon::common::Com_Printf(
                     b"clientDownload: %d : \"%s\" download disabled\n\x00" as *const u8
                         as *const libc::c_char,
-                    cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long as i32,
+                    cl.offset_from(crate::src::server::sv_main::svs.clients) as isize as i32,
                     (*cl).downloadName.as_mut_ptr(),
                 );
                 if (*crate::src::server::sv_main::sv_pure).integer != 0 {
@@ -1927,7 +1927,7 @@ pub unsafe extern "C" fn SV_WriteDownloadToClient(
                 crate::src::qcommon::common::Com_Printf(
                     b"clientDownload: %d : \"%s\" file not found on server\n\x00" as *const u8
                         as *const libc::c_char,
-                    cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long as i32,
+                    cl.offset_from(crate::src::server::sv_main::svs.clients) as isize as i32,
                     (*cl).downloadName.as_mut_ptr(),
                 ); // client is expecting block zero
                 crate::src::qcommon::q_shared::Com_sprintf(
@@ -1959,7 +1959,7 @@ pub unsafe extern "C" fn SV_WriteDownloadToClient(
         }
         crate::src::qcommon::common::Com_Printf(
             b"clientDownload: %d : beginning \"%s\"\n\x00" as *const u8 as *const libc::c_char,
-            cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long as i32,
+            cl.offset_from(crate::src::server::sv_main::svs.clients) as isize as i32,
             (*cl).downloadName.as_mut_ptr(),
         );
         // Init
@@ -2047,7 +2047,7 @@ pub unsafe extern "C" fn SV_WriteDownloadToClient(
     }
     crate::src::qcommon::common::Com_DPrintf(
         b"clientDownload: %d : writing block %d\n\x00" as *const u8 as *const libc::c_char,
-        cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long as i32,
+        cl.offset_from(crate::src::server::sv_main::svs.clients) as isize as i32,
         (*cl).downloadXmitBlock,
     );
     // Move on to the next block
@@ -2523,7 +2523,7 @@ unsafe extern "C" fn SV_UpdateUserinfo_f(mut cl: *mut crate::server_h::client_t)
     crate::src::qcommon::vm::VM_Call(
         crate::src::server::sv_main::gvm,
         crate::g_public_h::GAME_CLIENT_USERINFO_CHANGED as i32,
-        cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long,
+        cl.offset_from(crate::src::server::sv_main::svs.clients) as isize,
     );
 }
 
@@ -2708,7 +2708,7 @@ pub unsafe extern "C" fn SV_ExecuteClientCommand(
             crate::src::qcommon::vm::VM_Call(
                 crate::src::server::sv_main::gvm,
                 crate::g_public_h::GAME_CLIENT_COMMAND as i32,
-                cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long,
+                cl.offset_from(crate::src::server::sv_main::svs.clients) as isize,
             );
         }
     } else if bProcessed as u64 == 0 {
@@ -2809,7 +2809,7 @@ pub unsafe extern "C" fn SV_ClientThink(
     crate::src::qcommon::vm::VM_Call(
         crate::src::server::sv_main::gvm,
         crate::g_public_h::GAME_CLIENT_THINK as i32,
-        cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long,
+        cl.offset_from(crate::src::server::sv_main::svs.clients) as isize,
     );
 }
 /*
@@ -3008,7 +3008,7 @@ unsafe extern "C" fn SV_UserVoip(
     let mut packet: *mut crate::server_h::voipServerPacket_t =
         0 as *mut crate::server_h::voipServerPacket_t;
     let mut i: i32 = 0;
-    sender = cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long as i32;
+    sender = cl.offset_from(crate::src::server::sv_main::svs.clients) as isize as i32;
     generation = crate::src::qcommon::msg::MSG_ReadByte(msg as *mut crate::qcommon_h::msg_t);
     sequence = crate::src::qcommon::msg::MSG_ReadLong(msg as *mut crate::qcommon_h::msg_t);
     frames = crate::src::qcommon::msg::MSG_ReadByte(msg as *mut crate::qcommon_h::msg_t);
@@ -3413,7 +3413,7 @@ pub unsafe extern "C" fn SV_ExecuteClientMessage(
     } else if c != crate::qcommon_h::clc_EOF as i32 {
         crate::src::qcommon::common::Com_Printf(
             b"WARNING: bad command byte for client %i\n\x00" as *const u8 as *const libc::c_char,
-            cl.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long as i32,
+            cl.offset_from(crate::src::server::sv_main::svs.clients) as isize as i32,
         );
     };
     //	if ( msg->readcount != msg->cursize ) {

--- a/quake3-rs/ioquake3/src/server/sv_game.rs
+++ b/quake3-rs/ioquake3/src/server/sv_game.rs
@@ -449,8 +449,8 @@ pub unsafe extern "C" fn SV_NumForGentity(mut ent: *mut crate::g_public_h::share
     let mut num: i32 = 0;
     num = ((ent as *mut crate::src::qcommon::q_shared::byte).offset_from(
         crate::src::server::sv_main::sv.gentities as *mut crate::src::qcommon::q_shared::byte,
-    ) as libc::c_long
-        / crate::src::server::sv_main::sv.gentitySize as libc::c_long) as i32;
+    ) as isize
+        / crate::src::server::sv_main::sv.gentitySize as isize) as i32;
     return num;
 }
 #[no_mangle]
@@ -498,7 +498,7 @@ pub unsafe extern "C" fn SV_GEntityForSvEntity(
     mut svEnt: *mut crate::server_h::svEntity_t,
 ) -> *mut crate::g_public_h::sharedEntity_t {
     let mut num: i32 = 0;
-    num = svEnt.offset_from(crate::src::server::sv_main::sv.svEntities.as_mut_ptr()) as libc::c_long
+    num = svEnt.offset_from(crate::src::server::sv_main::sv.svEntities.as_mut_ptr()) as isize
         as i32;
     return SV_GentityNum(num);
 }

--- a/quake3-rs/ioquake3/src/server/sv_main.rs
+++ b/quake3-rs/ioquake3/src/server/sv_main.rs
@@ -829,12 +829,12 @@ SVC_HashForAddress
 ================
 */
 
-unsafe extern "C" fn SVC_HashForAddress(mut address: crate::qcommon_h::netadr_t) -> libc::c_long {
+unsafe extern "C" fn SVC_HashForAddress(mut address: crate::qcommon_h::netadr_t) -> isize {
     let mut ip: *mut crate::src::qcommon::q_shared::byte =
         0 as *mut crate::src::qcommon::q_shared::byte;
     let mut size: crate::stddef_h::size_t = 0 as i32 as crate::stddef_h::size_t;
     let mut i: i32 = 0;
-    let mut hash: libc::c_long = 0 as i32 as libc::c_long;
+    let mut hash: isize = 0 as i32 as isize;
     match address.type_0 as u32 {
         4 => {
             ip = address.ip.as_mut_ptr();
@@ -848,11 +848,11 @@ unsafe extern "C" fn SVC_HashForAddress(mut address: crate::qcommon_h::netadr_t)
     }
     i = 0 as i32;
     while (i as libc::c_ulong) < size {
-        hash += *ip.offset(i as isize) as libc::c_long * (i + 119 as i32) as libc::c_long;
+        hash += *ip.offset(i as isize) as isize * (i + 119 as i32) as isize;
         i += 1
     }
     hash = hash ^ hash >> 10 as i32 ^ hash >> 20 as i32;
-    hash &= (1024 as i32 - 1 as i32) as libc::c_long;
+    hash &= (1024 as i32 - 1 as i32) as isize;
     return hash;
 }
 /*
@@ -870,7 +870,7 @@ unsafe extern "C" fn SVC_BucketForAddress(
 ) -> *mut crate::server_h::leakyBucket_t {
     let mut bucket: *mut crate::server_h::leakyBucket_t = 0 as *mut crate::server_h::leakyBucket_t;
     let mut i: i32 = 0;
-    let mut hash: libc::c_long = SVC_HashForAddress(address);
+    let mut hash: isize = SVC_HashForAddress(address);
     let mut now: i32 = crate::src::sys::sys_unix::Sys_Milliseconds();
     bucket = bucketHashes[hash as usize];
     while !bucket.is_null() {

--- a/quake3-rs/ioquake3/src/server/sv_net_chan.rs
+++ b/quake3-rs/ioquake3/src/server/sv_net_chan.rs
@@ -110,8 +110,8 @@ unsafe extern "C" fn SV_Netchan_Encode(
     mut msg: *mut crate::qcommon_h::msg_t,
     mut clientCommandString: *const libc::c_char,
 ) {
-    let mut i: libc::c_long = 0;
-    let mut index: libc::c_long = 0;
+    let mut i: isize = 0;
+    let mut index: isize = 0;
     let mut key: crate::src::qcommon::q_shared::byte = 0;
     let mut string: *mut crate::src::qcommon::q_shared::byte =
         0 as *mut crate::src::qcommon::q_shared::byte;
@@ -133,24 +133,24 @@ unsafe extern "C" fn SV_Netchan_Encode(
     (*msg).bit = sbit;
     (*msg).readcount = srdc;
     string = clientCommandString as *mut crate::src::qcommon::q_shared::byte;
-    index = 0 as i32 as libc::c_long;
+    index = 0 as i32 as isize;
     // xor the client challenge with the netchan sequence number
     key = ((*client).challenge ^ (*client).netchan.outgoingSequence)
         as crate::src::qcommon::q_shared::byte;
-    i = 4 as i32 as libc::c_long;
-    while i < (*msg).cursize as libc::c_long {
+    i = 4 as i32 as isize;
+    while i < (*msg).cursize as isize {
         // modify the key with the last received and with this message acknowledged client command
         if *string.offset(index as isize) == 0 {
-            index = 0 as i32 as libc::c_long
+            index = 0 as i32 as isize
         }
         if *string.offset(index as isize) as i32 > 127 as i32
             || *string.offset(index as isize) as i32 == '%' as i32
         {
-            key = (key as i32 ^ ('.' as i32) << (i & 1 as i32 as libc::c_long))
+            key = (key as i32 ^ ('.' as i32) << (i & 1 as i32 as isize))
                 as crate::src::qcommon::q_shared::byte
         } else {
             key = (key as i32
-                ^ (*string.offset(index as isize) as i32) << (i & 1 as i32 as libc::c_long))
+                ^ (*string.offset(index as isize) as i32) << (i & 1 as i32 as isize))
                 as crate::src::qcommon::q_shared::byte
         }
         index += 1;

--- a/quake3-rs/ioquake3/src/server/sv_snapshot.rs
+++ b/quake3-rs/ioquake3/src/server/sv_snapshot.rs
@@ -884,7 +884,7 @@ unsafe extern "C" fn SV_BuildClientSnapshot(mut client: *mut crate::server_h::cl
     }
     // grab the current playerState_t
     ps = crate::src::server::sv_game::SV_GameClientNum(
-        client.offset_from(crate::src::server::sv_main::svs.clients) as libc::c_long as i32,
+        client.offset_from(crate::src::server::sv_main::svs.clients) as isize as i32,
     ) as *mut crate::src::qcommon::q_shared::playerState_s;
     (*frame).ps = *ps;
     // never send client's own entity, because it can

--- a/quake3-rs/ioquake3/src/server/sv_world.rs
+++ b/quake3-rs/ioquake3/src/server/sv_world.rs
@@ -523,7 +523,7 @@ unsafe extern "C" fn SV_AreaEntities_r(mut node: *mut worldSector_t, mut ap: *mu
             }
             *(*ap).list.offset((*ap).count as isize) = check
                 .offset_from(crate::src::server::sv_main::sv.svEntities.as_mut_ptr())
-                as libc::c_long as i32;
+                as isize as i32;
             (*ap).count += 1
         }
         check = next

--- a/quake3-rs/ioquake3/src/sys/con_tty.rs
+++ b/quake3-rs/ioquake3/src/sys/con_tty.rs
@@ -645,8 +645,8 @@ pub unsafe extern "C" fn CON_Input() -> *mut libc::c_char {
                     % (8 as i32
                         * ::std::mem::size_of::<crate::stdlib::__fd_mask>() as libc::c_ulong
                             as i32)) as crate::stdlib::__fd_mask;
-            timeout.tv_sec = 0 as i32 as crate::stdlib::__time_t;
-            timeout.tv_usec = 0 as i32 as crate::stdlib::__suseconds_t;
+            timeout.tv_sec = (0 as i32 as crate::stdlib::__time_t) as libc::time_t;
+            timeout.tv_usec = (0 as i32 as crate::stdlib::__suseconds_t) as libc::suseconds_t;
             if crate::stdlib::select(
                 0 as i32 + 1 as i32,
                 &mut fdset,
@@ -663,7 +663,7 @@ pub unsafe extern "C" fn CON_Input() -> *mut libc::c_char {
                             % (8 as i32
                                 * ::std::mem::size_of::<crate::stdlib::__fd_mask>() as libc::c_ulong
                                     as i32)) as crate::stdlib::__fd_mask
-                    != 0 as i32 as libc::c_long)
+                    != 0 as i32 as isize)
             {
                 return 0 as *mut libc::c_char;
             }

--- a/quake3-rs/ioquake3/src/sys/sys_unix.rs
+++ b/quake3-rs/ioquake3/src/sys/sys_unix.rs
@@ -12557,12 +12557,12 @@ pub unsafe extern "C" fn Sys_Milliseconds() -> i32 {
     crate::stdlib::gettimeofday(&mut tp, 0 as *mut crate::stdlib::timezone);
     if sys_timeBase == 0 {
         sys_timeBase = tp.tv_sec as libc::c_ulong;
-        return (tp.tv_usec / 1000 as i32 as libc::c_long) as i32;
+        return (tp.tv_usec as isize / 1000) as i32;
     }
     curtime = (tp.tv_sec as libc::c_ulong)
         .wrapping_sub(sys_timeBase)
         .wrapping_mul(1000 as i32 as libc::c_ulong)
-        .wrapping_add((tp.tv_usec / 1000 as i32 as libc::c_long) as libc::c_ulong)
+        .wrapping_add((tp.tv_usec as isize / 1000) as libc::c_ulong)
         as i32;
     return curtime;
 }
@@ -13152,8 +13152,8 @@ pub unsafe extern "C" fn Sys_Sleep(mut msec: i32) {
                 tv_sec: 0,
                 tv_usec: 0,
             };
-            timeout.tv_sec = (msec / 1000 as i32) as crate::stdlib::__time_t;
-            timeout.tv_usec = (msec % 1000 as i32 * 1000 as i32) as crate::stdlib::__suseconds_t;
+            timeout.tv_sec = ((msec / 1000 as i32) as crate::stdlib::__time_t) as libc::time_t;
+            timeout.tv_usec = ((msec % 1000 as i32 * 1000 as i32) as crate::stdlib::__suseconds_t) as libc::suseconds_t;
             crate::stdlib::select(
                 0 as i32 + 1 as i32,
                 &mut fdset,
@@ -13257,7 +13257,7 @@ pub unsafe extern "C" fn Sys_ErrorDialog(mut error: *const libc::c_char) {
             f,
             buffer.as_mut_ptr() as *const libc::c_void,
             size as crate::stddef_h::size_t,
-        ) != size as libc::c_long)
+        ) != size as isize)
         {
             continue;
         }
@@ -13301,7 +13301,7 @@ Sys_AppendToExecBuffer
 unsafe extern "C" fn Sys_AppendToExecBuffer(mut text: *const libc::c_char) {
     let mut size: crate::stddef_h::size_t =
         (::std::mem::size_of::<[libc::c_char; 1024]>() as libc::c_ulong).wrapping_sub(
-            execBufferPointer.offset_from(execBuffer.as_mut_ptr()) as libc::c_long as libc::c_ulong,
+            execBufferPointer.offset_from(execBuffer.as_mut_ptr()) as isize as libc::c_ulong,
         );
     let mut length: i32 =
         crate::stdlib::strlen(text).wrapping_add(1 as i32 as libc::c_ulong) as i32;

--- a/quake3-rs/ioquake3/src/zlib/adler32.rs
+++ b/quake3-rs/ioquake3/src/zlib/adler32.rs
@@ -38,7 +38,7 @@ pub unsafe extern "C" fn adler32(
     }
     /* initial Adler-32 value (deferred check for len == 1 speed) */
     if buf.is_null() {
-        return 1 as libc::c_long as crate::zconf_h::uLong;
+        return 1 as isize as crate::zconf_h::uLong;
     }
     /* in case short lengths are provided, keep it somewhat fast */
     if len < 16 as i32 as u32 {

--- a/quake3-rs/ioquake3/src/zlib/crc32.rs
+++ b/quake3-rs/ioquake3/src/zlib/crc32.rs
@@ -2220,7 +2220,7 @@ unsafe extern "C" fn crc32_little(
     let mut buf4: *const u4 = 0 as *const u4;
     c = crc as u4;
     c = !c;
-    while len != 0 && buf as crate::stddef_h::ptrdiff_t & 3 as i32 as libc::c_long != 0 {
+    while len != 0 && buf as crate::stddef_h::ptrdiff_t & 3 as i32 as isize != 0 {
         let fresh9 = buf;
         buf = buf.offset(1);
         c = (crc_table[0 as i32 as usize][((c ^ *fresh9 as u32) & 0xff as i32 as u32) as usize]
@@ -2329,7 +2329,7 @@ unsafe extern "C" fn crc32_big(
         .wrapping_add((crc as u4 & 0xff00 as i32 as u32) << 8 as i32)
         .wrapping_add((crc as u4 & 0xff as i32 as u32) << 24 as i32);
     c = !c;
-    while len != 0 && buf as crate::stddef_h::ptrdiff_t & 3 as i32 as libc::c_long != 0 {
+    while len != 0 && buf as crate::stddef_h::ptrdiff_t & 3 as i32 as isize != 0 {
         let fresh20 = buf;
         buf = buf.offset(1);
         c = (crc_table[4 as i32 as usize][(c >> 24 as i32 ^ *fresh20 as u32) as usize]
@@ -3098,11 +3098,11 @@ pub unsafe extern "C" fn crc32_combine(
     let mut even: [libc::c_ulong; 32] = [0; 32];
     let mut odd: [libc::c_ulong; 32] = [0; 32];
     /* degenerate case */
-    if len2 == 0 as i32 as libc::c_long {
+    if len2 == 0 as i32 as isize {
         return crc1;
     }
     /* put operator for one zero bit in odd */
-    odd[0 as i32 as usize] = 0xedb88320 as libc::c_long as libc::c_ulong; /* CRC-32 polynomial */
+    odd[0 as i32 as usize] = 0xedb88320 as isize as libc::c_ulong; /* CRC-32 polynomial */
     row = 1 as i32 as libc::c_ulong;
     n = 1 as i32;
     while n < 32 as i32 {
@@ -3120,21 +3120,21 @@ pub unsafe extern "C" fn crc32_combine(
       /* apply zeros operator for this bit of len2 */
     {
         gf2_matrix_square(even.as_mut_ptr(), odd.as_mut_ptr());
-        if len2 & 1 as i32 as libc::c_long != 0 {
+        if len2 & 1 as i32 as isize != 0 {
             crc1 = gf2_matrix_times(even.as_mut_ptr(), crc1)
         }
         len2 >>= 1 as i32;
         /* if no more bits set, then done */
-        if len2 == 0 as i32 as libc::c_long {
+        if len2 == 0 as i32 as isize {
             break;
         }
         /* another iteration of the loop with odd and even swapped */
         gf2_matrix_square(odd.as_mut_ptr(), even.as_mut_ptr());
-        if len2 & 1 as i32 as libc::c_long != 0 {
+        if len2 & 1 as i32 as isize != 0 {
             crc1 = gf2_matrix_times(odd.as_mut_ptr(), crc1)
         }
         len2 >>= 1 as i32;
-        if !(len2 != 0 as i32 as libc::c_long) {
+        if !(len2 != 0 as i32 as isize) {
             break;
         }
         /* if no more bits set, then done */

--- a/quake3-rs/ioquake3/src/zlib/inffast.rs
+++ b/quake3-rs/ioquake3/src/zlib/inffast.rs
@@ -232,7 +232,7 @@ pub unsafe extern "C" fn inflate_fast(mut strm: crate::zlib_h::z_streamp, mut st
                         );
                         hold >>= op;
                         bits = bits.wrapping_sub(op);
-                        op = out.offset_from(beg) as libc::c_long as u32;
+                        op = out.offset_from(beg) as isize as u32;
                         if dist > op {
                             current_block_141 = 5873035170358615968;
                             break;
@@ -420,14 +420,14 @@ pub unsafe extern "C" fn inflate_fast(mut strm: crate::zlib_h::z_streamp, mut st
     (*strm).next_in = in_0.offset(1 as i32 as isize);
     (*strm).next_out = out.offset(1 as i32 as isize);
     (*strm).avail_in = if in_0 < last {
-        (5 as i32 as libc::c_long) + last.offset_from(in_0) as libc::c_long
+        (5 as i32 as isize) + last.offset_from(in_0) as isize
     } else {
-        (5 as i32 as libc::c_long) - in_0.offset_from(last) as libc::c_long
+        (5 as i32 as isize) - in_0.offset_from(last) as isize
     } as u32;
     (*strm).avail_out = if out < end {
-        (257 as i32 as libc::c_long) + end.offset_from(out) as libc::c_long
+        (257 as i32 as isize) + end.offset_from(out) as isize
     } else {
-        (257 as i32 as libc::c_long) - out.offset_from(end) as libc::c_long
+        (257 as i32 as isize) - out.offset_from(end) as isize
     } as u32;
     (*state).hold = hold;
     (*state).bits = bits;

--- a/quake3-rs/ioquake3/src/zlib/inflate.rs
+++ b/quake3-rs/ioquake3/src/zlib/inflate.rs
@@ -167,7 +167,7 @@ pub unsafe extern "C" fn inflatePrime(
         return -(2 as i32);
     }
     value =
-        (value as libc::c_long & ((1 as libc::c_long) << bits) - 1 as i32 as libc::c_long) as i32;
+        (value as isize & ((1 as isize) << bits) - 1 as i32 as isize) as i32;
     (*state).hold = (*state)
         .hold
         .wrapping_add((value << (*state).bits) as libc::c_ulong);
@@ -5010,7 +5010,7 @@ pub unsafe extern "C" fn inflate(mut strm: crate::zlib_h::z_streamp, mut flush: 
                         } else {
                             (*state).dmax = (1 as u32) << len;
                             (*state).check = crate::src::zlib::adler32::adler32(
-                                0 as libc::c_long as crate::zconf_h::uLong,
+                                0 as isize as crate::zconf_h::uLong,
                                 0 as *const crate::zconf_h::Bytef,
                                 0 as i32 as crate::zconf_h::uInt,
                             );
@@ -5304,7 +5304,7 @@ pub unsafe extern "C" fn inflate(mut strm: crate::zlib_h::z_streamp, mut flush: 
                     return 2 as i32;
                 }
                 (*state).check = crate::src::zlib::adler32::adler32(
-                    0 as libc::c_long as crate::zconf_h::uLong,
+                    0 as isize as crate::zconf_h::uLong,
                     0 as *const crate::zconf_h::Bytef,
                     0 as i32 as crate::zconf_h::uInt,
                 );
@@ -5907,7 +5907,7 @@ pub unsafe extern "C" fn inflateSetDictionary(
     /* check for correct dictionary id */
     if (*state).mode as u32 == crate::src::zlib::inflate::DICT as i32 as u32 {
         id = crate::src::zlib::adler32::adler32(
-            0 as libc::c_long as crate::zconf_h::uLong,
+            0 as isize as crate::zconf_h::uLong,
             0 as *const crate::zconf_h::Bytef,
             0 as i32 as crate::zconf_h::uInt,
         );
@@ -6789,16 +6789,16 @@ pub unsafe extern "C" fn inflateCopy(
                 as *const crate::src::zlib::inftrees::code
     {
         (*copy).lencode = (*copy).codes.as_mut_ptr().offset(
-            (*state).lencode.offset_from((*state).codes.as_mut_ptr()) as libc::c_long as isize,
+            (*state).lencode.offset_from((*state).codes.as_mut_ptr()) as isize as isize,
         );
         (*copy).distcode = (*copy).codes.as_mut_ptr().offset(
-            (*state).distcode.offset_from((*state).codes.as_mut_ptr()) as libc::c_long as isize,
+            (*state).distcode.offset_from((*state).codes.as_mut_ptr()) as isize as isize,
         )
     }
     (*copy).next = (*copy)
         .codes
         .as_mut_ptr()
-        .offset((*state).next.offset_from((*state).codes.as_mut_ptr()) as libc::c_long as isize);
+        .offset((*state).next.offset_from((*state).codes.as_mut_ptr()) as isize as isize);
     if !window.is_null() {
         wsize = (1 as u32) << (*state).wbits;
         crate::stdlib::memcpy(

--- a/quake3-rs/ioquake3/src/zlib/inftrees.rs
+++ b/quake3-rs/ioquake3/src/zlib/inftrees.rs
@@ -471,7 +471,7 @@ pub unsafe extern "C" fn inflate_table(
             low = huff & mask;
             (*(*table).offset(low as isize)).op = curr as u8;
             (*(*table).offset(low as isize)).bits = root as u8;
-            (*(*table).offset(low as isize)).val = next.offset_from(*table) as libc::c_long as u16
+            (*(*table).offset(low as isize)).val = next.offset_from(*table) as isize as u16
         }
     }
     /*

--- a/quake3-rs/ioquake3/src/zlib/zutil.rs
+++ b/quake3-rs/ioquake3/src/zlib/zutil.rs
@@ -104,7 +104,7 @@ pub unsafe extern "C" fn zlibCompileFlags() -> crate::zconf_h::uLong {
         }
     }
     flags = (flags as libc::c_ulong)
-        .wrapping_add(((1 as libc::c_long) << 17 as i32) as libc::c_ulong)
+        .wrapping_add(((1 as isize) << 17 as i32) as libc::c_ulong)
         as crate::zconf_h::uLong as crate::zconf_h::uLong;
     return flags;
 }

--- a/quake3-rs/renderer_opengl1_x86_64/src/jmemsys_h.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jmemsys_h.rs
@@ -8,8 +8,8 @@ pub struct backing_store_struct {
             _: crate::jpeglib_h::j_common_ptr,
             _: backing_store_ptr,
             _: *mut libc::c_void,
-            _: libc::c_long,
-            _: libc::c_long,
+            _: isize,
+            _: isize,
         ) -> (),
     >,
     pub write_backing_store: Option<
@@ -17,8 +17,8 @@ pub struct backing_store_struct {
             _: crate::jpeglib_h::j_common_ptr,
             _: backing_store_ptr,
             _: *mut libc::c_void,
-            _: libc::c_long,
-            _: libc::c_long,
+            _: isize,
+            _: isize,
         ) -> (),
     >,
     pub close_backing_store:

--- a/quake3-rs/renderer_opengl1_x86_64/src/jmorecfg_h.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jmorecfg_h.rs
@@ -34,7 +34,7 @@ pub type JOCTET = u8;
 pub type UINT8 = u8;
 pub type UINT16 = u16;
 pub type INT16 = i16;
-pub type INT32 = libc::c_long;
+pub type INT32 = isize;
 /* Datatype used for image dimensions.  The JPEG standard only supports
  * images up to 64K*64K due to 16-bit fields in SOF markers.  Therefore
  * "unsigned int" is sufficient on all machines.  However, if you need to

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jaricom.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jaricom.rs
@@ -148,457 +148,457 @@ pub static mut jpeg_aritab: [crate::jmorecfg_h::INT32; 114] = [
     (0x5a1d as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (1 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (1 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 1 as i32 as libc::c_long,
+        | 1 as i32 as isize,
     (0x2586 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (2 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 14 as i32 as libc::c_long,
+        | 14 as i32 as isize,
     (0x1114 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (3 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 16 as i32 as libc::c_long,
+        | 16 as i32 as isize,
     (0x80b as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (4 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 18 as i32 as libc::c_long,
+        | 18 as i32 as isize,
     (0x3d8 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (5 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 20 as i32 as libc::c_long,
+        | 20 as i32 as isize,
     (0x1da as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (6 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 23 as i32 as libc::c_long,
+        | 23 as i32 as isize,
     (0xe5 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (7 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 25 as i32 as libc::c_long,
+        | 25 as i32 as isize,
     (0x6f as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (8 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 28 as i32 as libc::c_long,
+        | 28 as i32 as isize,
     (0x36 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (9 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 30 as i32 as libc::c_long,
+        | 30 as i32 as isize,
     (0x1a as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (10 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 33 as i32 as libc::c_long,
+        | 33 as i32 as isize,
     (0xd as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (11 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 35 as i32 as libc::c_long,
+        | 35 as i32 as isize,
     (0x6 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (12 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 9 as i32 as libc::c_long,
+        | 9 as i32 as isize,
     (0x3 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (13 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 10 as i32 as libc::c_long,
+        | 10 as i32 as isize,
     (0x1 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (13 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 12 as i32 as libc::c_long,
+        | 12 as i32 as isize,
     (0x5a7f as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (15 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (1 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 15 as i32 as libc::c_long,
+        | 15 as i32 as isize,
     (0x3f25 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (16 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 36 as i32 as libc::c_long,
+        | 36 as i32 as isize,
     (0x2cf2 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (17 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 38 as i32 as libc::c_long,
+        | 38 as i32 as isize,
     (0x207c as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (18 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 39 as i32 as libc::c_long,
+        | 39 as i32 as isize,
     (0x17b9 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (19 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 40 as i32 as libc::c_long,
+        | 40 as i32 as isize,
     (0x1182 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (20 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 42 as i32 as libc::c_long,
+        | 42 as i32 as isize,
     (0xcef as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (21 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 43 as i32 as libc::c_long,
+        | 43 as i32 as isize,
     (0x9a1 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (22 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 45 as i32 as libc::c_long,
+        | 45 as i32 as isize,
     (0x72f as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (23 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 46 as i32 as libc::c_long,
+        | 46 as i32 as isize,
     (0x55c as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (24 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 48 as i32 as libc::c_long,
+        | 48 as i32 as isize,
     (0x406 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (25 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 49 as i32 as libc::c_long,
+        | 49 as i32 as isize,
     (0x303 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (26 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 51 as i32 as libc::c_long,
+        | 51 as i32 as isize,
     (0x240 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (27 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 52 as i32 as libc::c_long,
+        | 52 as i32 as isize,
     (0x1b1 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (28 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 54 as i32 as libc::c_long,
+        | 54 as i32 as isize,
     (0x144 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (29 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 56 as i32 as libc::c_long,
+        | 56 as i32 as isize,
     (0xf5 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (30 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 57 as i32 as libc::c_long,
+        | 57 as i32 as isize,
     (0xb7 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (31 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 59 as i32 as libc::c_long,
+        | 59 as i32 as isize,
     (0x8a as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (32 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 60 as i32 as libc::c_long,
+        | 60 as i32 as isize,
     (0x68 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (33 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 62 as i32 as libc::c_long,
+        | 62 as i32 as isize,
     (0x4e as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (34 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 63 as i32 as libc::c_long,
+        | 63 as i32 as isize,
     (0x3b as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (35 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 32 as i32 as libc::c_long,
+        | 32 as i32 as isize,
     (0x2c as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (9 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 33 as i32 as libc::c_long,
+        | 33 as i32 as isize,
     (0x5ae1 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (37 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (1 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 37 as i32 as libc::c_long,
+        | 37 as i32 as isize,
     (0x484c as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (38 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 64 as i32 as libc::c_long,
+        | 64 as i32 as isize,
     (0x3a0d as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (39 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 65 as i32 as libc::c_long,
+        | 65 as i32 as isize,
     (0x2ef1 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (40 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 67 as i32 as libc::c_long,
+        | 67 as i32 as isize,
     (0x261f as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (41 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 68 as i32 as libc::c_long,
+        | 68 as i32 as isize,
     (0x1f33 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (42 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 69 as i32 as libc::c_long,
+        | 69 as i32 as isize,
     (0x19a8 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (43 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 70 as i32 as libc::c_long,
+        | 70 as i32 as isize,
     (0x1518 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (44 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 72 as i32 as libc::c_long,
+        | 72 as i32 as isize,
     (0x1177 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (45 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 73 as i32 as libc::c_long,
+        | 73 as i32 as isize,
     (0xe74 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (46 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 74 as i32 as libc::c_long,
+        | 74 as i32 as isize,
     (0xbfb as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (47 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 75 as i32 as libc::c_long,
+        | 75 as i32 as isize,
     (0x9f8 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (48 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 77 as i32 as libc::c_long,
+        | 77 as i32 as isize,
     (0x861 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (49 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 78 as i32 as libc::c_long,
+        | 78 as i32 as isize,
     (0x706 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (50 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 79 as i32 as libc::c_long,
+        | 79 as i32 as isize,
     (0x5cd as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (51 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 48 as i32 as libc::c_long,
+        | 48 as i32 as isize,
     (0x4de as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (52 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 50 as i32 as libc::c_long,
+        | 50 as i32 as isize,
     (0x40f as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (53 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 50 as i32 as libc::c_long,
+        | 50 as i32 as isize,
     (0x363 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (54 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 51 as i32 as libc::c_long,
+        | 51 as i32 as isize,
     (0x2d4 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (55 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 52 as i32 as libc::c_long,
+        | 52 as i32 as isize,
     (0x25c as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (56 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 53 as i32 as libc::c_long,
+        | 53 as i32 as isize,
     (0x1f8 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (57 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 54 as i32 as libc::c_long,
+        | 54 as i32 as isize,
     (0x1a4 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (58 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 55 as i32 as libc::c_long,
+        | 55 as i32 as isize,
     (0x160 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (59 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 56 as i32 as libc::c_long,
+        | 56 as i32 as isize,
     (0x125 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (60 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 57 as i32 as libc::c_long,
+        | 57 as i32 as isize,
     (0xf6 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (61 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 58 as i32 as libc::c_long,
+        | 58 as i32 as isize,
     (0xcb as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (62 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 59 as i32 as libc::c_long,
+        | 59 as i32 as isize,
     (0xab as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (63 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 61 as i32 as libc::c_long,
+        | 61 as i32 as isize,
     (0x8f as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (32 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 61 as i32 as libc::c_long,
+        | 61 as i32 as isize,
     (0x5b12 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (65 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (1 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 65 as i32 as libc::c_long,
+        | 65 as i32 as isize,
     (0x4d04 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (66 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 80 as i32 as libc::c_long,
+        | 80 as i32 as isize,
     (0x412c as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (67 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 81 as i32 as libc::c_long,
+        | 81 as i32 as isize,
     (0x37d8 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (68 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 82 as i32 as libc::c_long,
+        | 82 as i32 as isize,
     (0x2fe8 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (69 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 83 as i32 as libc::c_long,
+        | 83 as i32 as isize,
     (0x293c as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (70 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 84 as i32 as libc::c_long,
+        | 84 as i32 as isize,
     (0x2379 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (71 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 86 as i32 as libc::c_long,
+        | 86 as i32 as isize,
     (0x1edf as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (72 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 87 as i32 as libc::c_long,
+        | 87 as i32 as isize,
     (0x1aa9 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (73 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 87 as i32 as libc::c_long,
+        | 87 as i32 as isize,
     (0x174e as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (74 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 72 as i32 as libc::c_long,
+        | 72 as i32 as isize,
     (0x1424 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (75 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 72 as i32 as libc::c_long,
+        | 72 as i32 as isize,
     (0x119c as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (76 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 74 as i32 as libc::c_long,
+        | 74 as i32 as isize,
     (0xf6b as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (77 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 74 as i32 as libc::c_long,
+        | 74 as i32 as isize,
     (0xd51 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (78 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 75 as i32 as libc::c_long,
+        | 75 as i32 as isize,
     (0xbb6 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (79 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 77 as i32 as libc::c_long,
+        | 77 as i32 as isize,
     (0xa40 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (48 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 77 as i32 as libc::c_long,
+        | 77 as i32 as isize,
     (0x5832 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (81 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (1 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 80 as i32 as libc::c_long,
+        | 80 as i32 as isize,
     (0x4d1c as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (82 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 88 as i32 as libc::c_long,
+        | 88 as i32 as isize,
     (0x438e as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (83 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 89 as i32 as libc::c_long,
+        | 89 as i32 as isize,
     (0x3bdd as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (84 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 90 as i32 as libc::c_long,
+        | 90 as i32 as isize,
     (0x34ee as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (85 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 91 as i32 as libc::c_long,
+        | 91 as i32 as isize,
     (0x2eae as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (86 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 92 as i32 as libc::c_long,
+        | 92 as i32 as isize,
     (0x299a as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (87 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 93 as i32 as libc::c_long,
+        | 93 as i32 as isize,
     (0x2516 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (71 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 86 as i32 as libc::c_long,
+        | 86 as i32 as isize,
     (0x5570 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (89 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (1 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 88 as i32 as libc::c_long,
+        | 88 as i32 as isize,
     (0x4ca9 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (90 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 95 as i32 as libc::c_long,
+        | 95 as i32 as isize,
     (0x44d9 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (91 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 96 as i32 as libc::c_long,
+        | 96 as i32 as isize,
     (0x3e22 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (92 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 97 as i32 as libc::c_long,
+        | 97 as i32 as isize,
     (0x3824 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (93 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 99 as i32 as libc::c_long,
+        | 99 as i32 as isize,
     (0x32b4 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (94 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 99 as i32 as libc::c_long,
+        | 99 as i32 as isize,
     (0x2e17 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (86 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 93 as i32 as libc::c_long,
+        | 93 as i32 as isize,
     (0x56a8 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (96 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (1 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 95 as i32 as libc::c_long,
+        | 95 as i32 as isize,
     (0x4f46 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (97 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 101 as i32 as libc::c_long,
+        | 101 as i32 as isize,
     (0x47e5 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (98 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 102 as i32 as libc::c_long,
+        | 102 as i32 as isize,
     (0x41cf as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (99 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 103 as i32 as libc::c_long,
+        | 103 as i32 as isize,
     (0x3c3d as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (100 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 104 as i32 as libc::c_long,
+        | 104 as i32 as isize,
     (0x375e as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (93 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 99 as i32 as libc::c_long,
+        | 99 as i32 as isize,
     (0x5231 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (102 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 105 as i32 as libc::c_long,
+        | 105 as i32 as isize,
     (0x4c0f as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (103 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 106 as i32 as libc::c_long,
+        | 106 as i32 as isize,
     (0x4639 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (104 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 107 as i32 as libc::c_long,
+        | 107 as i32 as isize,
     (0x415e as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (99 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 103 as i32 as libc::c_long,
+        | 103 as i32 as isize,
     (0x5627 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (106 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (1 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 105 as i32 as libc::c_long,
+        | 105 as i32 as isize,
     (0x50e7 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (107 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 108 as i32 as libc::c_long,
+        | 108 as i32 as isize,
     (0x4b85 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (103 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 109 as i32 as libc::c_long,
+        | 109 as i32 as isize,
     (0x5597 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (109 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 110 as i32 as libc::c_long,
+        | 110 as i32 as isize,
     (0x504f as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (107 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 111 as i32 as libc::c_long,
+        | 111 as i32 as isize,
     (0x5a10 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (111 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (1 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 110 as i32 as libc::c_long,
+        | 110 as i32 as isize,
     (0x5522 as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (109 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 112 as i32 as libc::c_long,
+        | 112 as i32 as isize,
     (0x59eb as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (111 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (1 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 112 as i32 as libc::c_long,
+        | 112 as i32 as isize,
     (0x5a1d as i32 as crate::jmorecfg_h::INT32) << 16 as i32
         | (113 as i32 as crate::jmorecfg_h::INT32) << 8 as i32
         | (0 as i32 as crate::jmorecfg_h::INT32) << 7 as i32
-        | 113 as i32 as libc::c_long,
+        | 113 as i32 as isize,
 ];

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jcapimin.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jcapimin.rs
@@ -409,8 +409,8 @@ pub unsafe extern "C" fn jpeg_finish_compress(mut cinfo: crate::jpeglib_h::j_com
         iMCU_row = 0 as i32 as crate::jmorecfg_h::JDIMENSION;
         while iMCU_row < (*cinfo).total_iMCU_rows {
             if !(*cinfo).progress.is_null() {
-                (*(*cinfo).progress).pass_counter = iMCU_row as libc::c_long;
-                (*(*cinfo).progress).pass_limit = (*cinfo).total_iMCU_rows as libc::c_long;
+                (*(*cinfo).progress).pass_counter = iMCU_row as isize;
+                (*(*cinfo).progress).pass_limit = (*cinfo).total_iMCU_rows as isize;
                 Some(
                     (*(*cinfo).progress)
                         .progress_monitor

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jcapistd.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jcapistd.rs
@@ -336,8 +336,8 @@ pub unsafe extern "C" fn jpeg_write_scanlines(
     }
     /* Call progress monitor hook if present */
     if !(*cinfo).progress.is_null() {
-        (*(*cinfo).progress).pass_counter = (*cinfo).next_scanline as libc::c_long;
-        (*(*cinfo).progress).pass_limit = (*cinfo).image_height as libc::c_long;
+        (*(*cinfo).progress).pass_counter = (*cinfo).next_scanline as isize;
+        (*(*cinfo).progress).pass_limit = (*cinfo).image_height as isize;
         Some(
             (*(*cinfo).progress)
                 .progress_monitor
@@ -412,8 +412,8 @@ pub unsafe extern "C" fn jpeg_write_raw_data(
     }
     /* Call progress monitor hook if present */
     if !(*cinfo).progress.is_null() {
-        (*(*cinfo).progress).pass_counter = (*cinfo).next_scanline as libc::c_long;
-        (*(*cinfo).progress).pass_limit = (*cinfo).image_height as libc::c_long;
+        (*(*cinfo).progress).pass_counter = (*cinfo).next_scanline as isize;
+        (*(*cinfo).progress).pass_limit = (*cinfo).image_height as isize;
         Some(
             (*(*cinfo).progress)
                 .progress_monitor

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jcarith.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jcarith.rs
@@ -285,15 +285,15 @@ unsafe extern "C" fn finish_pass(mut cinfo: crate::jpeglib_h::j_compress_ptr) {
     /* Section D.1.8: Termination of encoding */
     /* Find the e->c in the coding interval with the largest
      * number of trailing zero bits */
-    temp = (*e).a - 1 as i32 as libc::c_long + (*e).c & 0xffff0000 as libc::c_long;
+    temp = (*e).a - 1 as i32 as isize + (*e).c & 0xffff0000 as isize;
     if temp < (*e).c {
-        (*e).c = temp + 0x8000 as libc::c_long
+        (*e).c = temp + 0x8000 as isize
     } else {
         (*e).c = temp
     }
     /* Send remaining bytes to output */
     (*e).c <<= (*e).ct;
-    if (*e).c & 0xf8000000 as libc::c_long != 0 {
+    if (*e).c & 0xf8000000 as isize != 0 {
         /* One final overflow has to be handled */
         if (*e).buffer >= 0 as i32 {
             if (*e).zc != 0 {
@@ -348,7 +348,7 @@ unsafe extern "C" fn finish_pass(mut cinfo: crate::jpeglib_h::j_compress_ptr) {
         }
     }
     /* Output final bytes only if they are not 0x00 */
-    if (*e).c & 0x7fff800 as libc::c_long != 0 {
+    if (*e).c & 0x7fff800 as isize != 0 {
         if (*e).zc != 0 {
             loop
             /* output final pending zero bytes */
@@ -361,18 +361,18 @@ unsafe extern "C" fn finish_pass(mut cinfo: crate::jpeglib_h::j_compress_ptr) {
             }
         }
         emit_byte(
-            ((*e).c >> 19 as i32 & 0xff as i32 as libc::c_long) as i32,
+            ((*e).c >> 19 as i32 & 0xff as i32 as isize) as i32,
             cinfo,
         );
-        if (*e).c >> 19 as i32 & 0xff as i32 as libc::c_long == 0xff as i32 as libc::c_long {
+        if (*e).c >> 19 as i32 & 0xff as i32 as isize == 0xff as i32 as isize {
             emit_byte(0 as i32, cinfo);
         }
-        if (*e).c & 0x7f800 as libc::c_long != 0 {
+        if (*e).c & 0x7f800 as isize != 0 {
             emit_byte(
-                ((*e).c >> 11 as i32 & 0xff as i32 as libc::c_long) as i32,
+                ((*e).c >> 11 as i32 & 0xff as i32 as isize) as i32,
                 cinfo,
             );
-            if (*e).c >> 11 as i32 & 0xff as i32 as libc::c_long == 0xff as i32 as libc::c_long {
+            if (*e).c >> 11 as i32 & 0xff as i32 as isize == 0xff as i32 as isize {
                 emit_byte(0 as i32, cinfo);
             }
         }
@@ -418,9 +418,9 @@ unsafe extern "C" fn arith_encode(
     qe = *crate::src::jpeg_8c::jaricom::jpeg_aritab
         .as_ptr()
         .offset((sv & 0x7f as i32) as isize); /* Next_Index_LPS + Switch_MPS */
-    nl = (qe & 0xff as i32 as libc::c_long) as u8; /* Next_Index_MPS */
+    nl = (qe & 0xff as i32 as isize) as u8; /* Next_Index_MPS */
     qe >>= 8 as i32;
-    nm = (qe & 0xff as i32 as libc::c_long) as u8;
+    nm = (qe & 0xff as i32 as isize) as u8;
     qe >>= 8 as i32;
     /* Encode & estimation procedures per sections D.1.4 & D.1.5 */
     (*e).a -= qe;
@@ -438,7 +438,7 @@ unsafe extern "C" fn arith_encode(
     /* Estimate_after_LPS */
     } else {
         /* Encode the more probable symbol */
-        if (*e).a >= 0x8000 as libc::c_long {
+        if (*e).a >= 0x8000 as isize {
             return;
         }
         if (*e).a < qe {
@@ -461,7 +461,7 @@ unsafe extern "C" fn arith_encode(
         if (*e).ct == 0 as i32 {
             /* Another byte is ready for output */
             temp = (*e).c >> 19 as i32;
-            if temp > 0xff as i32 as libc::c_long {
+            if temp > 0xff as i32 as isize {
                 /* Handle overflow over all stacked 0xFF bytes */
                 if (*e).buffer >= 0 as i32 {
                     if (*e).zc != 0 {
@@ -481,8 +481,8 @@ unsafe extern "C" fn arith_encode(
                 /* new output byte, might overflow later */
                 (*e).zc += (*e).sc; /* carry-over converts stacked 0xFF bytes to 0x00 */
                 (*e).sc = 0 as i32 as crate::jmorecfg_h::INT32;
-                (*e).buffer = (temp & 0xff as i32 as libc::c_long) as i32
-            } else if temp == 0xff as i32 as libc::c_long {
+                (*e).buffer = (temp & 0xff as i32 as isize) as i32
+            } else if temp == 0xff as i32 as isize {
                 (*e).sc += 1
             /* Note: The 3 spacer bits in the C register guarantee
              * that the new buffer byte can't be 0xFF here
@@ -523,13 +523,13 @@ unsafe extern "C" fn arith_encode(
                         }
                     }
                 }
-                (*e).buffer = (temp & 0xff as i32 as libc::c_long) as i32
+                (*e).buffer = (temp & 0xff as i32 as isize) as i32
                 /* new output byte (can still overflow) */
             }
-            (*e).c &= 0x7ffff as libc::c_long;
+            (*e).c &= 0x7ffff as isize;
             (*e).ct += 8 as i32
         }
-        if !((*e).a < 0x8000 as libc::c_long) {
+        if !((*e).a < 0x8000 as isize) {
             break;
         }
     }
@@ -576,7 +576,7 @@ unsafe extern "C" fn emit_restart(
     }
     /* Reset arithmetic encoding variables */
     (*entropy).c = 0 as i32 as crate::jmorecfg_h::INT32;
-    (*entropy).a = 0x10000 as libc::c_long;
+    (*entropy).a = 0x10000 as isize;
     (*entropy).sc = 0 as i32 as crate::jmorecfg_h::INT32;
     (*entropy).zc = 0 as i32 as crate::jmorecfg_h::INT32;
     (*entropy).ct = 11 as i32;
@@ -667,13 +667,13 @@ unsafe extern "C" fn encode_mcu_DC_first(
             }
             arith_encode(cinfo, st, 0 as i32);
             /* Section F.1.4.4.1.2: Establish dc_context conditioning category */
-            if m < ((1 as libc::c_long) << (*cinfo).arith_dc_L[tbl as usize] as i32 >> 1 as i32)
+            if m < ((1 as isize) << (*cinfo).arith_dc_L[tbl as usize] as i32 >> 1 as i32)
                 as i32
             {
                 /* large diff category */
                 (*entropy).dc_context[ci as usize] = 0 as i32
             } else if m
-                > ((1 as libc::c_long) << (*cinfo).arith_dc_U[tbl as usize] as i32 >> 1 as i32)
+                > ((1 as isize) << (*cinfo).arith_dc_U[tbl as usize] as i32 >> 1 as i32)
                     as i32
             {
                 (*entropy).dc_context[ci as usize] += 8 as i32
@@ -1072,13 +1072,13 @@ unsafe extern "C" fn encode_mcu(
             }
             arith_encode(cinfo, st, 0 as i32);
             /* Section F.1.4.4.1.2: Establish dc_context conditioning category */
-            if m < ((1 as libc::c_long) << (*cinfo).arith_dc_L[tbl as usize] as i32 >> 1 as i32)
+            if m < ((1 as isize) << (*cinfo).arith_dc_L[tbl as usize] as i32 >> 1 as i32)
                 as i32
             {
                 /* large diff category */
                 (*entropy).dc_context[ci as usize] = 0 as i32
             } else if m
-                > ((1 as libc::c_long) << (*cinfo).arith_dc_U[tbl as usize] as i32 >> 1 as i32)
+                > ((1 as isize) << (*cinfo).arith_dc_U[tbl as usize] as i32 >> 1 as i32)
                     as i32
             {
                 (*entropy).dc_context[ci as usize] += 8 as i32
@@ -1329,7 +1329,7 @@ unsafe extern "C" fn start_pass(
     }
     /* Initialize arithmetic encoding variables */
     (*entropy).c = 0 as i32 as crate::jmorecfg_h::INT32; /* empty */
-    (*entropy).a = 0x10000 as libc::c_long;
+    (*entropy).a = 0x10000 as isize;
     (*entropy).sc = 0 as i32 as crate::jmorecfg_h::INT32;
     (*entropy).zc = 0 as i32 as crate::jmorecfg_h::INT32;
     (*entropy).ct = 11 as i32;

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jccoefct.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jccoefct.rs
@@ -784,12 +784,12 @@ pub unsafe extern "C" fn jinit_c_coef_controller(
                 1 as i32,
                 0 as i32,
                 crate::src::jpeg_8c::jutils::jround_up(
-                    (*compptr).width_in_blocks as libc::c_long,
-                    (*compptr).h_samp_factor as libc::c_long,
+                    (*compptr).width_in_blocks as isize,
+                    (*compptr).h_samp_factor as isize,
                 ) as crate::jmorecfg_h::JDIMENSION,
                 crate::src::jpeg_8c::jutils::jround_up(
-                    (*compptr).height_in_blocks as libc::c_long,
-                    (*compptr).v_samp_factor as libc::c_long,
+                    (*compptr).height_in_blocks as isize,
+                    (*compptr).v_samp_factor as isize,
                 ) as crate::jmorecfg_h::JDIMENSION,
                 (*compptr).v_samp_factor as crate::jmorecfg_h::JDIMENSION,
             );

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jccolor.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jccolor.rs
@@ -234,48 +234,48 @@ unsafe extern "C" fn rgb_ycc_start(mut cinfo: crate::jpeglib_h::j_compress_ptr) 
     ) as *mut crate::jmorecfg_h::INT32;
     (*cconvert).rgb_ycc_tab = rgb_ycc_tab;
     i = 0 as i32 as crate::jmorecfg_h::INT32;
-    while i <= 255 as i32 as libc::c_long {
-        *rgb_ycc_tab.offset((i + 0 as i32 as libc::c_long) as isize) =
-            (0.29900f64 * ((1 as libc::c_long) << 16 as i32) as f64 + 0.5f64)
+    while i <= 255 as i32 as isize {
+        *rgb_ycc_tab.offset((i + 0 as i32 as isize) as isize) =
+            (0.29900f64 * ((1 as isize) << 16 as i32) as f64 + 0.5f64)
                 as crate::jmorecfg_h::INT32
                 * i;
-        *rgb_ycc_tab.offset((i + (1 as i32 * (255 as i32 + 1 as i32)) as libc::c_long) as isize) =
-            (0.58700f64 * ((1 as libc::c_long) << 16 as i32) as f64 + 0.5f64)
+        *rgb_ycc_tab.offset((i + (1 as i32 * (255 as i32 + 1 as i32)) as isize) as isize) =
+            (0.58700f64 * ((1 as isize) << 16 as i32) as f64 + 0.5f64)
                 as crate::jmorecfg_h::INT32
                 * i;
-        *rgb_ycc_tab.offset((i + (2 as i32 * (255 as i32 + 1 as i32)) as libc::c_long) as isize) =
-            (0.11400f64 * ((1 as libc::c_long) << 16 as i32) as f64 + 0.5f64)
+        *rgb_ycc_tab.offset((i + (2 as i32 * (255 as i32 + 1 as i32)) as isize) as isize) =
+            (0.11400f64 * ((1 as isize) << 16 as i32) as f64 + 0.5f64)
                 as crate::jmorecfg_h::INT32
                 * i
                 + ((1 as i32 as crate::jmorecfg_h::INT32) << 16 as i32 - 1 as i32);
-        *rgb_ycc_tab.offset((i + (3 as i32 * (255 as i32 + 1 as i32)) as libc::c_long) as isize) =
-            -((0.16874f64 * ((1 as libc::c_long) << 16 as i32) as f64 + 0.5f64)
+        *rgb_ycc_tab.offset((i + (3 as i32 * (255 as i32 + 1 as i32)) as isize) as isize) =
+            -((0.16874f64 * ((1 as isize) << 16 as i32) as f64 + 0.5f64)
                 as crate::jmorecfg_h::INT32)
                 * i;
-        *rgb_ycc_tab.offset((i + (4 as i32 * (255 as i32 + 1 as i32)) as libc::c_long) as isize) =
-            -((0.33126f64 * ((1 as libc::c_long) << 16 as i32) as f64 + 0.5f64)
+        *rgb_ycc_tab.offset((i + (4 as i32 * (255 as i32 + 1 as i32)) as isize) as isize) =
+            -((0.33126f64 * ((1 as isize) << 16 as i32) as f64 + 0.5f64)
                 as crate::jmorecfg_h::INT32)
                 * i;
         /* We use a rounding fudge-factor of 0.5-epsilon for Cb and Cr.
          * This ensures that the maximum output will round to MAXJSAMPLE
          * not MAXJSAMPLE+1, and thus that we don't have to range-limit.
          */
-        *rgb_ycc_tab.offset((i + (5 as i32 * (255 as i32 + 1 as i32)) as libc::c_long) as isize) =
-            (0.50000f64 * ((1 as libc::c_long) << 16 as i32) as f64 + 0.5f64)
+        *rgb_ycc_tab.offset((i + (5 as i32 * (255 as i32 + 1 as i32)) as isize) as isize) =
+            (0.50000f64 * ((1 as isize) << 16 as i32) as f64 + 0.5f64)
                 as crate::jmorecfg_h::INT32
                 * i
                 + ((128 as i32 as crate::jmorecfg_h::INT32) << 16 as i32)
                 + ((1 as i32 as crate::jmorecfg_h::INT32) << 16 as i32 - 1 as i32)
-                - 1 as i32 as libc::c_long;
+                - 1 as i32 as isize;
         /*  B=>Cb and R=>Cr tables are the same
             rgb_ycc_tab[i+R_CR_OFF] = FIX(0.50000) * i    + CBCR_OFFSET + ONE_HALF-1;
         */
-        *rgb_ycc_tab.offset((i + (6 as i32 * (255 as i32 + 1 as i32)) as libc::c_long) as isize) =
-            -((0.41869f64 * ((1 as libc::c_long) << 16 as i32) as f64 + 0.5f64)
+        *rgb_ycc_tab.offset((i + (6 as i32 * (255 as i32 + 1 as i32)) as isize) as isize) =
+            -((0.41869f64 * ((1 as isize) << 16 as i32) as f64 + 0.5f64)
                 as crate::jmorecfg_h::INT32)
                 * i;
-        *rgb_ycc_tab.offset((i + (7 as i32 * (255 as i32 + 1 as i32)) as libc::c_long) as isize) =
-            -((0.08131f64 * ((1 as libc::c_long) << 16 as i32) as f64 + 0.5f64)
+        *rgb_ycc_tab.offset((i + (7 as i32 * (255 as i32 + 1 as i32)) as isize) as isize) =
+            -((0.08131f64 * ((1 as isize) << 16 as i32) as f64 + 0.5f64)
                 as crate::jmorecfg_h::INT32)
                 * i;
         i += 1

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jchuff.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jchuff.rs
@@ -209,8 +209,8 @@ pub struct huff_entropy_encoder {
     pub next_restart_num: i32,
     pub dc_derived_tbls: [*mut c_derived_tbl; 4],
     pub ac_derived_tbls: [*mut c_derived_tbl; 4],
-    pub dc_count_ptrs: [*mut libc::c_long; 4],
-    pub ac_count_ptrs: [*mut libc::c_long; 4],
+    pub dc_count_ptrs: [*mut isize; 4],
+    pub ac_count_ptrs: [*mut isize; 4],
     pub gather_statistics: crate::jmorecfg_h::boolean,
     pub next_output_byte: *mut crate::jmorecfg_h::JOCTET,
     pub free_in_buffer: crate::stddef_h::size_t,
@@ -485,12 +485,12 @@ unsafe extern "C" fn emit_bits_s(
             (*state).cinfo as crate::jpeglib_h::j_common_ptr
         ); /* new number of bits in buffer */
     } /* align incoming bits */
-    put_buffer &= ((1 as i32 as crate::jmorecfg_h::INT32) << size) - 1 as i32 as libc::c_long; /* and merge with old buffer contents */
+    put_buffer &= ((1 as i32 as crate::jmorecfg_h::INT32) << size) - 1 as i32 as isize; /* and merge with old buffer contents */
     put_bits += size;
     put_buffer <<= 24 as i32 - put_bits;
     put_buffer |= (*state).cur.put_buffer;
     while put_bits >= 8 as i32 {
-        let mut c: i32 = (put_buffer >> 16 as i32 & 0xff as i32 as libc::c_long) as i32;
+        let mut c: i32 = (put_buffer >> 16 as i32 & 0xff as i32 as isize) as i32;
         let fresh3 = (*state).next_output_byte;
         (*state).next_output_byte = (*state).next_output_byte.offset(1);
         *fresh3 = c as crate::jmorecfg_h::JOCTET;
@@ -543,13 +543,13 @@ unsafe extern "C" fn emit_bits_e(mut entropy: huff_entropy_ptr, mut code: u32, m
     if (*entropy).gather_statistics != 0 {
         return;
     } /* align incoming bits */
-    put_buffer &= ((1 as i32 as crate::jmorecfg_h::INT32) << size) - 1 as i32 as libc::c_long;
+    put_buffer &= ((1 as i32 as crate::jmorecfg_h::INT32) << size) - 1 as i32 as isize;
     put_bits += size;
     put_buffer <<= 24 as i32 - put_bits;
     /* and merge with old buffer contents */
     put_buffer |= (*entropy).saved.put_buffer;
     while put_bits >= 8 as i32 {
-        let mut c: i32 = (put_buffer >> 16 as i32 & 0xff as i32 as libc::c_long) as i32;
+        let mut c: i32 = (put_buffer >> 16 as i32 & 0xff as i32 as isize) as i32;
         let fresh5 = (*entropy).next_output_byte;
         (*entropy).next_output_byte = (*entropy).next_output_byte.offset(1);
         *fresh5 = c as crate::jmorecfg_h::JOCTET;
@@ -1437,8 +1437,8 @@ unsafe extern "C" fn htest_one_block(
     mut cinfo: crate::jpeglib_h::j_compress_ptr,
     mut block: crate::jpeglib_h::JCOEFPTR,
     mut last_dc_val: i32,
-    mut dc_counts: *mut libc::c_long,
-    mut ac_counts: *mut libc::c_long,
+    mut dc_counts: *mut isize,
+    mut ac_counts: *mut isize,
 ) {
     let mut temp: i32 = 0;
     let mut nbits: i32 = 0;
@@ -1600,7 +1600,7 @@ unsafe extern "C" fn encode_mcu_gather(
 unsafe extern "C" fn jpeg_gen_optimal_table(
     mut cinfo: crate::jpeglib_h::j_compress_ptr,
     mut htbl: *mut crate::jpeglib_h::JHUFF_TBL,
-    mut freq: *mut libc::c_long,
+    mut freq: *mut isize,
 ) {
     /* assumed maximum initial code length */
     let mut bits: [crate::jmorecfg_h::UINT8; 33] = [0; 33]; /* bits[k] = # of symbols with code length k */
@@ -1611,7 +1611,7 @@ unsafe extern "C" fn jpeg_gen_optimal_table(
     let mut p: i32 = 0;
     let mut i: i32 = 0;
     let mut j: i32 = 0;
-    let mut v: libc::c_long = 0;
+    let mut v: isize = 0;
     /* This algorithm is explained in section K.2 of the JPEG standard */
     crate::stdlib::memset(
         bits.as_mut_ptr() as *mut libc::c_void,
@@ -1628,7 +1628,7 @@ unsafe extern "C" fn jpeg_gen_optimal_table(
         others[i as usize] = -(1 as i32);
         i += 1
     }
-    *freq.offset(256 as i32 as isize) = 1 as i32 as libc::c_long;
+    *freq.offset(256 as i32 as isize) = 1 as i32 as isize;
     loop
     /* Including the pseudo-symbol 256 in the Huffman procedure guarantees
      * that no real symbol is given code-value of all ones, because 256
@@ -1639,7 +1639,7 @@ unsafe extern "C" fn jpeg_gen_optimal_table(
     /* In case of ties, take the larger symbol number */
     {
         c1 = -(1 as i32);
-        v = 1000000000 as libc::c_long;
+        v = 1000000000 as isize;
         i = 0 as i32;
         while i <= 256 as i32 {
             if *freq.offset(i as isize) != 0 && *freq.offset(i as isize) <= v {
@@ -1651,7 +1651,7 @@ unsafe extern "C" fn jpeg_gen_optimal_table(
         /* Find the next smallest nonzero frequency, set c2 = its symbol */
         /* In case of ties, take the larger symbol number */
         c2 = -(1 as i32);
-        v = 1000000000 as libc::c_long;
+        v = 1000000000 as isize;
         i = 0 as i32;
         while i <= 256 as i32 {
             if *freq.offset(i as isize) != 0 && *freq.offset(i as isize) <= v && i != c1 {
@@ -1666,7 +1666,7 @@ unsafe extern "C" fn jpeg_gen_optimal_table(
         }
         /* Else merge the two counts/trees */
         *freq.offset(c1 as isize) += *freq.offset(c2 as isize);
-        *freq.offset(c2 as isize) = 0 as i32 as libc::c_long;
+        *freq.offset(c2 as isize) = 0 as i32 as isize;
         /* Increment the codesize of everything in c1's tree branch */
         codesize[c1 as usize] += 1; /* chain c2 onto c1's tree branch */
         while others[c1 as usize] >= 0 as i32 {
@@ -1966,15 +1966,15 @@ unsafe extern "C" fn start_pass_huff(
                         cinfo as crate::jpeglib_h::j_common_ptr,
                         1 as i32,
                         (257 as i32 as libc::c_ulong)
-                            .wrapping_mul(::std::mem::size_of::<libc::c_long>() as libc::c_ulong),
+                            .wrapping_mul(::std::mem::size_of::<isize>() as libc::c_ulong),
                     )
-                        as *mut libc::c_long
+                        as *mut isize
                 }
                 crate::stdlib::memset(
                     (*entropy).dc_count_ptrs[tbl as usize] as *mut libc::c_void,
                     0 as i32,
                     (257 as i32 as libc::c_ulong)
-                        .wrapping_mul(::std::mem::size_of::<libc::c_long>() as libc::c_ulong),
+                        .wrapping_mul(::std::mem::size_of::<isize>() as libc::c_ulong),
                 );
             } else {
                 /* Compute derived values for Huffman tables */
@@ -2016,15 +2016,15 @@ unsafe extern "C" fn start_pass_huff(
                         cinfo as crate::jpeglib_h::j_common_ptr,
                         1 as i32,
                         (257 as i32 as libc::c_ulong)
-                            .wrapping_mul(::std::mem::size_of::<libc::c_long>() as libc::c_ulong),
+                            .wrapping_mul(::std::mem::size_of::<isize>() as libc::c_ulong),
                     )
-                        as *mut libc::c_long
+                        as *mut isize
                 }
                 crate::stdlib::memset(
                     (*entropy).ac_count_ptrs[tbl as usize] as *mut libc::c_void,
                     0 as i32,
                     (257 as i32 as libc::c_ulong)
-                        .wrapping_mul(::std::mem::size_of::<libc::c_long>() as libc::c_ulong),
+                        .wrapping_mul(::std::mem::size_of::<isize>() as libc::c_ulong),
                 );
             } else {
                 jpeg_make_c_derived_tbl(
@@ -2075,7 +2075,7 @@ pub unsafe extern "C" fn jinit_huff_encoder(mut cinfo: crate::jpeglib_h::j_compr
     while i < 4 as i32 {
         (*entropy).ac_derived_tbls[i as usize] = 0 as *mut c_derived_tbl;
         (*entropy).dc_derived_tbls[i as usize] = (*entropy).ac_derived_tbls[i as usize];
-        (*entropy).ac_count_ptrs[i as usize] = 0 as *mut libc::c_long;
+        (*entropy).ac_count_ptrs[i as usize] = 0 as *mut isize;
         (*entropy).dc_count_ptrs[i as usize] = (*entropy).ac_count_ptrs[i as usize];
         i += 1
     }

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jcmarker.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jcmarker.rs
@@ -563,8 +563,8 @@ unsafe extern "C" fn emit_sof(mut cinfo: crate::jpeglib_h::j_compress_ptr, mut c
         3 as i32 * (*cinfo).num_components + 2 as i32 + 5 as i32 + 1 as i32,
     );
     /* Make sure image isn't bigger than SOF field can handle */
-    if (*cinfo).jpeg_height as libc::c_long > 65535 as libc::c_long
-        || (*cinfo).jpeg_width as libc::c_long > 65535 as libc::c_long
+    if (*cinfo).jpeg_height as isize > 65535 as isize
+        || (*cinfo).jpeg_width as isize > 65535 as isize
     {
         (*(*cinfo).err).msg_code = crate::src::jpeg_8c::jerror::JERR_IMAGE_TOO_BIG as i32;
         (*(*cinfo).err).msg_parm.i[0 as i32 as usize] = 65535 as i32 as u32 as i32;

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jcmaster.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jcmaster.rs
@@ -286,11 +286,11 @@ pub unsafe extern "C" fn jpeg_calc_jpeg_dimensions(mut cinfo: crate::jpeglib_h::
      * but image_width and image_height can come from arbitrary data,
      * and we need some space for multiplication by block_size.
      */
-    if (*cinfo).image_width as libc::c_long >> 24 as i32 != 0
-        || (*cinfo).image_height as libc::c_long >> 24 as i32 != 0
+    if (*cinfo).image_width as isize >> 24 as i32 != 0
+        || (*cinfo).image_height as isize >> 24 as i32 != 0
     {
         (*(*cinfo).err).msg_code = crate::src::jpeg_8c::jerror::JERR_IMAGE_TOO_BIG as i32;
-        (*(*cinfo).err).msg_parm.i[0 as i32 as usize] = 65500 as libc::c_long as u32 as i32;
+        (*(*cinfo).err).msg_parm.i[0 as i32 as usize] = 65500 as isize as u32 as i32;
         Some(
             (*(*cinfo).err)
                 .error_exit
@@ -320,12 +320,12 @@ pub unsafe extern "C" fn jpeg_calc_jpeg_dimensions(mut cinfo: crate::jpeglib_h::
     {
         /* Provide block_size/2 scaling */
         (*cinfo).jpeg_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * (*cinfo).block_size as libc::c_long,
-            2 as libc::c_long,
+            (*cinfo).image_width as isize * (*cinfo).block_size as isize,
+            2 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).jpeg_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * (*cinfo).block_size as libc::c_long,
-            2 as libc::c_long,
+            (*cinfo).image_height as isize * (*cinfo).block_size as isize,
+            2 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 2 as i32;
         (*cinfo).min_DCT_v_scaled_size = 2 as i32
@@ -336,12 +336,12 @@ pub unsafe extern "C" fn jpeg_calc_jpeg_dimensions(mut cinfo: crate::jpeglib_h::
     {
         /* Provide block_size/3 scaling */
         (*cinfo).jpeg_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * (*cinfo).block_size as libc::c_long,
-            3 as libc::c_long,
+            (*cinfo).image_width as isize * (*cinfo).block_size as isize,
+            3 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).jpeg_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * (*cinfo).block_size as libc::c_long,
-            3 as libc::c_long,
+            (*cinfo).image_height as isize * (*cinfo).block_size as isize,
+            3 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 3 as i32;
         (*cinfo).min_DCT_v_scaled_size = 3 as i32
@@ -352,12 +352,12 @@ pub unsafe extern "C" fn jpeg_calc_jpeg_dimensions(mut cinfo: crate::jpeglib_h::
     {
         /* Provide block_size/4 scaling */
         (*cinfo).jpeg_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * (*cinfo).block_size as libc::c_long,
-            4 as libc::c_long,
+            (*cinfo).image_width as isize * (*cinfo).block_size as isize,
+            4 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).jpeg_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * (*cinfo).block_size as libc::c_long,
-            4 as libc::c_long,
+            (*cinfo).image_height as isize * (*cinfo).block_size as isize,
+            4 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 4 as i32;
         (*cinfo).min_DCT_v_scaled_size = 4 as i32
@@ -368,12 +368,12 @@ pub unsafe extern "C" fn jpeg_calc_jpeg_dimensions(mut cinfo: crate::jpeglib_h::
     {
         /* Provide block_size/5 scaling */
         (*cinfo).jpeg_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * (*cinfo).block_size as libc::c_long,
-            5 as libc::c_long,
+            (*cinfo).image_width as isize * (*cinfo).block_size as isize,
+            5 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).jpeg_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * (*cinfo).block_size as libc::c_long,
-            5 as libc::c_long,
+            (*cinfo).image_height as isize * (*cinfo).block_size as isize,
+            5 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 5 as i32;
         (*cinfo).min_DCT_v_scaled_size = 5 as i32
@@ -384,12 +384,12 @@ pub unsafe extern "C" fn jpeg_calc_jpeg_dimensions(mut cinfo: crate::jpeglib_h::
     {
         /* Provide block_size/6 scaling */
         (*cinfo).jpeg_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * (*cinfo).block_size as libc::c_long,
-            6 as libc::c_long,
+            (*cinfo).image_width as isize * (*cinfo).block_size as isize,
+            6 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).jpeg_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * (*cinfo).block_size as libc::c_long,
-            6 as libc::c_long,
+            (*cinfo).image_height as isize * (*cinfo).block_size as isize,
+            6 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 6 as i32;
         (*cinfo).min_DCT_v_scaled_size = 6 as i32
@@ -400,12 +400,12 @@ pub unsafe extern "C" fn jpeg_calc_jpeg_dimensions(mut cinfo: crate::jpeglib_h::
     {
         /* Provide block_size/7 scaling */
         (*cinfo).jpeg_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * (*cinfo).block_size as libc::c_long,
-            7 as libc::c_long,
+            (*cinfo).image_width as isize * (*cinfo).block_size as isize,
+            7 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).jpeg_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * (*cinfo).block_size as libc::c_long,
-            7 as libc::c_long,
+            (*cinfo).image_height as isize * (*cinfo).block_size as isize,
+            7 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 7 as i32;
         (*cinfo).min_DCT_v_scaled_size = 7 as i32
@@ -416,12 +416,12 @@ pub unsafe extern "C" fn jpeg_calc_jpeg_dimensions(mut cinfo: crate::jpeglib_h::
     {
         /* Provide block_size/8 scaling */
         (*cinfo).jpeg_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * (*cinfo).block_size as libc::c_long,
-            8 as libc::c_long,
+            (*cinfo).image_width as isize * (*cinfo).block_size as isize,
+            8 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).jpeg_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * (*cinfo).block_size as libc::c_long,
-            8 as libc::c_long,
+            (*cinfo).image_height as isize * (*cinfo).block_size as isize,
+            8 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 8 as i32;
         (*cinfo).min_DCT_v_scaled_size = 8 as i32
@@ -432,12 +432,12 @@ pub unsafe extern "C" fn jpeg_calc_jpeg_dimensions(mut cinfo: crate::jpeglib_h::
     {
         /* Provide block_size/9 scaling */
         (*cinfo).jpeg_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * (*cinfo).block_size as libc::c_long,
-            9 as libc::c_long,
+            (*cinfo).image_width as isize * (*cinfo).block_size as isize,
+            9 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).jpeg_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * (*cinfo).block_size as libc::c_long,
-            9 as libc::c_long,
+            (*cinfo).image_height as isize * (*cinfo).block_size as isize,
+            9 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 9 as i32;
         (*cinfo).min_DCT_v_scaled_size = 9 as i32
@@ -448,12 +448,12 @@ pub unsafe extern "C" fn jpeg_calc_jpeg_dimensions(mut cinfo: crate::jpeglib_h::
     {
         /* Provide block_size/10 scaling */
         (*cinfo).jpeg_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * (*cinfo).block_size as libc::c_long,
-            10 as libc::c_long,
+            (*cinfo).image_width as isize * (*cinfo).block_size as isize,
+            10 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).jpeg_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * (*cinfo).block_size as libc::c_long,
-            10 as libc::c_long,
+            (*cinfo).image_height as isize * (*cinfo).block_size as isize,
+            10 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 10 as i32;
         (*cinfo).min_DCT_v_scaled_size = 10 as i32
@@ -464,12 +464,12 @@ pub unsafe extern "C" fn jpeg_calc_jpeg_dimensions(mut cinfo: crate::jpeglib_h::
     {
         /* Provide block_size/11 scaling */
         (*cinfo).jpeg_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * (*cinfo).block_size as libc::c_long,
-            11 as libc::c_long,
+            (*cinfo).image_width as isize * (*cinfo).block_size as isize,
+            11 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).jpeg_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * (*cinfo).block_size as libc::c_long,
-            11 as libc::c_long,
+            (*cinfo).image_height as isize * (*cinfo).block_size as isize,
+            11 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 11 as i32;
         (*cinfo).min_DCT_v_scaled_size = 11 as i32
@@ -480,12 +480,12 @@ pub unsafe extern "C" fn jpeg_calc_jpeg_dimensions(mut cinfo: crate::jpeglib_h::
     {
         /* Provide block_size/12 scaling */
         (*cinfo).jpeg_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * (*cinfo).block_size as libc::c_long,
-            12 as libc::c_long,
+            (*cinfo).image_width as isize * (*cinfo).block_size as isize,
+            12 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).jpeg_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * (*cinfo).block_size as libc::c_long,
-            12 as libc::c_long,
+            (*cinfo).image_height as isize * (*cinfo).block_size as isize,
+            12 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 12 as i32;
         (*cinfo).min_DCT_v_scaled_size = 12 as i32
@@ -496,12 +496,12 @@ pub unsafe extern "C" fn jpeg_calc_jpeg_dimensions(mut cinfo: crate::jpeglib_h::
     {
         /* Provide block_size/13 scaling */
         (*cinfo).jpeg_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * (*cinfo).block_size as libc::c_long,
-            13 as libc::c_long,
+            (*cinfo).image_width as isize * (*cinfo).block_size as isize,
+            13 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).jpeg_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * (*cinfo).block_size as libc::c_long,
-            13 as libc::c_long,
+            (*cinfo).image_height as isize * (*cinfo).block_size as isize,
+            13 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 13 as i32;
         (*cinfo).min_DCT_v_scaled_size = 13 as i32
@@ -512,12 +512,12 @@ pub unsafe extern "C" fn jpeg_calc_jpeg_dimensions(mut cinfo: crate::jpeglib_h::
     {
         /* Provide block_size/14 scaling */
         (*cinfo).jpeg_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * (*cinfo).block_size as libc::c_long,
-            14 as libc::c_long,
+            (*cinfo).image_width as isize * (*cinfo).block_size as isize,
+            14 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).jpeg_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * (*cinfo).block_size as libc::c_long,
-            14 as libc::c_long,
+            (*cinfo).image_height as isize * (*cinfo).block_size as isize,
+            14 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 14 as i32;
         (*cinfo).min_DCT_v_scaled_size = 14 as i32
@@ -528,24 +528,24 @@ pub unsafe extern "C" fn jpeg_calc_jpeg_dimensions(mut cinfo: crate::jpeglib_h::
     {
         /* Provide block_size/15 scaling */
         (*cinfo).jpeg_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * (*cinfo).block_size as libc::c_long,
-            15 as libc::c_long,
+            (*cinfo).image_width as isize * (*cinfo).block_size as isize,
+            15 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).jpeg_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * (*cinfo).block_size as libc::c_long,
-            15 as libc::c_long,
+            (*cinfo).image_height as isize * (*cinfo).block_size as isize,
+            15 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 15 as i32;
         (*cinfo).min_DCT_v_scaled_size = 15 as i32
     } else {
         /* Provide block_size/16 scaling */
         (*cinfo).jpeg_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * (*cinfo).block_size as libc::c_long,
-            16 as libc::c_long,
+            (*cinfo).image_width as isize * (*cinfo).block_size as isize,
+            16 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).jpeg_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * (*cinfo).block_size as libc::c_long,
-            16 as libc::c_long,
+            (*cinfo).image_height as isize * (*cinfo).block_size as isize,
+            16 as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 16 as i32;
         (*cinfo).min_DCT_v_scaled_size = 16 as i32
@@ -579,7 +579,7 @@ unsafe extern "C" fn initial_setup(
     let mut ssize: i32 = 0;
     let mut compptr: *mut crate::jpeglib_h::jpeg_component_info =
         0 as *mut crate::jpeglib_h::jpeg_component_info;
-    let mut samplesperrow: libc::c_long = 0;
+    let mut samplesperrow: isize = 0;
     let mut jd_samplesperrow: crate::jmorecfg_h::JDIMENSION = 0;
     if transcode_only != 0 {
         jpeg_calc_trans_dimensions(cinfo);
@@ -629,11 +629,11 @@ unsafe extern "C" fn initial_setup(
         .expect("non-null function pointer")(cinfo as crate::jpeglib_h::j_common_ptr);
     }
     /* Make sure image isn't bigger than I can handle */
-    if (*cinfo).jpeg_height as libc::c_long > 65500 as libc::c_long
-        || (*cinfo).jpeg_width as libc::c_long > 65500 as libc::c_long
+    if (*cinfo).jpeg_height as isize > 65500 as isize
+        || (*cinfo).jpeg_width as isize > 65500 as isize
     {
         (*(*cinfo).err).msg_code = crate::src::jpeg_8c::jerror::JERR_IMAGE_TOO_BIG as i32;
-        (*(*cinfo).err).msg_parm.i[0 as i32 as usize] = 65500 as libc::c_long as u32 as i32;
+        (*(*cinfo).err).msg_parm.i[0 as i32 as usize] = 65500 as isize as u32 as i32;
         Some(
             (*(*cinfo).err)
                 .error_exit
@@ -643,9 +643,9 @@ unsafe extern "C" fn initial_setup(
     }
     /* Width of an input scanline must be representable as JDIMENSION. */
     samplesperrow =
-        (*cinfo).image_width as libc::c_long * (*cinfo).input_components as libc::c_long;
+        (*cinfo).image_width as isize * (*cinfo).input_components as isize;
     jd_samplesperrow = samplesperrow as crate::jmorecfg_h::JDIMENSION;
-    if jd_samplesperrow as libc::c_long != samplesperrow {
+    if jd_samplesperrow as isize != samplesperrow {
         (*(*cinfo).err).msg_code = crate::src::jpeg_8c::jerror::JERR_WIDTH_OVERFLOW as i32;
         Some(
             (*(*cinfo).err)
@@ -756,23 +756,23 @@ unsafe extern "C" fn initial_setup(
         }
         /* Size in DCT blocks */
         (*compptr).width_in_blocks = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).jpeg_width as libc::c_long * (*compptr).h_samp_factor as libc::c_long,
-            ((*cinfo).max_h_samp_factor * (*cinfo).block_size) as libc::c_long,
+            (*cinfo).jpeg_width as isize * (*compptr).h_samp_factor as isize,
+            ((*cinfo).max_h_samp_factor * (*cinfo).block_size) as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*compptr).height_in_blocks = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).jpeg_height as libc::c_long * (*compptr).v_samp_factor as libc::c_long,
-            ((*cinfo).max_v_samp_factor * (*cinfo).block_size) as libc::c_long,
+            (*cinfo).jpeg_height as isize * (*compptr).v_samp_factor as isize,
+            ((*cinfo).max_v_samp_factor * (*cinfo).block_size) as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         /* Size in samples */
         (*compptr).downsampled_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).jpeg_width as libc::c_long
-                * ((*compptr).h_samp_factor * (*compptr).DCT_h_scaled_size) as libc::c_long,
-            ((*cinfo).max_h_samp_factor * (*cinfo).block_size) as libc::c_long,
+            (*cinfo).jpeg_width as isize
+                * ((*compptr).h_samp_factor * (*compptr).DCT_h_scaled_size) as isize,
+            ((*cinfo).max_h_samp_factor * (*cinfo).block_size) as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*compptr).downsampled_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).jpeg_height as libc::c_long
-                * ((*compptr).v_samp_factor * (*compptr).DCT_v_scaled_size) as libc::c_long,
-            ((*cinfo).max_v_samp_factor * (*cinfo).block_size) as libc::c_long,
+            (*cinfo).jpeg_height as isize
+                * ((*compptr).v_samp_factor * (*compptr).DCT_v_scaled_size) as isize,
+            ((*cinfo).max_v_samp_factor * (*cinfo).block_size) as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         /* Mark component needed (this flag isn't actually used for compression) */
         (*compptr).component_needed = 1 as i32;
@@ -783,8 +783,8 @@ unsafe extern "C" fn initial_setup(
      * main controller will call coefficient controller).
      */
     (*cinfo).total_iMCU_rows = crate::src::jpeg_8c::jutils::jdiv_round_up(
-        (*cinfo).jpeg_height as libc::c_long,
-        ((*cinfo).max_v_samp_factor * (*cinfo).block_size) as libc::c_long,
+        (*cinfo).jpeg_height as isize,
+        ((*cinfo).max_v_samp_factor * (*cinfo).block_size) as isize,
     ) as crate::jmorecfg_h::JDIMENSION;
 }
 
@@ -1230,12 +1230,12 @@ unsafe extern "C" fn per_scan_setup(mut cinfo: crate::jpeglib_h::j_compress_ptr)
         }
         /* Overall image size in MCUs */
         (*cinfo).MCUs_per_row = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).jpeg_width as libc::c_long,
-            ((*cinfo).max_h_samp_factor * (*cinfo).block_size) as libc::c_long,
+            (*cinfo).jpeg_width as isize,
+            ((*cinfo).max_h_samp_factor * (*cinfo).block_size) as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).MCU_rows_in_scan = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).jpeg_height as libc::c_long,
-            ((*cinfo).max_v_samp_factor * (*cinfo).block_size) as libc::c_long,
+            (*cinfo).jpeg_height as isize,
+            ((*cinfo).max_v_samp_factor * (*cinfo).block_size) as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).blocks_in_MCU = 0 as i32;
         ci = 0 as i32;
@@ -1290,12 +1290,12 @@ unsafe extern "C" fn per_scan_setup(mut cinfo: crate::jpeglib_h::j_compress_ptr)
     /* Convert restart specified in rows to actual MCU count. */
     /* Note that count must fit in 16 bits, so we provide limiting. */
     if (*cinfo).restart_in_rows > 0 as i32 {
-        let mut nominal: libc::c_long =
-            (*cinfo).restart_in_rows as libc::c_long * (*cinfo).MCUs_per_row as libc::c_long;
-        (*cinfo).restart_interval = if nominal < 65535 as libc::c_long {
+        let mut nominal: isize =
+            (*cinfo).restart_in_rows as isize * (*cinfo).MCUs_per_row as isize;
+        (*cinfo).restart_interval = if nominal < 65535 as isize {
             nominal
         } else {
-            65535 as libc::c_long
+            65535 as isize
         } as u32
     };
 }

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jcparam.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jcparam.rs
@@ -223,7 +223,7 @@ pub unsafe extern "C" fn jpeg_add_quant_table(
     let mut qtblptr: *mut *mut crate::jpeglib_h::JQUANT_TBL =
         0 as *mut *mut crate::jpeglib_h::JQUANT_TBL;
     let mut i: i32 = 0;
-    let mut temp: libc::c_long = 0;
+    let mut temp: isize = 0;
     /* Safety check to ensure start_compress not called yet. */
     if (*cinfo).global_state != 100 as i32 {
         (*(*cinfo).err).msg_code = crate::src::jpeg_8c::jerror::JERR_BAD_STATE as i32;
@@ -256,18 +256,18 @@ pub unsafe extern "C" fn jpeg_add_quant_table(
     }
     i = 0 as i32;
     while i < 64 as i32 {
-        temp = (*basic_table.offset(i as isize) as libc::c_long * scale_factor as libc::c_long
-            + 50 as libc::c_long)
-            / 100 as libc::c_long;
+        temp = (*basic_table.offset(i as isize) as isize * scale_factor as isize
+            + 50 as isize)
+            / 100 as isize;
         /* limit the values to the valid range */
-        if temp <= 0 as libc::c_long {
-            temp = 1 as libc::c_long
+        if temp <= 0 as isize {
+            temp = 1 as isize
         } /* max quantizer needed for 12 bits */
-        if temp > 32767 as libc::c_long {
-            temp = 32767 as libc::c_long
+        if temp > 32767 as isize {
+            temp = 32767 as isize
         } /* limit to baseline range if requested */
-        if force_baseline != 0 && temp > 255 as libc::c_long {
-            temp = 255 as libc::c_long
+        if force_baseline != 0 && temp > 255 as isize {
+            temp = 255 as isize
         }
         (**qtblptr).quantval[i as usize] = temp as crate::jmorecfg_h::UINT16;
         i += 1

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jcprepct.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jcprepct.rs
@@ -522,10 +522,10 @@ unsafe extern "C" fn create_context_buffer(mut cinfo: crate::jpeglib_h::j_compre
         .expect("non-null function pointer")(
             cinfo as crate::jpeglib_h::j_common_ptr,
             1 as i32,
-            ((*compptr).width_in_blocks as libc::c_long
-                * (*cinfo).min_DCT_h_scaled_size as libc::c_long
-                * (*cinfo).max_h_samp_factor as libc::c_long
-                / (*compptr).h_samp_factor as libc::c_long)
+            ((*compptr).width_in_blocks as isize
+                * (*cinfo).min_DCT_h_scaled_size as isize
+                * (*cinfo).max_h_samp_factor as isize
+                / (*compptr).h_samp_factor as isize)
                 as crate::jmorecfg_h::JDIMENSION,
             (3 as i32 * rgroup_height) as crate::jmorecfg_h::JDIMENSION,
         );
@@ -652,10 +652,10 @@ pub unsafe extern "C" fn jinit_c_prep_controller(
             .expect("non-null function pointer")(
                 cinfo as crate::jpeglib_h::j_common_ptr,
                 1 as i32,
-                ((*compptr).width_in_blocks as libc::c_long
-                    * (*cinfo).min_DCT_h_scaled_size as libc::c_long
-                    * (*cinfo).max_h_samp_factor as libc::c_long
-                    / (*compptr).h_samp_factor as libc::c_long)
+                ((*compptr).width_in_blocks as isize
+                    * (*cinfo).min_DCT_h_scaled_size as isize
+                    * (*cinfo).max_h_samp_factor as isize
+                    / (*compptr).h_samp_factor as isize)
                     as crate::jmorecfg_h::JDIMENSION,
                 (*cinfo).max_v_samp_factor as crate::jmorecfg_h::JDIMENSION,
             );

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jcsample.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jcsample.rs
@@ -413,7 +413,7 @@ unsafe extern "C" fn int_downsample(
             }
             let fresh2 = outptr;
             outptr = outptr.offset(1);
-            *fresh2 = ((outvalue + numpix2 as libc::c_long) / numpix as libc::c_long)
+            *fresh2 = ((outvalue + numpix2 as isize) / numpix as isize)
                 as crate::jmorecfg_h::JSAMPLE;
             outcol = outcol.wrapping_add(1);
             outcol_h = (outcol_h as u32).wrapping_add(h_expand as u32)
@@ -646,12 +646,12 @@ unsafe extern "C" fn h2v2_smooth_downsample(
         neighsum += (*above_ptr as i32
             + *above_ptr.offset(2 as i32 as isize) as i32
             + *below_ptr as i32
-            + *below_ptr.offset(2 as i32 as isize) as i32) as libc::c_long;
+            + *below_ptr.offset(2 as i32 as isize) as i32) as isize;
         membersum = membersum * memberscale + neighsum * neighscale;
         let fresh5 = outptr;
         outptr = outptr.offset(1);
         *fresh5 =
-            (membersum + 32768 as i32 as libc::c_long >> 16 as i32) as crate::jmorecfg_h::JSAMPLE;
+            (membersum + 32768 as i32 as isize >> 16 as i32) as crate::jmorecfg_h::JSAMPLE;
         inptr0 = inptr0.offset(2 as i32 as isize);
         inptr1 = inptr1.offset(2 as i32 as isize);
         above_ptr = above_ptr.offset(2 as i32 as isize);
@@ -681,13 +681,13 @@ unsafe extern "C" fn h2v2_smooth_downsample(
                 + *above_ptr.offset(2 as i32 as isize) as i32
                 + *below_ptr.offset(-(1 as i32) as isize) as i32
                 + *below_ptr.offset(2 as i32 as isize) as i32)
-                as libc::c_long;
+                as isize;
             /* form final output scaled up by 2^16 */
             membersum = membersum * memberscale + neighsum * neighscale;
             /* round, descale and output it */
             let fresh6 = outptr;
             outptr = outptr.offset(1);
-            *fresh6 = (membersum + 32768 as i32 as libc::c_long >> 16 as i32)
+            *fresh6 = (membersum + 32768 as i32 as isize >> 16 as i32)
                 as crate::jmorecfg_h::JSAMPLE;
             inptr0 = inptr0.offset(2 as i32 as isize);
             inptr1 = inptr1.offset(2 as i32 as isize);
@@ -714,10 +714,10 @@ unsafe extern "C" fn h2v2_smooth_downsample(
         neighsum += (*above_ptr.offset(-(1 as i32) as isize) as i32
             + *above_ptr.offset(1 as i32 as isize) as i32
             + *below_ptr.offset(-(1 as i32) as isize) as i32
-            + *below_ptr.offset(1 as i32 as isize) as i32) as libc::c_long;
+            + *below_ptr.offset(1 as i32 as isize) as i32) as isize;
         membersum = membersum * memberscale + neighsum * neighscale;
         *outptr =
-            (membersum + 32768 as i32 as libc::c_long >> 16 as i32) as crate::jmorecfg_h::JSAMPLE;
+            (membersum + 32768 as i32 as isize >> 16 as i32) as crate::jmorecfg_h::JSAMPLE;
         inrow += 2 as i32;
         outrow += 1
     }
@@ -766,7 +766,7 @@ unsafe extern "C" fn fullsize_smooth_downsample(
      * Also recall that SF = smoothing_factor / 1024.
      */
     memberscale =
-        65536 as libc::c_long - (*cinfo).smoothing_factor as libc::c_long * 512 as libc::c_long; /* scaled 1-8*SF */
+        65536 as isize - (*cinfo).smoothing_factor as isize * 512 as isize; /* scaled 1-8*SF */
     neighscale = ((*cinfo).smoothing_factor * 64 as i32) as crate::jmorecfg_h::INT32; /* scaled SF */
     inrow = 0 as i32;
     while inrow < (*cinfo).max_v_samp_factor {
@@ -784,14 +784,14 @@ unsafe extern "C" fn fullsize_smooth_downsample(
         inptr = inptr.offset(1);
         membersum = *fresh9 as i32 as crate::jmorecfg_h::INT32;
         nextcolsum = *above_ptr as i32 + *below_ptr as i32 + *inptr as i32;
-        neighsum = colsum as libc::c_long
-            + (colsum as libc::c_long - membersum)
-            + nextcolsum as libc::c_long;
+        neighsum = colsum as isize
+            + (colsum as isize - membersum)
+            + nextcolsum as isize;
         membersum = membersum * memberscale + neighsum * neighscale;
         let fresh10 = outptr;
         outptr = outptr.offset(1);
         *fresh10 =
-            (membersum + 32768 as i32 as libc::c_long >> 16 as i32) as crate::jmorecfg_h::JSAMPLE;
+            (membersum + 32768 as i32 as isize >> 16 as i32) as crate::jmorecfg_h::JSAMPLE;
         lastcolsum = colsum;
         colsum = nextcolsum;
         colctr = output_cols.wrapping_sub(2 as i32 as u32);
@@ -802,13 +802,13 @@ unsafe extern "C" fn fullsize_smooth_downsample(
             above_ptr = above_ptr.offset(1);
             below_ptr = below_ptr.offset(1);
             nextcolsum = *above_ptr as i32 + *below_ptr as i32 + *inptr as i32;
-            neighsum = lastcolsum as libc::c_long
-                + (colsum as libc::c_long - membersum)
-                + nextcolsum as libc::c_long;
+            neighsum = lastcolsum as isize
+                + (colsum as isize - membersum)
+                + nextcolsum as isize;
             membersum = membersum * memberscale + neighsum * neighscale;
             let fresh12 = outptr;
             outptr = outptr.offset(1);
-            *fresh12 = (membersum + 32768 as i32 as libc::c_long >> 16 as i32)
+            *fresh12 = (membersum + 32768 as i32 as isize >> 16 as i32)
                 as crate::jmorecfg_h::JSAMPLE;
             lastcolsum = colsum;
             colsum = nextcolsum;
@@ -816,12 +816,12 @@ unsafe extern "C" fn fullsize_smooth_downsample(
         }
         /* Special case for last column */
         membersum = *inptr as i32 as crate::jmorecfg_h::INT32;
-        neighsum = lastcolsum as libc::c_long
-            + (colsum as libc::c_long - membersum)
-            + colsum as libc::c_long;
+        neighsum = lastcolsum as isize
+            + (colsum as isize - membersum)
+            + colsum as isize;
         membersum = membersum * memberscale + neighsum * neighscale;
         *outptr =
-            (membersum + 32768 as i32 as libc::c_long >> 16 as i32) as crate::jmorecfg_h::JSAMPLE;
+            (membersum + 32768 as i32 as isize >> 16 as i32) as crate::jmorecfg_h::JSAMPLE;
         inrow += 1
     }
 }

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdapistd.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdapistd.rs
@@ -282,7 +282,7 @@ pub unsafe extern "C" fn jpeg_start_decompress(
                     (*(*cinfo).progress).pass_counter += 1;
                     if (*(*cinfo).progress).pass_counter >= (*(*cinfo).progress).pass_limit {
                         /* jdmaster underestimated number of scans; ratchet up one scan */
-                        (*(*cinfo).progress).pass_limit += (*cinfo).total_iMCU_rows as libc::c_long
+                        (*(*cinfo).progress).pass_limit += (*cinfo).total_iMCU_rows as isize
                     }
                 }
             }
@@ -347,8 +347,8 @@ unsafe extern "C" fn output_pass_setup(
             let mut last_scanline: crate::jmorecfg_h::JDIMENSION = 0;
             /* No progress made, must suspend */
             if !(*cinfo).progress.is_null() {
-                (*(*cinfo).progress).pass_counter = (*cinfo).output_scanline as libc::c_long;
-                (*(*cinfo).progress).pass_limit = (*cinfo).output_height as libc::c_long;
+                (*(*cinfo).progress).pass_counter = (*cinfo).output_scanline as isize;
+                (*(*cinfo).progress).pass_limit = (*cinfo).output_height as isize;
                 Some(
                     (*(*cinfo).progress)
                         .progress_monitor
@@ -446,8 +446,8 @@ pub unsafe extern "C" fn jpeg_read_scanlines(
     }
     /* Call progress monitor hook if present */
     if !(*cinfo).progress.is_null() {
-        (*(*cinfo).progress).pass_counter = (*cinfo).output_scanline as libc::c_long;
-        (*(*cinfo).progress).pass_limit = (*cinfo).output_height as libc::c_long;
+        (*(*cinfo).progress).pass_counter = (*cinfo).output_scanline as isize;
+        (*(*cinfo).progress).pass_limit = (*cinfo).output_height as isize;
         Some(
             (*(*cinfo).progress)
                 .progress_monitor
@@ -505,8 +505,8 @@ pub unsafe extern "C" fn jpeg_read_raw_data(
     }
     /* Call progress monitor hook if present */
     if !(*cinfo).progress.is_null() {
-        (*(*cinfo).progress).pass_counter = (*cinfo).output_scanline as libc::c_long;
-        (*(*cinfo).progress).pass_limit = (*cinfo).output_height as libc::c_long;
+        (*(*cinfo).progress).pass_counter = (*cinfo).output_scanline as isize;
+        (*(*cinfo).progress).pass_limit = (*cinfo).output_height as isize;
         Some(
             (*(*cinfo).progress)
                 .progress_monitor

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdarith.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdarith.rs
@@ -279,7 +279,7 @@ unsafe extern "C" fn arith_decode(
     let mut sv: i32 = 0;
     let mut data: i32 = 0;
     /* Renormalization & data input per section D.2.6 */
-    while (*e).a < 0x8000 as libc::c_long {
+    while (*e).a < 0x8000 as isize {
         (*e).ct -= 1;
         if (*e).ct < 0 as i32 {
             /* Need to fetch next data byte */
@@ -312,7 +312,7 @@ unsafe extern "C" fn arith_decode(
                 }
             }
             /* => e->a = 0x10000L after loop exit */
-            (*e).c = (*e).c << 8 as i32 | data as libc::c_long; /* insert data into C register */
+            (*e).c = (*e).c << 8 as i32 | data as isize; /* insert data into C register */
             (*e).ct += 8 as i32;
             if (*e).ct < 0 as i32 {
                 /* update bit shift counter */
@@ -320,7 +320,7 @@ unsafe extern "C" fn arith_decode(
                 (*e).ct += 1;
                 if (*e).ct == 0 as i32 {
                     /* Got 2 initial bytes -> re-init A and exit loop */
-                    (*e).a = 0x8000 as libc::c_long
+                    (*e).a = 0x8000 as isize
                 }
             }
         }
@@ -333,9 +333,9 @@ unsafe extern "C" fn arith_decode(
     qe = *crate::src::jpeg_8c::jaricom::jpeg_aritab
         .as_ptr()
         .offset((sv & 0x7f as i32) as isize); /* Next_Index_LPS + Switch_MPS */
-    nl = (qe & 0xff as i32 as libc::c_long) as u8; /* Next_Index_MPS */
+    nl = (qe & 0xff as i32 as isize) as u8; /* Next_Index_MPS */
     qe >>= 8 as i32;
-    nm = (qe & 0xff as i32 as libc::c_long) as u8;
+    nm = (qe & 0xff as i32 as isize) as u8;
     qe >>= 8 as i32;
     /* Decode & estimation procedures per sections D.2.4 & D.2.5 */
     temp = (*e).a - qe;
@@ -354,7 +354,7 @@ unsafe extern "C" fn arith_decode(
             *st = (sv & 0x80 as i32 ^ nl as i32) as u8; /* Estimate_after_LPS */
             sv ^= 0x80 as i32
         }
-    } else if (*e).a < 0x8000 as libc::c_long {
+    } else if (*e).a < 0x8000 as isize {
         /* Conditional MPS (more probable symbol) exchange */
         if (*e).a < qe {
             *st = (sv & 0x80 as i32 ^ nl as i32) as u8;
@@ -506,13 +506,13 @@ unsafe extern "C" fn decode_mcu_DC_first(
                 }
             }
             /* Section F.1.4.4.1.2: Establish dc_context conditioning category */
-            if m < ((1 as libc::c_long) << (*cinfo).arith_dc_L[tbl as usize] as i32 >> 1 as i32)
+            if m < ((1 as isize) << (*cinfo).arith_dc_L[tbl as usize] as i32 >> 1 as i32)
                 as i32
             {
                 /* small diff category */
                 (*entropy).dc_context[ci as usize] = 0 as i32
             } else if m
-                > ((1 as libc::c_long) << (*cinfo).arith_dc_U[tbl as usize] as i32 >> 1 as i32)
+                > ((1 as isize) << (*cinfo).arith_dc_U[tbl as usize] as i32 >> 1 as i32)
                     as i32
             {
                 /* zero diff category */
@@ -869,13 +869,13 @@ unsafe extern "C" fn decode_mcu(
                 }
             }
             /* Section F.1.4.4.1.2: Establish dc_context conditioning category */
-            if m < ((1 as libc::c_long) << (*cinfo).arith_dc_L[tbl as usize] as i32 >> 1 as i32)
+            if m < ((1 as isize) << (*cinfo).arith_dc_L[tbl as usize] as i32 >> 1 as i32)
                 as i32
             {
                 /* small diff category */
                 (*entropy).dc_context[ci as usize] = 0 as i32
             } else if m
-                > ((1 as libc::c_long) << (*cinfo).arith_dc_U[tbl as usize] as i32 >> 1 as i32)
+                > ((1 as isize) << (*cinfo).arith_dc_U[tbl as usize] as i32 >> 1 as i32)
                     as i32
             {
                 /* zero diff category */

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdatasrc.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdatasrc.rs
@@ -339,16 +339,16 @@ unsafe extern "C" fn fill_mem_input_buffer(
 
 unsafe extern "C" fn skip_input_data(
     mut cinfo: crate::jpeglib_h::j_decompress_ptr,
-    mut num_bytes: libc::c_long,
+    mut num_bytes: isize,
 ) {
     let mut src: *mut crate::jpeglib_h::jpeg_source_mgr = (*cinfo).src;
     /* Just a dumb implementation for now.  Could use fseek() except
      * it doesn't work on pipes.  Not clear that being smart is worth
      * any trouble anyway --- large skips are infrequent.
      */
-    if num_bytes > 0 as i32 as libc::c_long {
-        while num_bytes > (*src).bytes_in_buffer as libc::c_long {
-            num_bytes -= (*src).bytes_in_buffer as libc::c_long;
+    if num_bytes > 0 as i32 as isize {
+        while num_bytes > (*src).bytes_in_buffer as isize {
+            num_bytes -= (*src).bytes_in_buffer as isize;
             Some((*src).fill_input_buffer.expect("non-null function pointer"))
                 .expect("non-null function pointer")(cinfo);
             /* note we assume that fill_input_buffer will never return FALSE,
@@ -437,7 +437,7 @@ pub unsafe extern "C" fn jpeg_stdio_src(
     );
     (*src).pub_0.skip_input_data = Some(
         skip_input_data
-            as unsafe extern "C" fn(_: crate::jpeglib_h::j_decompress_ptr, _: libc::c_long) -> (),
+            as unsafe extern "C" fn(_: crate::jpeglib_h::j_decompress_ptr, _: isize) -> (),
     );
     (*src).pub_0.resync_to_restart = Some(
         crate::src::jpeg_8c::jdmarker::jpeg_resync_to_restart
@@ -504,7 +504,7 @@ pub unsafe extern "C" fn jpeg_mem_src(
     );
     (*src).skip_input_data = Some(
         skip_input_data
-            as unsafe extern "C" fn(_: crate::jpeglib_h::j_decompress_ptr, _: libc::c_long) -> (),
+            as unsafe extern "C" fn(_: crate::jpeglib_h::j_decompress_ptr, _: isize) -> (),
     );
     (*src).resync_to_restart = Some(
         crate::src::jpeg_8c::jdmarker::jpeg_resync_to_restart

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdcoefct.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdcoefct.rs
@@ -783,8 +783,8 @@ unsafe extern "C" fn decompress_smooth_data(
                     /* AC01 */
                     Al = *coef_bits.offset(1 as i32 as isize);
                     if Al != 0 as i32 && workspace[1 as i32 as usize] as i32 == 0 as i32 {
-                        num = 36 as i32 as libc::c_long * Q00 * (DC4 - DC6) as libc::c_long;
-                        if num >= 0 as i32 as libc::c_long {
+                        num = 36 as i32 as isize * Q00 * (DC4 - DC6) as isize;
+                        if num >= 0 as i32 as isize {
                             pred = (((Q01 << 7 as i32) + num) / (Q01 << 8 as i32)) as i32;
                             if Al > 0 as i32 && pred >= (1 as i32) << Al {
                                 pred = ((1 as i32) << Al) - 1 as i32
@@ -801,8 +801,8 @@ unsafe extern "C" fn decompress_smooth_data(
                     /* AC10 */
                     Al = *coef_bits.offset(2 as i32 as isize);
                     if Al != 0 as i32 && workspace[8 as i32 as usize] as i32 == 0 as i32 {
-                        num = 36 as i32 as libc::c_long * Q00 * (DC2 - DC8) as libc::c_long;
-                        if num >= 0 as i32 as libc::c_long {
+                        num = 36 as i32 as isize * Q00 * (DC2 - DC8) as isize;
+                        if num >= 0 as i32 as isize {
                             pred = (((Q10 << 7 as i32) + num) / (Q10 << 8 as i32)) as i32;
                             if Al > 0 as i32 && pred >= (1 as i32) << Al {
                                 pred = ((1 as i32) << Al) - 1 as i32
@@ -819,10 +819,10 @@ unsafe extern "C" fn decompress_smooth_data(
                     /* AC20 */
                     Al = *coef_bits.offset(3 as i32 as isize);
                     if Al != 0 as i32 && workspace[16 as i32 as usize] as i32 == 0 as i32 {
-                        num = 9 as i32 as libc::c_long
+                        num = 9 as i32 as isize
                             * Q00
-                            * (DC2 + DC8 - 2 as i32 * DC5) as libc::c_long;
-                        if num >= 0 as i32 as libc::c_long {
+                            * (DC2 + DC8 - 2 as i32 * DC5) as isize;
+                        if num >= 0 as i32 as isize {
                             pred = (((Q20 << 7 as i32) + num) / (Q20 << 8 as i32)) as i32;
                             if Al > 0 as i32 && pred >= (1 as i32) << Al {
                                 pred = ((1 as i32) << Al) - 1 as i32
@@ -839,10 +839,10 @@ unsafe extern "C" fn decompress_smooth_data(
                     /* AC11 */
                     Al = *coef_bits.offset(4 as i32 as isize);
                     if Al != 0 as i32 && workspace[9 as i32 as usize] as i32 == 0 as i32 {
-                        num = 5 as i32 as libc::c_long
+                        num = 5 as i32 as isize
                             * Q00
-                            * (DC1 - DC3 - DC7 + DC9) as libc::c_long;
-                        if num >= 0 as i32 as libc::c_long {
+                            * (DC1 - DC3 - DC7 + DC9) as isize;
+                        if num >= 0 as i32 as isize {
                             pred = (((Q11 << 7 as i32) + num) / (Q11 << 8 as i32)) as i32;
                             if Al > 0 as i32 && pred >= (1 as i32) << Al {
                                 pred = ((1 as i32) << Al) - 1 as i32
@@ -859,10 +859,10 @@ unsafe extern "C" fn decompress_smooth_data(
                     /* AC02 */
                     Al = *coef_bits.offset(5 as i32 as isize);
                     if Al != 0 as i32 && workspace[2 as i32 as usize] as i32 == 0 as i32 {
-                        num = 9 as i32 as libc::c_long
+                        num = 9 as i32 as isize
                             * Q00
-                            * (DC4 + DC6 - 2 as i32 * DC5) as libc::c_long;
-                        if num >= 0 as i32 as libc::c_long {
+                            * (DC4 + DC6 - 2 as i32 * DC5) as isize;
+                        if num >= 0 as i32 as isize {
                             pred = (((Q02 << 7 as i32) + num) / (Q02 << 8 as i32)) as i32;
                             if Al > 0 as i32 && pred >= (1 as i32) << Al {
                                 pred = ((1 as i32) << Al) - 1 as i32
@@ -969,12 +969,12 @@ pub unsafe extern "C" fn jinit_d_coef_controller(
                 1 as i32,
                 1 as i32,
                 crate::src::jpeg_8c::jutils::jround_up(
-                    (*compptr).width_in_blocks as libc::c_long,
-                    (*compptr).h_samp_factor as libc::c_long,
+                    (*compptr).width_in_blocks as isize,
+                    (*compptr).h_samp_factor as isize,
                 ) as crate::jmorecfg_h::JDIMENSION,
                 crate::src::jpeg_8c::jutils::jround_up(
-                    (*compptr).height_in_blocks as libc::c_long,
-                    (*compptr).v_samp_factor as libc::c_long,
+                    (*compptr).height_in_blocks as isize,
+                    (*compptr).v_samp_factor as isize,
                 ) as crate::jmorecfg_h::JDIMENSION,
                 access_rows as crate::jmorecfg_h::JDIMENSION,
             );

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdcolor.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdcolor.rs
@@ -284,27 +284,27 @@ unsafe extern "C" fn build_ycc_rgb_table(mut cinfo: crate::jpeglib_h::j_decompre
         /* The Cb or Cr value we are thinking of is x = i - CENTERJSAMPLE */
         /* Cr=>R value is nearest int to 1.40200 * x */
         *(*cconvert).Cr_r_tab.offset(i as isize) =
-            ((1.40200f64 * ((1 as libc::c_long) << 16 as i32) as f64 + 0.5f64)
+            ((1.40200f64 * ((1 as isize) << 16 as i32) as f64 + 0.5f64)
                 as crate::jmorecfg_h::INT32
                 * x
                 + ((1 as i32 as crate::jmorecfg_h::INT32) << 16 as i32 - 1 as i32)
                 >> 16 as i32) as i32;
         /* Cb=>B value is nearest int to 1.77200 * x */
         *(*cconvert).Cb_b_tab.offset(i as isize) =
-            ((1.77200f64 * ((1 as libc::c_long) << 16 as i32) as f64 + 0.5f64)
+            ((1.77200f64 * ((1 as isize) << 16 as i32) as f64 + 0.5f64)
                 as crate::jmorecfg_h::INT32
                 * x
                 + ((1 as i32 as crate::jmorecfg_h::INT32) << 16 as i32 - 1 as i32)
                 >> 16 as i32) as i32;
         /* Cr=>G value is scaled-up -0.71414 * x */
         *(*cconvert).Cr_g_tab.offset(i as isize) =
-            -((0.71414f64 * ((1 as libc::c_long) << 16 as i32) as f64 + 0.5f64)
+            -((0.71414f64 * ((1 as isize) << 16 as i32) as f64 + 0.5f64)
                 as crate::jmorecfg_h::INT32)
                 * x;
         /* Cb=>G value is scaled-up -0.34414 * x */
         /* We also add in ONE_HALF so that need not do it in inner loop */
         *(*cconvert).Cb_g_tab.offset(i as isize) =
-            -((0.34414f64 * ((1 as libc::c_long) << 16 as i32) as f64 + 0.5f64)
+            -((0.34414f64 * ((1 as isize) << 16 as i32) as f64 + 0.5f64)
                 as crate::jmorecfg_h::INT32)
                 * x
                 + ((1 as i32 as crate::jmorecfg_h::INT32) << 16 as i32 - 1 as i32);

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdhuff.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdhuff.rs
@@ -510,7 +510,7 @@ unsafe extern "C" fn jpeg_make_d_derived_tbl(
         } /* ensures jpeg_huff_decode terminates */
         l += 1
     }
-    (*dtbl).maxcode[17 as i32 as usize] = 0xfffff as libc::c_long;
+    (*dtbl).maxcode[17 as i32 as usize] = 0xfffff as isize;
     /* Compute lookahead tables to speed up decoding.
      * First we set all the table entries to 0, indicating "too long";
      * then we iterate through the Huffman codes that are short enough and
@@ -659,7 +659,7 @@ unsafe extern "C" fn jpeg_fill_bit_buffer(
                 }
             }
             /* OK, load c into get_buffer */
-            get_buffer = get_buffer << 8 as i32 | c as libc::c_long;
+            get_buffer = get_buffer << 8 as i32 | c as isize;
             bits_left += 8 as i32
         }
     } else {
@@ -766,7 +766,7 @@ unsafe extern "C" fn jpeg_huff_decode(
             bits_left = (*state).bits_left
         }
         bits_left -= 1 as i32;
-        code |= ((get_buffer >> bits_left) as i32 & bmask[1 as i32 as usize]) as libc::c_long;
+        code |= ((get_buffer >> bits_left) as i32 & bmask[1 as i32 as usize]) as isize;
         l += 1
     }
     /* Unload the local registers */

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdinput.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdinput.rs
@@ -237,12 +237,12 @@ pub unsafe extern "C" fn jpeg_core_output_dimensions(
     if (*cinfo).scale_num.wrapping_mul((*cinfo).block_size as u32) <= (*cinfo).scale_denom {
         /* Provide 1/block_size scaling */
         (*cinfo).output_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_width as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).output_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_height as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 1 as i32;
         (*cinfo).min_DCT_v_scaled_size = 1 as i32
@@ -251,12 +251,12 @@ pub unsafe extern "C" fn jpeg_core_output_dimensions(
     {
         /* Provide 2/block_size scaling */
         (*cinfo).output_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * 2 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_width as isize * 2 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).output_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * 2 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_height as isize * 2 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 2 as i32;
         (*cinfo).min_DCT_v_scaled_size = 2 as i32
@@ -265,12 +265,12 @@ pub unsafe extern "C" fn jpeg_core_output_dimensions(
     {
         /* Provide 3/block_size scaling */
         (*cinfo).output_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * 3 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_width as isize * 3 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).output_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * 3 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_height as isize * 3 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 3 as i32;
         (*cinfo).min_DCT_v_scaled_size = 3 as i32
@@ -279,12 +279,12 @@ pub unsafe extern "C" fn jpeg_core_output_dimensions(
     {
         /* Provide 4/block_size scaling */
         (*cinfo).output_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * 4 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_width as isize * 4 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).output_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * 4 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_height as isize * 4 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 4 as i32;
         (*cinfo).min_DCT_v_scaled_size = 4 as i32
@@ -293,12 +293,12 @@ pub unsafe extern "C" fn jpeg_core_output_dimensions(
     {
         /* Provide 5/block_size scaling */
         (*cinfo).output_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * 5 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_width as isize * 5 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).output_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * 5 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_height as isize * 5 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 5 as i32;
         (*cinfo).min_DCT_v_scaled_size = 5 as i32
@@ -307,12 +307,12 @@ pub unsafe extern "C" fn jpeg_core_output_dimensions(
     {
         /* Provide 6/block_size scaling */
         (*cinfo).output_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * 6 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_width as isize * 6 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).output_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * 6 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_height as isize * 6 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 6 as i32;
         (*cinfo).min_DCT_v_scaled_size = 6 as i32
@@ -321,12 +321,12 @@ pub unsafe extern "C" fn jpeg_core_output_dimensions(
     {
         /* Provide 7/block_size scaling */
         (*cinfo).output_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * 7 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_width as isize * 7 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).output_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * 7 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_height as isize * 7 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 7 as i32;
         (*cinfo).min_DCT_v_scaled_size = 7 as i32
@@ -335,12 +335,12 @@ pub unsafe extern "C" fn jpeg_core_output_dimensions(
     {
         /* Provide 8/block_size scaling */
         (*cinfo).output_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * 8 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_width as isize * 8 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).output_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * 8 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_height as isize * 8 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 8 as i32;
         (*cinfo).min_DCT_v_scaled_size = 8 as i32
@@ -349,12 +349,12 @@ pub unsafe extern "C" fn jpeg_core_output_dimensions(
     {
         /* Provide 9/block_size scaling */
         (*cinfo).output_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * 9 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_width as isize * 9 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).output_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * 9 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_height as isize * 9 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 9 as i32;
         (*cinfo).min_DCT_v_scaled_size = 9 as i32
@@ -363,12 +363,12 @@ pub unsafe extern "C" fn jpeg_core_output_dimensions(
     {
         /* Provide 10/block_size scaling */
         (*cinfo).output_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * 10 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_width as isize * 10 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).output_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * 10 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_height as isize * 10 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 10 as i32;
         (*cinfo).min_DCT_v_scaled_size = 10 as i32
@@ -377,12 +377,12 @@ pub unsafe extern "C" fn jpeg_core_output_dimensions(
     {
         /* Provide 11/block_size scaling */
         (*cinfo).output_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * 11 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_width as isize * 11 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).output_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * 11 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_height as isize * 11 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 11 as i32;
         (*cinfo).min_DCT_v_scaled_size = 11 as i32
@@ -391,12 +391,12 @@ pub unsafe extern "C" fn jpeg_core_output_dimensions(
     {
         /* Provide 12/block_size scaling */
         (*cinfo).output_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * 12 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_width as isize * 12 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).output_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * 12 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_height as isize * 12 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 12 as i32;
         (*cinfo).min_DCT_v_scaled_size = 12 as i32
@@ -405,12 +405,12 @@ pub unsafe extern "C" fn jpeg_core_output_dimensions(
     {
         /* Provide 13/block_size scaling */
         (*cinfo).output_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * 13 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_width as isize * 13 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).output_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * 13 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_height as isize * 13 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 13 as i32;
         (*cinfo).min_DCT_v_scaled_size = 13 as i32
@@ -419,12 +419,12 @@ pub unsafe extern "C" fn jpeg_core_output_dimensions(
     {
         /* Provide 14/block_size scaling */
         (*cinfo).output_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * 14 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_width as isize * 14 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).output_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * 14 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_height as isize * 14 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 14 as i32;
         (*cinfo).min_DCT_v_scaled_size = 14 as i32
@@ -433,24 +433,24 @@ pub unsafe extern "C" fn jpeg_core_output_dimensions(
     {
         /* Provide 15/block_size scaling */
         (*cinfo).output_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * 15 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_width as isize * 15 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).output_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * 15 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_height as isize * 15 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 15 as i32;
         (*cinfo).min_DCT_v_scaled_size = 15 as i32
     } else {
         /* Provide 16/block_size scaling */
         (*cinfo).output_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * 16 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_width as isize * 16 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).output_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * 16 as libc::c_long,
-            (*cinfo).block_size as libc::c_long,
+            (*cinfo).image_height as isize * 16 as isize,
+            (*cinfo).block_size as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).min_DCT_h_scaled_size = 16 as i32;
         (*cinfo).min_DCT_v_scaled_size = 16 as i32
@@ -475,11 +475,11 @@ unsafe extern "C" fn initial_setup(mut cinfo: crate::jpeglib_h::j_decompress_ptr
     let mut compptr: *mut crate::jpeglib_h::jpeg_component_info =
         0 as *mut crate::jpeglib_h::jpeg_component_info;
     /* Make sure image isn't bigger than I can handle */
-    if (*cinfo).image_height as libc::c_long > 65500 as libc::c_long
-        || (*cinfo).image_width as libc::c_long > 65500 as libc::c_long
+    if (*cinfo).image_height as isize > 65500 as isize
+        || (*cinfo).image_width as isize > 65500 as isize
     {
         (*(*cinfo).err).msg_code = crate::src::jpeg_8c::jerror::JERR_IMAGE_TOO_BIG as i32;
-        (*(*cinfo).err).msg_parm.i[0 as i32 as usize] = 65500 as libc::c_long as u32 as i32;
+        (*(*cinfo).err).msg_parm.i[0 as i32 as usize] = 65500 as isize as u32 as i32;
         Some(
             (*(*cinfo).err)
                 .error_exit
@@ -665,12 +665,12 @@ unsafe extern "C" fn initial_setup(mut cinfo: crate::jpeglib_h::j_decompress_ptr
         (*compptr).DCT_v_scaled_size = (*cinfo).block_size;
         /* Size in DCT blocks */
         (*compptr).width_in_blocks = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * (*compptr).h_samp_factor as libc::c_long,
-            ((*cinfo).max_h_samp_factor * (*cinfo).block_size) as libc::c_long,
+            (*cinfo).image_width as isize * (*compptr).h_samp_factor as isize,
+            ((*cinfo).max_h_samp_factor * (*cinfo).block_size) as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*compptr).height_in_blocks = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * (*compptr).v_samp_factor as libc::c_long,
-            ((*cinfo).max_v_samp_factor * (*cinfo).block_size) as libc::c_long,
+            (*cinfo).image_height as isize * (*compptr).v_samp_factor as isize,
+            ((*cinfo).max_v_samp_factor * (*cinfo).block_size) as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         /* downsampled_width and downsampled_height will also be overridden by
          * jdmaster.c if we are doing full decompression.  The transcoder library
@@ -678,12 +678,12 @@ unsafe extern "C" fn initial_setup(mut cinfo: crate::jpeglib_h::j_decompress_ptr
          */
         /* Size in samples */
         (*compptr).downsampled_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long * (*compptr).h_samp_factor as libc::c_long,
-            (*cinfo).max_h_samp_factor as libc::c_long,
+            (*cinfo).image_width as isize * (*compptr).h_samp_factor as isize,
+            (*cinfo).max_h_samp_factor as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*compptr).downsampled_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long * (*compptr).v_samp_factor as libc::c_long,
-            (*cinfo).max_v_samp_factor as libc::c_long,
+            (*cinfo).image_height as isize * (*compptr).v_samp_factor as isize,
+            (*cinfo).max_v_samp_factor as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         /* Mark component needed, until color conversion says otherwise */
         (*compptr).component_needed = 1 as i32;
@@ -694,8 +694,8 @@ unsafe extern "C" fn initial_setup(mut cinfo: crate::jpeglib_h::j_decompress_ptr
     }
     /* Compute number of fully interleaved MCU rows. */
     (*cinfo).total_iMCU_rows = crate::src::jpeg_8c::jutils::jdiv_round_up(
-        (*cinfo).image_height as libc::c_long,
-        ((*cinfo).max_v_samp_factor * (*cinfo).block_size) as libc::c_long,
+        (*cinfo).image_height as isize,
+        ((*cinfo).max_v_samp_factor * (*cinfo).block_size) as isize,
     ) as crate::jmorecfg_h::JDIMENSION;
     /* Decide whether file contains multiple scans */
     if (*cinfo).comps_in_scan < (*cinfo).num_components || (*cinfo).progressive_mode != 0 {
@@ -756,12 +756,12 @@ unsafe extern "C" fn per_scan_setup(mut cinfo: crate::jpeglib_h::j_decompress_pt
         }
         /* Overall image size in MCUs */
         (*cinfo).MCUs_per_row = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long,
-            ((*cinfo).max_h_samp_factor * (*cinfo).block_size) as libc::c_long,
+            (*cinfo).image_width as isize,
+            ((*cinfo).max_h_samp_factor * (*cinfo).block_size) as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).MCU_rows_in_scan = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long,
-            ((*cinfo).max_v_samp_factor * (*cinfo).block_size) as libc::c_long,
+            (*cinfo).image_height as isize,
+            ((*cinfo).max_v_samp_factor * (*cinfo).block_size) as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*cinfo).blocks_in_MCU = 0 as i32;
         ci = 0 as i32;

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdmarker.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdmarker.rs
@@ -476,7 +476,7 @@ unsafe extern "C" fn get_sof(
     bytes_in_buffer = bytes_in_buffer.wrapping_sub(1);
     let fresh1 = next_input_byte;
     next_input_byte = next_input_byte.offset(1);
-    length += *fresh1 as libc::c_long;
+    length += *fresh1 as isize;
     if bytes_in_buffer == 0 as i32 as libc::c_ulong {
         if Some(
             (*datasrc)
@@ -589,7 +589,7 @@ unsafe extern "C" fn get_sof(
     let fresh7 = next_input_byte;
     next_input_byte = next_input_byte.offset(1);
     (*cinfo).num_components = *fresh7 as i32;
-    length -= 8 as i32 as libc::c_long;
+    length -= 8 as i32 as isize;
     let mut _mp: *mut i32 = (*(*cinfo).err).msg_parm.i.as_mut_ptr();
     *_mp.offset(0 as i32 as isize) = (*cinfo).unread_marker;
     *_mp.offset(1 as i32 as isize) = (*cinfo).image_width as i32;
@@ -626,7 +626,7 @@ unsafe extern "C" fn get_sof(
         )
         .expect("non-null function pointer")(cinfo as crate::jpeglib_h::j_common_ptr);
     }
-    if length != ((*cinfo).num_components * 3 as i32) as libc::c_long {
+    if length != ((*cinfo).num_components * 3 as i32) as isize {
         (*(*cinfo).err).msg_code = crate::src::jpeg_8c::jerror::JERR_BAD_LENGTH as i32;
         Some(
             (*(*cinfo).err)
@@ -793,7 +793,7 @@ unsafe extern "C" fn get_sos(
     bytes_in_buffer = bytes_in_buffer.wrapping_sub(1);
     let fresh12 = next_input_byte;
     next_input_byte = next_input_byte.offset(1);
-    length += *fresh12 as libc::c_long;
+    length += *fresh12 as isize;
     if bytes_in_buffer == 0 as i32 as libc::c_ulong {
         if Some(
             (*datasrc)
@@ -820,7 +820,7 @@ unsafe extern "C" fn get_sos(
             .expect("non-null function pointer"),
     )
     .expect("non-null function pointer")(cinfo as crate::jpeglib_h::j_common_ptr, 1 as i32);
-    if length != (n * 2 as i32 + 6 as i32) as libc::c_long
+    if length != (n * 2 as i32 + 6 as i32) as isize
         || n > 4 as i32
         || n == 0 as i32 && (*cinfo).progressive_mode == 0
     {
@@ -1049,9 +1049,9 @@ unsafe extern "C" fn get_dac(
     bytes_in_buffer = bytes_in_buffer.wrapping_sub(1);
     let fresh20 = next_input_byte;
     next_input_byte = next_input_byte.offset(1);
-    length += *fresh20 as libc::c_long;
-    length -= 2 as i32 as libc::c_long;
-    while length > 0 as i32 as libc::c_long {
+    length += *fresh20 as isize;
+    length -= 2 as i32 as isize;
+    while length > 0 as i32 as isize {
         if bytes_in_buffer == 0 as i32 as libc::c_ulong {
             if Some(
                 (*datasrc)
@@ -1088,7 +1088,7 @@ unsafe extern "C" fn get_dac(
         let fresh22 = next_input_byte;
         next_input_byte = next_input_byte.offset(1);
         val = *fresh22 as i32;
-        length -= 2 as i32 as libc::c_long;
+        length -= 2 as i32 as isize;
         (*(*cinfo).err).msg_code = crate::src::jpeg_8c::jerror::JTRC_DAC as i32;
         (*(*cinfo).err).msg_parm.i[0 as i32 as usize] = index;
         (*(*cinfo).err).msg_parm.i[1 as i32 as usize] = val;
@@ -1134,7 +1134,7 @@ unsafe extern "C" fn get_dac(
             }
         }
     }
-    if length != 0 as i32 as libc::c_long {
+    if length != 0 as i32 as isize {
         (*(*cinfo).err).msg_code = crate::src::jpeg_8c::jerror::JERR_BAD_LENGTH as i32;
         Some(
             (*(*cinfo).err)
@@ -1200,9 +1200,9 @@ unsafe extern "C" fn get_dht(
     bytes_in_buffer = bytes_in_buffer.wrapping_sub(1);
     let fresh24 = next_input_byte;
     next_input_byte = next_input_byte.offset(1);
-    length += *fresh24 as libc::c_long;
-    length -= 2 as i32 as libc::c_long;
-    while length > 16 as i32 as libc::c_long {
+    length += *fresh24 as isize;
+    length -= 2 as i32 as isize;
+    while length > 16 as i32 as isize {
         if bytes_in_buffer == 0 as i32 as libc::c_ulong {
             if Some(
                 (*datasrc)
@@ -1256,7 +1256,7 @@ unsafe extern "C" fn get_dht(
             count += bits[i as usize] as i32;
             i += 1
         }
-        length -= (1 as i32 + 16 as i32) as libc::c_long;
+        length -= (1 as i32 + 16 as i32) as isize;
         let mut _mp: *mut i32 = (*(*cinfo).err).msg_parm.i.as_mut_ptr();
         *_mp.offset(0 as i32 as isize) = bits[1 as i32 as usize] as i32;
         *_mp.offset(1 as i32 as isize) = bits[2 as i32 as usize] as i32;
@@ -1329,7 +1329,7 @@ unsafe extern "C" fn get_dht(
             huffval[i as usize] = *fresh27;
             i += 1
         }
-        length -= count as libc::c_long;
+        length -= count as isize;
         if index & 0x10 as i32 != 0 {
             /* AC table definition */
             index -= 0x10 as i32;
@@ -1374,7 +1374,7 @@ unsafe extern "C" fn get_dht(
             ::std::mem::size_of::<[crate::jmorecfg_h::UINT8; 256]>() as libc::c_ulong,
         );
     }
-    if length != 0 as i32 as libc::c_long {
+    if length != 0 as i32 as isize {
         (*(*cinfo).err).msg_code = crate::src::jpeg_8c::jerror::JERR_BAD_LENGTH as i32;
         Some(
             (*(*cinfo).err)
@@ -1438,9 +1438,9 @@ unsafe extern "C" fn get_dqt(
     bytes_in_buffer = bytes_in_buffer.wrapping_sub(1);
     let fresh29 = next_input_byte;
     next_input_byte = next_input_byte.offset(1);
-    length += *fresh29 as libc::c_long;
-    length -= 2 as i32 as libc::c_long;
-    while length > 0 as i32 as libc::c_long {
+    length += *fresh29 as isize;
+    length -= 2 as i32 as isize;
+    while length > 0 as i32 as isize {
         length -= 1;
         if bytes_in_buffer == 0 as i32 as libc::c_ulong {
             if Some(
@@ -1494,10 +1494,10 @@ unsafe extern "C" fn get_dqt(
         }
         quant_ptr = (*cinfo).quant_tbl_ptrs[n as usize];
         if prec != 0 {
-            if length < (64 as i32 * 2 as i32) as libc::c_long {
+            if length < (64 as i32 * 2 as i32) as isize {
                 /* Initialize full table for safety. */
                 i = 0 as i32 as crate::jmorecfg_h::INT32;
-                while i < 64 as i32 as libc::c_long {
+                while i < 64 as i32 as isize {
                     (*quant_ptr).quantval[i as usize] = 1 as i32 as crate::jmorecfg_h::UINT16;
                     i += 1
                 }
@@ -1505,10 +1505,10 @@ unsafe extern "C" fn get_dqt(
             } else {
                 count = 64 as i32 as crate::jmorecfg_h::INT32
             }
-        } else if length < 64 as i32 as libc::c_long {
+        } else if length < 64 as i32 as isize {
             /* Initialize full table for safety. */
             i = 0 as i32 as crate::jmorecfg_h::INT32;
-            while i < 64 as i32 as libc::c_long {
+            while i < 64 as i32 as isize {
                 (*quant_ptr).quantval[i as usize] = 1 as i32 as crate::jmorecfg_h::UINT16;
                 i += 1
             }
@@ -1591,23 +1591,23 @@ unsafe extern "C" fn get_dqt(
         }
         if (*(*cinfo).err).trace_level >= 2 as i32 {
             i = 0 as i32 as crate::jmorecfg_h::INT32;
-            while i < 64 as i32 as libc::c_long {
+            while i < 64 as i32 as isize {
                 let mut _mp: *mut i32 = (*(*cinfo).err).msg_parm.i.as_mut_ptr();
                 *_mp.offset(0 as i32 as isize) = (*quant_ptr).quantval[i as usize] as i32;
                 *_mp.offset(1 as i32 as isize) =
-                    (*quant_ptr).quantval[(i + 1 as i32 as libc::c_long) as usize] as i32;
+                    (*quant_ptr).quantval[(i + 1 as i32 as isize) as usize] as i32;
                 *_mp.offset(2 as i32 as isize) =
-                    (*quant_ptr).quantval[(i + 2 as i32 as libc::c_long) as usize] as i32;
+                    (*quant_ptr).quantval[(i + 2 as i32 as isize) as usize] as i32;
                 *_mp.offset(3 as i32 as isize) =
-                    (*quant_ptr).quantval[(i + 3 as i32 as libc::c_long) as usize] as i32;
+                    (*quant_ptr).quantval[(i + 3 as i32 as isize) as usize] as i32;
                 *_mp.offset(4 as i32 as isize) =
-                    (*quant_ptr).quantval[(i + 4 as i32 as libc::c_long) as usize] as i32;
+                    (*quant_ptr).quantval[(i + 4 as i32 as isize) as usize] as i32;
                 *_mp.offset(5 as i32 as isize) =
-                    (*quant_ptr).quantval[(i + 5 as i32 as libc::c_long) as usize] as i32;
+                    (*quant_ptr).quantval[(i + 5 as i32 as isize) as usize] as i32;
                 *_mp.offset(6 as i32 as isize) =
-                    (*quant_ptr).quantval[(i + 6 as i32 as libc::c_long) as usize] as i32;
+                    (*quant_ptr).quantval[(i + 6 as i32 as isize) as usize] as i32;
                 *_mp.offset(7 as i32 as isize) =
-                    (*quant_ptr).quantval[(i + 7 as i32 as libc::c_long) as usize] as i32;
+                    (*quant_ptr).quantval[(i + 7 as i32 as isize) as usize] as i32;
                 (*(*cinfo).err).msg_code = crate::src::jpeg_8c::jerror::JTRC_QUANTVALS as i32;
                 Some(
                     (*(*cinfo).err)
@@ -1618,7 +1618,7 @@ unsafe extern "C" fn get_dqt(
                     cinfo as crate::jpeglib_h::j_common_ptr,
                     2 as i32,
                 );
-                i += 8 as i32 as libc::c_long
+                i += 8 as i32 as isize
             }
         }
         length -= count;
@@ -1626,7 +1626,7 @@ unsafe extern "C" fn get_dqt(
             length -= count
         }
     }
-    if length != 0 as i32 as libc::c_long {
+    if length != 0 as i32 as isize {
         (*(*cinfo).err).msg_code = crate::src::jpeg_8c::jerror::JERR_BAD_LENGTH as i32;
         Some(
             (*(*cinfo).err)
@@ -1684,8 +1684,8 @@ unsafe extern "C" fn get_dri(
     bytes_in_buffer = bytes_in_buffer.wrapping_sub(1);
     let fresh35 = next_input_byte;
     next_input_byte = next_input_byte.offset(1);
-    length += *fresh35 as libc::c_long;
-    if length != 4 as i32 as libc::c_long {
+    length += *fresh35 as isize;
+    if length != 4 as i32 as isize {
         (*(*cinfo).err).msg_code = crate::src::jpeg_8c::jerror::JERR_BAD_LENGTH as i32;
         Some(
             (*(*cinfo).err)
@@ -1825,7 +1825,7 @@ unsafe extern "C" fn examine_app0(
                 cinfo as crate::jpeglib_h::j_common_ptr, 1 as i32
             );
         }
-        totallen -= 14 as i32 as libc::c_long;
+        totallen -= 14 as i32 as isize;
         if totallen
             != *data.offset(12 as i32 as isize) as crate::jmorecfg_h::INT32
                 * *data.offset(13 as i32 as isize) as crate::jmorecfg_h::INT32
@@ -1975,7 +1975,7 @@ unsafe extern "C" fn examine_app14(
         /* Start of APP14 does not match "Adobe", or too short */
         (*(*cinfo).err).msg_code = crate::src::jpeg_8c::jerror::JTRC_APP14 as i32;
         (*(*cinfo).err).msg_parm.i[0 as i32 as usize] =
-            (datalen as libc::c_long + remaining) as i32;
+            (datalen as isize + remaining) as i32;
         Some(
             (*(*cinfo).err)
                 .emit_message
@@ -2033,12 +2033,12 @@ unsafe extern "C" fn get_interesting_appn(
     bytes_in_buffer = bytes_in_buffer.wrapping_sub(1);
     let fresh39 = next_input_byte;
     next_input_byte = next_input_byte.offset(1);
-    length += *fresh39 as libc::c_long;
-    length -= 2 as i32 as libc::c_long;
+    length += *fresh39 as isize;
+    length -= 2 as i32 as isize;
     /* get the interesting part of the marker data */
-    if length >= 14 as i32 as libc::c_long {
+    if length >= 14 as i32 as isize {
         numtoread = 14 as i32 as u32
-    } else if length > 0 as i32 as libc::c_long {
+    } else if length > 0 as i32 as isize {
         numtoread = length as u32
     } else {
         numtoread = 0 as i32 as u32
@@ -2065,7 +2065,7 @@ unsafe extern "C" fn get_interesting_appn(
         b[i as usize] = *fresh40;
         i = i.wrapping_add(1)
     }
-    length -= numtoread as libc::c_long;
+    length -= numtoread as isize;
     /* process it */
     match (*cinfo).unread_marker {
         224 => {
@@ -2091,7 +2091,7 @@ unsafe extern "C" fn get_interesting_appn(
     /* skip any remaining data -- could be lots */
     (*datasrc).next_input_byte = next_input_byte;
     (*datasrc).bytes_in_buffer = bytes_in_buffer;
-    if length > 0 as i32 as libc::c_long {
+    if length > 0 as i32 as isize {
         Some(
             (*(*cinfo).src)
                 .skip_input_data
@@ -2152,9 +2152,9 @@ unsafe extern "C" fn save_marker(
         bytes_in_buffer = bytes_in_buffer.wrapping_sub(1);
         let fresh42 = next_input_byte;
         next_input_byte = next_input_byte.offset(1);
-        length += *fresh42 as libc::c_long;
-        length -= 2 as i32 as libc::c_long;
-        if length >= 0 as i32 as libc::c_long {
+        length += *fresh42 as isize;
+        length -= 2 as i32 as isize;
+        if length >= 0 as i32 as isize {
             /* watch out for bogus length word */
             /* figure out how much we want to save */
             let mut limit: u32 = 0;
@@ -2264,7 +2264,7 @@ unsafe extern "C" fn save_marker(
             (*(*cinfo).err).msg_code = crate::src::jpeg_8c::jerror::JTRC_MISC_MARKER as i32;
             (*(*cinfo).err).msg_parm.i[0 as i32 as usize] = (*cinfo).unread_marker;
             (*(*cinfo).err).msg_parm.i[1 as i32 as usize] =
-                (data_length as libc::c_long + length) as i32;
+                (data_length as isize + length) as i32;
             Some(
                 (*(*cinfo).err)
                     .emit_message
@@ -2278,7 +2278,7 @@ unsafe extern "C" fn save_marker(
     /* skip any remaining data -- could be lots */
     (*datasrc).next_input_byte = next_input_byte; /* do before skip_input_data */
     (*datasrc).bytes_in_buffer = bytes_in_buffer;
-    if length > 0 as i32 as libc::c_long {
+    if length > 0 as i32 as isize {
         Some(
             (*(*cinfo).src)
                 .skip_input_data
@@ -2333,8 +2333,8 @@ unsafe extern "C" fn skip_variable(
     bytes_in_buffer = bytes_in_buffer.wrapping_sub(1);
     let fresh46 = next_input_byte;
     next_input_byte = next_input_byte.offset(1);
-    length += *fresh46 as libc::c_long;
-    length -= 2 as i32 as libc::c_long;
+    length += *fresh46 as isize;
+    length -= 2 as i32 as isize;
     (*(*cinfo).err).msg_code = crate::src::jpeg_8c::jerror::JTRC_MISC_MARKER as i32;
     (*(*cinfo).err).msg_parm.i[0 as i32 as usize] = (*cinfo).unread_marker;
     (*(*cinfo).err).msg_parm.i[1 as i32 as usize] = length as i32;
@@ -2346,7 +2346,7 @@ unsafe extern "C" fn skip_variable(
     .expect("non-null function pointer")(cinfo as crate::jpeglib_h::j_common_ptr, 1 as i32);
     (*datasrc).next_input_byte = next_input_byte;
     (*datasrc).bytes_in_buffer = bytes_in_buffer;
-    if length > 0 as i32 as libc::c_long {
+    if length > 0 as i32 as isize {
         Some(
             (*(*cinfo).src)
                 .skip_input_data
@@ -3209,7 +3209,7 @@ pub unsafe extern "C" fn jpeg_save_markers(
     mut length_limit: u32,
 ) {
     let mut marker: my_marker_ptr = (*cinfo).marker as my_marker_ptr;
-    let mut maxlength: libc::c_long = 0;
+    let mut maxlength: isize = 0;
     let mut processor: crate::jpeglib_h::jpeg_marker_parser_method = None;
     /* Length limit mustn't be larger than what we can allocate
      * (should only be a concern in a 16-bit environment).
@@ -3218,8 +3218,8 @@ pub unsafe extern "C" fn jpeg_save_markers(
         ((*(*cinfo).mem).max_alloc_chunk as libc::c_ulong)
             .wrapping_sub(
                 ::std::mem::size_of::<crate::jpeglib_h::jpeg_marker_struct>() as libc::c_ulong,
-            ) as libc::c_long;
-    if length_limit as libc::c_long > maxlength {
+            ) as isize;
+    if length_limit as isize > maxlength {
         length_limit = maxlength as u32
     }
     /* Choose processor routine to use.

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdmaster.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdmaster.rs
@@ -355,14 +355,14 @@ pub unsafe extern "C" fn jpeg_calc_output_dimensions(
     while ci < (*cinfo).num_components {
         /* Size in samples, after IDCT scaling */
         (*compptr).downsampled_width = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_width as libc::c_long
-                * ((*compptr).h_samp_factor * (*compptr).DCT_h_scaled_size) as libc::c_long,
-            ((*cinfo).max_h_samp_factor * (*cinfo).block_size) as libc::c_long,
+            (*cinfo).image_width as isize
+                * ((*compptr).h_samp_factor * (*compptr).DCT_h_scaled_size) as isize,
+            ((*cinfo).max_h_samp_factor * (*cinfo).block_size) as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         (*compptr).downsampled_height = crate::src::jpeg_8c::jutils::jdiv_round_up(
-            (*cinfo).image_height as libc::c_long
-                * ((*compptr).v_samp_factor * (*compptr).DCT_v_scaled_size) as libc::c_long,
-            ((*cinfo).max_v_samp_factor * (*cinfo).block_size) as libc::c_long,
+            (*cinfo).image_height as isize
+                * ((*compptr).v_samp_factor * (*compptr).DCT_v_scaled_size) as isize,
+            ((*cinfo).max_v_samp_factor * (*cinfo).block_size) as isize,
         ) as crate::jmorecfg_h::JDIMENSION;
         ci += 1;
         compptr = compptr.offset(1)
@@ -504,16 +504,16 @@ unsafe extern "C" fn prepare_range_limit_table(mut cinfo: crate::jpeglib_h::j_de
 unsafe extern "C" fn master_selection(mut cinfo: crate::jpeglib_h::j_decompress_ptr) {
     let mut master: my_master_ptr = (*cinfo).master as my_master_ptr;
     let mut use_c_buffer: crate::jmorecfg_h::boolean = 0;
-    let mut samplesperrow: libc::c_long = 0;
+    let mut samplesperrow: isize = 0;
     let mut jd_samplesperrow: crate::jmorecfg_h::JDIMENSION = 0;
     /* Initialize dimensions and other stuff */
     jpeg_calc_output_dimensions(cinfo);
     prepare_range_limit_table(cinfo);
     /* Width of an output scanline must be representable as JDIMENSION. */
     samplesperrow =
-        (*cinfo).output_width as libc::c_long * (*cinfo).out_color_components as libc::c_long;
+        (*cinfo).output_width as isize * (*cinfo).out_color_components as isize;
     jd_samplesperrow = samplesperrow as crate::jmorecfg_h::JDIMENSION;
-    if jd_samplesperrow as libc::c_long != samplesperrow {
+    if jd_samplesperrow as isize != samplesperrow {
         (*(*cinfo).err).msg_code = crate::src::jpeg_8c::jerror::JERR_WIDTH_OVERFLOW as i32;
         Some(
             (*(*cinfo).err)
@@ -654,9 +654,9 @@ unsafe extern "C" fn master_selection(mut cinfo: crate::jpeglib_h::j_decompress_
             /* For a nonprogressive multiscan file, estimate 1 scan per component. */
             nscans = (*cinfo).num_components
         }
-        (*(*cinfo).progress).pass_counter = 0 as libc::c_long;
+        (*(*cinfo).progress).pass_counter = 0 as isize;
         (*(*cinfo).progress).pass_limit =
-            (*cinfo).total_iMCU_rows as libc::c_long * nscans as libc::c_long;
+            (*cinfo).total_iMCU_rows as isize * nscans as isize;
         (*(*cinfo).progress).completed_passes = 0 as i32;
         (*(*cinfo).progress).total_passes = if (*cinfo).enable_2pass_quant != 0 {
             3 as i32

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdmerge.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdmerge.rs
@@ -153,27 +153,27 @@ unsafe extern "C" fn build_ycc_rgb_table(mut cinfo: crate::jpeglib_h::j_decompre
         /* The Cb or Cr value we are thinking of is x = i - CENTERJSAMPLE */
         /* Cr=>R value is nearest int to 1.40200 * x */
         *(*upsample).Cr_r_tab.offset(i as isize) =
-            ((1.40200f64 * ((1 as libc::c_long) << 16 as i32) as f64 + 0.5f64)
+            ((1.40200f64 * ((1 as isize) << 16 as i32) as f64 + 0.5f64)
                 as crate::jmorecfg_h::INT32
                 * x
                 + ((1 as i32 as crate::jmorecfg_h::INT32) << 16 as i32 - 1 as i32)
                 >> 16 as i32) as i32;
         /* Cb=>B value is nearest int to 1.77200 * x */
         *(*upsample).Cb_b_tab.offset(i as isize) =
-            ((1.77200f64 * ((1 as libc::c_long) << 16 as i32) as f64 + 0.5f64)
+            ((1.77200f64 * ((1 as isize) << 16 as i32) as f64 + 0.5f64)
                 as crate::jmorecfg_h::INT32
                 * x
                 + ((1 as i32 as crate::jmorecfg_h::INT32) << 16 as i32 - 1 as i32)
                 >> 16 as i32) as i32;
         /* Cr=>G value is scaled-up -0.71414 * x */
         *(*upsample).Cr_g_tab.offset(i as isize) =
-            -((0.71414f64 * ((1 as libc::c_long) << 16 as i32) as f64 + 0.5f64)
+            -((0.71414f64 * ((1 as isize) << 16 as i32) as f64 + 0.5f64)
                 as crate::jmorecfg_h::INT32)
                 * x;
         /* Cb=>G value is scaled-up -0.34414 * x */
         /* We also add in ONE_HALF so that need not do it in inner loop */
         *(*upsample).Cb_g_tab.offset(i as isize) =
-            -((0.34414f64 * ((1 as libc::c_long) << 16 as i32) as f64 + 0.5f64)
+            -((0.34414f64 * ((1 as isize) << 16 as i32) as f64 + 0.5f64)
                 as crate::jmorecfg_h::INT32)
                 * x
                 + ((1 as i32 as crate::jmorecfg_h::INT32) << 16 as i32 - 1 as i32);

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdpostct.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdpostct.rs
@@ -594,8 +594,8 @@ pub unsafe extern "C" fn jinit_d_post_controller(
                     .output_width
                     .wrapping_mul((*cinfo).out_color_components as u32),
                 crate::src::jpeg_8c::jutils::jround_up(
-                    (*cinfo).output_height as libc::c_long,
-                    (*post).strip_height as libc::c_long,
+                    (*cinfo).output_height as isize,
+                    (*post).strip_height as isize,
                 ) as crate::jmorecfg_h::JDIMENSION,
                 (*post).strip_height,
             )

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdsample.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdsample.rs
@@ -676,8 +676,8 @@ pub unsafe extern "C" fn jinit_upsampler(mut cinfo: crate::jpeglib_h::j_decompre
                 cinfo as crate::jpeglib_h::j_common_ptr,
                 1 as i32,
                 crate::src::jpeg_8c::jutils::jround_up(
-                    (*cinfo).output_width as libc::c_long,
-                    (*cinfo).max_h_samp_factor as libc::c_long,
+                    (*cinfo).output_width as isize,
+                    (*cinfo).max_h_samp_factor as isize,
                 ) as crate::jmorecfg_h::JDIMENSION,
                 (*cinfo).max_v_samp_factor as crate::jmorecfg_h::JDIMENSION,
             )

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdtrans.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jdtrans.rs
@@ -286,7 +286,7 @@ pub unsafe extern "C" fn jpeg_read_coefficients(
                 (*(*cinfo).progress).pass_counter += 1;
                 if (*(*cinfo).progress).pass_counter >= (*(*cinfo).progress).pass_limit {
                     /* startup underestimated number of scans; ratchet up one scan */
-                    (*(*cinfo).progress).pass_limit += (*cinfo).total_iMCU_rows as libc::c_long
+                    (*(*cinfo).progress).pass_limit += (*cinfo).total_iMCU_rows as isize
                 }
             }
         }
@@ -381,9 +381,9 @@ unsafe extern "C" fn transdecode_master_selection(mut cinfo: crate::jpeglib_h::j
         } else {
             nscans = 1 as i32
         }
-        (*(*cinfo).progress).pass_counter = 0 as libc::c_long;
+        (*(*cinfo).progress).pass_counter = 0 as isize;
         (*(*cinfo).progress).pass_limit =
-            (*cinfo).total_iMCU_rows as libc::c_long * nscans as libc::c_long;
+            (*cinfo).total_iMCU_rows as isize * nscans as isize;
         (*(*cinfo).progress).completed_passes = 0 as i32;
         (*(*cinfo).progress).total_passes = 1 as i32
     };

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jerror.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jerror.rs
@@ -542,7 +542,7 @@ unsafe extern "C" fn emit_message(mut cinfo: crate::jpeglib_h::j_common_ptr, mut
          * the policy implemented here is to show only the first warning,
          * unless trace_level >= 3.
          */
-        if (*err).num_warnings == 0 as i32 as libc::c_long || (*err).trace_level >= 3 as i32 {
+        if (*err).num_warnings == 0 as i32 as isize || (*err).trace_level >= 3 as i32 {
             Some((*err).output_message.expect("non-null function pointer"))
                 .expect("non-null function pointer")(cinfo);
         }
@@ -632,7 +632,7 @@ unsafe extern "C" fn format_message(
  */
 
 unsafe extern "C" fn reset_error_mgr(mut cinfo: crate::jpeglib_h::j_common_ptr) {
-    (*(*cinfo).err).num_warnings = 0 as i32 as libc::c_long;
+    (*(*cinfo).err).num_warnings = 0 as i32 as isize;
     /* trace_level is not reset since it is an application-supplied parameter */
     (*(*cinfo).err).msg_code = 0 as i32;
     /* may be useful as a flag for "no error" */
@@ -676,7 +676,7 @@ pub unsafe extern "C" fn jpeg_std_error(
     (*err).reset_error_mgr =
         Some(reset_error_mgr as unsafe extern "C" fn(_: crate::jpeglib_h::j_common_ptr) -> ());
     (*err).trace_level = 0 as i32;
-    (*err).num_warnings = 0 as i32 as libc::c_long;
+    (*err).num_warnings = 0 as i32 as isize;
     (*err).msg_code = 0 as i32;
     /* Initialize message table pointers */
     (*err).jpeg_message_table = jpeg_std_message_table.as_ptr(); /* for safety */

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jfdctfst.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jfdctfst.rs
@@ -135,22 +135,22 @@ pub unsafe extern "C" fn jpeg_fdct_ifast(
         tmp12 = tmp1 - tmp2;
         *dataptr.offset(0 as i32 as isize) = tmp10 + tmp11 - 8 as i32 * 128 as i32;
         *dataptr.offset(4 as i32 as isize) = tmp10 - tmp11;
-        z1 = ((tmp12 + tmp13) as libc::c_long * 181 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
+        z1 = ((tmp12 + tmp13) as isize * 181 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
             as crate::jdct_h::DCTELEM;
         *dataptr.offset(2 as i32 as isize) = tmp13 + z1;
         *dataptr.offset(6 as i32 as isize) = tmp13 - z1;
         tmp10 = tmp4 + tmp5;
         tmp11 = tmp5 + tmp6;
         tmp12 = tmp6 + tmp7;
-        z5 = ((tmp10 - tmp12) as libc::c_long * 98 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
+        z5 = ((tmp10 - tmp12) as isize * 98 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
             as crate::jdct_h::DCTELEM;
-        z2 = (tmp10 as libc::c_long * 139 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
+        z2 = (tmp10 as isize * 139 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
             as crate::jdct_h::DCTELEM
             + z5;
-        z4 = (tmp12 as libc::c_long * 334 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
+        z4 = (tmp12 as isize * 334 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
             as crate::jdct_h::DCTELEM
             + z5;
-        z3 = (tmp11 as libc::c_long * 181 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
+        z3 = (tmp11 as isize * 181 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
             as crate::jdct_h::DCTELEM;
         z11 = tmp7 + z3;
         z13 = tmp7 - z3;
@@ -204,22 +204,22 @@ pub unsafe extern "C" fn jpeg_fdct_ifast(
         tmp12 = tmp1 - tmp2;
         *dataptr.offset((8 as i32 * 0 as i32) as isize) = tmp10 + tmp11;
         *dataptr.offset((8 as i32 * 4 as i32) as isize) = tmp10 - tmp11;
-        z1 = ((tmp12 + tmp13) as libc::c_long * 181 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
+        z1 = ((tmp12 + tmp13) as isize * 181 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
             as crate::jdct_h::DCTELEM;
         *dataptr.offset((8 as i32 * 2 as i32) as isize) = tmp13 + z1;
         *dataptr.offset((8 as i32 * 6 as i32) as isize) = tmp13 - z1;
         tmp10 = tmp4 + tmp5;
         tmp11 = tmp5 + tmp6;
         tmp12 = tmp6 + tmp7;
-        z5 = ((tmp10 - tmp12) as libc::c_long * 98 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
+        z5 = ((tmp10 - tmp12) as isize * 98 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
             as crate::jdct_h::DCTELEM;
-        z2 = (tmp10 as libc::c_long * 139 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
+        z2 = (tmp10 as isize * 139 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
             as crate::jdct_h::DCTELEM
             + z5;
-        z4 = (tmp12 as libc::c_long * 334 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
+        z4 = (tmp12 as isize * 334 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
             as crate::jdct_h::DCTELEM
             + z5;
-        z3 = (tmp11 as libc::c_long * 181 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
+        z3 = (tmp11 as isize * 181 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
             as crate::jdct_h::DCTELEM;
         z11 = tmp7 + z3;
         z13 = tmp7 - z3;

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jfdctint.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jfdctint.rs
@@ -97,7 +97,7 @@ pub unsafe extern "C" fn jpeg_fdct_islow(
         tmp3 = (*elemptr.offset(3 as i32 as isize) as i32
             - *elemptr.offset(4 as i32 as isize) as i32) as crate::jmorecfg_h::INT32;
         *dataptr.offset(0 as i32 as isize) = ((tmp10 + tmp11
-            - (8 as i32 * 128 as i32) as libc::c_long)
+            - (8 as i32 * 128 as i32) as isize)
             << 2 as i32) as crate::jdct_h::DCTELEM;
         *dataptr.offset(4 as i32 as isize) = (tmp10 - tmp11 << 2 as i32) as crate::jdct_h::DCTELEM;
         z1 = (tmp12 + tmp13) * 4433 as i32 as crate::jmorecfg_h::INT32;
@@ -306,7 +306,7 @@ pub unsafe extern "C" fn jpeg_fdct_7x7(
             as crate::jmorecfg_h::INT32;
         z1 = tmp0 + tmp2;
         *dataptr.offset(0 as i32 as isize) = ((z1 + tmp1 + tmp3
-            - (7 as i32 * 128 as i32) as libc::c_long)
+            - (7 as i32 * 128 as i32) as isize)
             << 2 as i32) as crate::jdct_h::DCTELEM;
         tmp3 += tmp3;
         z1 -= tmp3;
@@ -542,7 +542,7 @@ pub unsafe extern "C" fn jpeg_fdct_6x6(
         tmp2 = (*elemptr.offset(2 as i32 as isize) as i32
             - *elemptr.offset(3 as i32 as isize) as i32) as crate::jmorecfg_h::INT32;
         *dataptr.offset(0 as i32 as isize) = ((tmp10 + tmp11
-            - (6 as i32 * 128 as i32) as libc::c_long)
+            - (6 as i32 * 128 as i32) as isize)
             << 2 as i32) as crate::jdct_h::DCTELEM;
         *dataptr.offset(2 as i32 as isize) = (tmp12
             * (1.224744871f64 * ((1 as i32 as crate::jmorecfg_h::INT32) << 13 as i32) as f64
@@ -700,7 +700,7 @@ pub unsafe extern "C" fn jpeg_fdct_5x5(
         tmp1 = (*elemptr.offset(1 as i32 as isize) as i32
             - *elemptr.offset(3 as i32 as isize) as i32) as crate::jmorecfg_h::INT32;
         *dataptr.offset(0 as i32 as isize) =
-            ((tmp10 + tmp2 - (5 as i32 * 128 as i32) as libc::c_long) << 2 as i32 + 1 as i32)
+            ((tmp10 + tmp2 - (5 as i32 * 128 as i32) as isize) << 2 as i32 + 1 as i32)
                 as crate::jdct_h::DCTELEM;
         tmp11 = tmp11
             * (0.790569415f64 * ((1 as i32 as crate::jmorecfg_h::INT32) << 13 as i32) as f64
@@ -865,7 +865,7 @@ pub unsafe extern "C" fn jpeg_fdct_4x4(
             - *elemptr.offset(2 as i32 as isize) as i32)
             as crate::jmorecfg_h::INT32;
         *dataptr.offset(0 as i32 as isize) =
-            ((tmp0 + tmp1 - (4 as i32 * 128 as i32) as libc::c_long) << 2 as i32 + 2 as i32)
+            ((tmp0 + tmp1 - (4 as i32 * 128 as i32) as isize) << 2 as i32 + 2 as i32)
                 as crate::jdct_h::DCTELEM;
         *dataptr.offset(2 as i32 as isize) =
             (tmp0 - tmp1 << 2 as i32 + 2 as i32) as crate::jdct_h::DCTELEM;
@@ -895,7 +895,7 @@ pub unsafe extern "C" fn jpeg_fdct_4x4(
         /* Even part */
         /* Add fudge factor here for final descale. */
         tmp0 = (*dataptr.offset((8 as i32 * 0 as i32) as isize)
-            + *dataptr.offset((8 as i32 * 3 as i32) as isize)) as libc::c_long
+            + *dataptr.offset((8 as i32 * 3 as i32) as isize)) as isize
             + ((1 as i32 as crate::jmorecfg_h::INT32) << 2 as i32 - 1 as i32);
         tmp1 = (*dataptr.offset((8 as i32 * 1 as i32) as isize)
             + *dataptr.offset((8 as i32 * 2 as i32) as isize))
@@ -966,7 +966,7 @@ pub unsafe extern "C" fn jpeg_fdct_3x3(
         tmp2 = (*elemptr.offset(0 as i32 as isize) as i32
             - *elemptr.offset(2 as i32 as isize) as i32) as crate::jmorecfg_h::INT32;
         *dataptr.offset(0 as i32 as isize) =
-            ((tmp0 + tmp1 - (3 as i32 * 128 as i32) as libc::c_long) << 2 as i32 + 2 as i32)
+            ((tmp0 + tmp1 - (3 as i32 * 128 as i32) as isize) << 2 as i32 + 2 as i32)
                 as crate::jdct_h::DCTELEM;
         *dataptr.offset(2 as i32 as isize) = ((tmp0 - tmp1 - tmp1)
             * (0.707106781f64 * ((1 as i32 as crate::jmorecfg_h::INT32) << 13 as i32) as f64
@@ -1073,7 +1073,7 @@ pub unsafe extern "C" fn jpeg_fdct_2x2(
     /* Column 0 */
     /* Apply unsigned->signed conversion */
     *data.offset((8 as i32 * 0 as i32) as isize) = ((tmp0 + tmp2
-        - (4 as i32 * 128 as i32) as libc::c_long)
+        - (4 as i32 * 128 as i32) as isize)
         << 4 as i32) as crate::jdct_h::DCTELEM;
     *data.offset((8 as i32 * 1 as i32) as isize) =
         (tmp0 - tmp2 << 4 as i32) as crate::jdct_h::DCTELEM;
@@ -1168,7 +1168,7 @@ pub unsafe extern "C" fn jpeg_fdct_9x9(
         z1 = tmp0 + tmp2 + tmp3;
         z2 = tmp1 + tmp4;
         /* Apply unsigned->signed conversion */
-        *dataptr.offset(0 as i32 as isize) = ((z1 + z2 - (9 as i32 * 128 as i32) as libc::c_long)
+        *dataptr.offset(0 as i32 as isize) = ((z1 + z2 - (9 as i32 * 128 as i32) as isize)
             << 1 as i32) as crate::jdct_h::DCTELEM; /* c2 */
         *dataptr.offset(6 as i32 as isize) = ((z1 - z2 - z2)
             * (0.707106781f64 * ((1 as i32 as crate::jmorecfg_h::INT32) << 13 as i32) as f64
@@ -1423,7 +1423,7 @@ pub unsafe extern "C" fn jpeg_fdct_10x10(
             - *elemptr.offset(5 as i32 as isize) as i32) as crate::jmorecfg_h::INT32;
         /* Apply unsigned->signed conversion */
         *dataptr.offset(0 as i32 as isize) = ((tmp10 + tmp11 + tmp12
-            - (10 as i32 * 128 as i32) as libc::c_long)
+            - (10 as i32 * 128 as i32) as isize)
             << 1 as i32) as crate::jdct_h::DCTELEM; /* c6 */
         tmp12 += tmp12;
         *dataptr.offset(4 as i32 as isize) = ((tmp10 - tmp12)
@@ -1712,7 +1712,7 @@ pub unsafe extern "C" fn jpeg_fdct_11x11(
             as crate::jmorecfg_h::INT32;
         /* Apply unsigned->signed conversion */
         *dataptr.offset(0 as i32 as isize) = ((tmp0 + tmp1 + tmp2 + tmp3 + tmp4 + tmp5
-            - (11 as i32 * 128 as i32) as libc::c_long)
+            - (11 as i32 * 128 as i32) as isize)
             << 1 as i32) as crate::jdct_h::DCTELEM; /* c10 */
         tmp5 += tmp5; /* c6 */
         tmp0 -= tmp5; /* c4 */
@@ -2088,7 +2088,7 @@ pub unsafe extern "C" fn jpeg_fdct_12x12(
             - *elemptr.offset(6 as i32 as isize) as i32) as crate::jmorecfg_h::INT32;
         /* Apply unsigned->signed conversion */
         *dataptr.offset(0 as i32 as isize) = (tmp10 + tmp11 + tmp12
-            - (12 as i32 * 128 as i32) as libc::c_long)
+            - (12 as i32 * 128 as i32) as isize)
             as crate::jdct_h::DCTELEM;
         *dataptr.offset(6 as i32 as isize) = (tmp13 - tmp14 - tmp15) as crate::jdct_h::DCTELEM;
         *dataptr.offset(4 as i32 as isize) = ((tmp10 - tmp12)
@@ -2399,7 +2399,7 @@ pub unsafe extern "C" fn jpeg_fdct_13x13(
             as crate::jmorecfg_h::INT32;
         /* Apply unsigned->signed conversion */
         *dataptr.offset(0 as i32 as isize) = (tmp0 + tmp1 + tmp2 + tmp3 + tmp4 + tmp5 + tmp6
-            - (13 as i32 * 128 as i32) as libc::c_long)
+            - (13 as i32 * 128 as i32) as isize)
             as crate::jdct_h::DCTELEM; /* (c8-c12)/2 */
         tmp6 += tmp6; /* (c8+c12)/2 */
         tmp0 -= tmp6;
@@ -2802,7 +2802,7 @@ pub unsafe extern "C" fn jpeg_fdct_14x14(
             - *elemptr.offset(7 as i32 as isize) as i32) as crate::jmorecfg_h::INT32;
         /* Apply unsigned->signed conversion */
         *dataptr.offset(0 as i32 as isize) = (tmp10 + tmp11 + tmp12 + tmp13
-            - (14 as i32 * 128 as i32) as libc::c_long)
+            - (14 as i32 * 128 as i32) as isize)
             as crate::jdct_h::DCTELEM; /* c6 */
         tmp13 += tmp13;
         *dataptr.offset(4 as i32 as isize) = ((tmp10 - tmp13)
@@ -3159,7 +3159,7 @@ pub unsafe extern "C" fn jpeg_fdct_15x15(
         z3 = tmp2 + tmp7;
         /* Apply unsigned->signed conversion */
         *dataptr.offset(0 as i32 as isize) =
-            (z1 + z2 + z3 - (15 as i32 * 128 as i32) as libc::c_long) as crate::jdct_h::DCTELEM; /* c4+c8 */
+            (z1 + z2 + z3 - (15 as i32 * 128 as i32) as isize) as crate::jdct_h::DCTELEM; /* c4+c8 */
         z3 += z3; /* c2-c4 */
         *dataptr.offset(6 as i32 as isize) = ((z1 - z3)
             * (1.144122806f64 * ((1 as i32 as crate::jmorecfg_h::INT32) << 13 as i32) as f64
@@ -3530,7 +3530,7 @@ pub unsafe extern "C" fn jpeg_fdct_16x16(
             - *elemptr.offset(8 as i32 as isize) as i32) as crate::jmorecfg_h::INT32;
         /* Apply unsigned->signed conversion */
         *dataptr.offset(0 as i32 as isize) = ((tmp10 + tmp11 + tmp12 + tmp13
-            - (16 as i32 * 128 as i32) as libc::c_long)
+            - (16 as i32 * 128 as i32) as isize)
             << 2 as i32) as crate::jdct_h::DCTELEM; /* c2[16] = c1[8] */
         *dataptr.offset(4 as i32 as isize) = ((tmp10 - tmp13)
             * (1.306562965f64 * ((1 as i32 as crate::jmorecfg_h::INT32) << 13 as i32) as f64
@@ -3963,7 +3963,7 @@ pub unsafe extern "C" fn jpeg_fdct_16x8(
         tmp7 = (*elemptr.offset(7 as i32 as isize) as i32
             - *elemptr.offset(8 as i32 as isize) as i32) as crate::jmorecfg_h::INT32;
         *dataptr.offset(0 as i32 as isize) = ((tmp10 + tmp11 + tmp12 + tmp13
-            - (16 as i32 * 128 as i32) as libc::c_long)
+            - (16 as i32 * 128 as i32) as isize)
             << 2 as i32) as crate::jdct_h::DCTELEM;
         *dataptr.offset(4 as i32 as isize) = ((tmp10 - tmp13)
             * (1.306562965f64 * ((1 as i32 as crate::jmorecfg_h::INT32) << 13 as i32) as f64
@@ -4305,7 +4305,7 @@ pub unsafe extern "C" fn jpeg_fdct_14x7(
         tmp6 = (*elemptr.offset(6 as i32 as isize) as i32
             - *elemptr.offset(7 as i32 as isize) as i32) as crate::jmorecfg_h::INT32;
         *dataptr.offset(0 as i32 as isize) = ((tmp10 + tmp11 + tmp12 + tmp13
-            - (14 as i32 * 128 as i32) as libc::c_long)
+            - (14 as i32 * 128 as i32) as isize)
             << 2 as i32) as crate::jdct_h::DCTELEM;
         tmp13 += tmp13;
         *dataptr.offset(4 as i32 as isize) = ((tmp10 - tmp13)
@@ -4604,7 +4604,7 @@ pub unsafe extern "C" fn jpeg_fdct_12x6(
         tmp5 = (*elemptr.offset(5 as i32 as isize) as i32
             - *elemptr.offset(6 as i32 as isize) as i32) as crate::jmorecfg_h::INT32;
         *dataptr.offset(0 as i32 as isize) = ((tmp10 + tmp11 + tmp12
-            - (12 as i32 * 128 as i32) as libc::c_long)
+            - (12 as i32 * 128 as i32) as isize)
             << 2 as i32) as crate::jdct_h::DCTELEM;
         *dataptr.offset(6 as i32 as isize) =
             (tmp13 - tmp14 - tmp15 << 2 as i32) as crate::jdct_h::DCTELEM;
@@ -4842,7 +4842,7 @@ pub unsafe extern "C" fn jpeg_fdct_10x5(
         tmp4 = (*elemptr.offset(4 as i32 as isize) as i32
             - *elemptr.offset(5 as i32 as isize) as i32) as crate::jmorecfg_h::INT32;
         *dataptr.offset(0 as i32 as isize) = ((tmp10 + tmp11 + tmp12
-            - (10 as i32 * 128 as i32) as libc::c_long)
+            - (10 as i32 * 128 as i32) as isize)
             << 2 as i32) as crate::jdct_h::DCTELEM;
         tmp12 += tmp12;
         *dataptr.offset(4 as i32 as isize) = ((tmp10 - tmp12)
@@ -5055,7 +5055,7 @@ pub unsafe extern "C" fn jpeg_fdct_8x4(
         tmp3 = (*elemptr.offset(3 as i32 as isize) as i32
             - *elemptr.offset(4 as i32 as isize) as i32) as crate::jmorecfg_h::INT32;
         *dataptr.offset(0 as i32 as isize) =
-            ((tmp10 + tmp11 - (8 as i32 * 128 as i32) as libc::c_long) << 2 as i32 + 1 as i32)
+            ((tmp10 + tmp11 - (8 as i32 * 128 as i32) as isize) << 2 as i32 + 1 as i32)
                 as crate::jdct_h::DCTELEM;
         *dataptr.offset(4 as i32 as isize) =
             (tmp10 - tmp11 << 2 as i32 + 1 as i32) as crate::jdct_h::DCTELEM;
@@ -5124,7 +5124,7 @@ pub unsafe extern "C" fn jpeg_fdct_8x4(
         /* Even part */
         /* Add fudge factor here for final descale. */
         tmp0 = (*dataptr.offset((8 as i32 * 0 as i32) as isize)
-            + *dataptr.offset((8 as i32 * 3 as i32) as isize)) as libc::c_long
+            + *dataptr.offset((8 as i32 * 3 as i32) as isize)) as isize
             + ((1 as i32 as crate::jmorecfg_h::INT32) << 2 as i32 - 1 as i32);
         tmp1 = (*dataptr.offset((8 as i32 * 1 as i32) as isize)
             + *dataptr.offset((8 as i32 * 2 as i32) as isize))
@@ -5210,7 +5210,7 @@ pub unsafe extern "C" fn jpeg_fdct_6x3(
         tmp2 = (*elemptr.offset(2 as i32 as isize) as i32
             - *elemptr.offset(3 as i32 as isize) as i32) as crate::jmorecfg_h::INT32;
         *dataptr.offset(0 as i32 as isize) =
-            ((tmp10 + tmp11 - (6 as i32 * 128 as i32) as libc::c_long) << 2 as i32 + 1 as i32)
+            ((tmp10 + tmp11 - (6 as i32 * 128 as i32) as isize) << 2 as i32 + 1 as i32)
                 as crate::jdct_h::DCTELEM;
         *dataptr.offset(2 as i32 as isize) = (tmp12
             * (1.224744871f64 * ((1 as i32 as crate::jmorecfg_h::INT32) << 13 as i32) as f64
@@ -5334,7 +5334,7 @@ pub unsafe extern "C" fn jpeg_fdct_4x2(
             - *elemptr.offset(2 as i32 as isize) as i32)
             as crate::jmorecfg_h::INT32;
         *dataptr.offset(0 as i32 as isize) =
-            ((tmp0 + tmp1 - (4 as i32 * 128 as i32) as libc::c_long) << 2 as i32 + 3 as i32)
+            ((tmp0 + tmp1 - (4 as i32 * 128 as i32) as isize) << 2 as i32 + 3 as i32)
                 as crate::jdct_h::DCTELEM;
         *dataptr.offset(2 as i32 as isize) =
             (tmp0 - tmp1 << 2 as i32 + 3 as i32) as crate::jdct_h::DCTELEM;
@@ -5363,7 +5363,7 @@ pub unsafe extern "C" fn jpeg_fdct_4x2(
     while ctr < 4 as i32 {
         /* Even part */
         /* Add fudge factor here for final descale. */
-        tmp0 = *dataptr.offset((8 as i32 * 0 as i32) as isize) as libc::c_long
+        tmp0 = *dataptr.offset((8 as i32 * 0 as i32) as isize) as isize
             + ((1 as i32 as crate::jmorecfg_h::INT32) << 2 as i32 - 1 as i32);
         tmp1 = *dataptr.offset((8 as i32 * 1 as i32) as isize) as crate::jmorecfg_h::INT32;
         *dataptr.offset((8 as i32 * 0 as i32) as isize) =
@@ -5406,7 +5406,7 @@ pub unsafe extern "C" fn jpeg_fdct_2x1(
      */
     /* Even part */
     /* Apply unsigned->signed conversion */
-    *data.offset(0 as i32 as isize) = ((tmp0 + tmp1 - (2 as i32 * 128 as i32) as libc::c_long)
+    *data.offset(0 as i32 as isize) = ((tmp0 + tmp1 - (2 as i32 * 128 as i32) as isize)
         << 5 as i32) as crate::jdct_h::DCTELEM;
     /* Odd part */
     *data.offset(1 as i32 as isize) = (tmp0 - tmp1 << 5 as i32) as crate::jdct_h::DCTELEM;
@@ -5478,7 +5478,7 @@ pub unsafe extern "C" fn jpeg_fdct_8x16(
             - *elemptr.offset(4 as i32 as isize) as i32) as crate::jmorecfg_h::INT32;
         /* Apply unsigned->signed conversion */
         *dataptr.offset(0 as i32 as isize) = ((tmp10 + tmp11
-            - (8 as i32 * 128 as i32) as libc::c_long)
+            - (8 as i32 * 128 as i32) as isize)
             << 2 as i32) as crate::jdct_h::DCTELEM;
         *dataptr.offset(4 as i32 as isize) = (tmp10 - tmp11 << 2 as i32) as crate::jdct_h::DCTELEM;
         z1 = (tmp12 + tmp13) * 4433 as i32 as crate::jmorecfg_h::INT32;
@@ -5828,7 +5828,7 @@ pub unsafe extern "C" fn jpeg_fdct_7x14(
         z1 = tmp0 + tmp2;
         /* Apply unsigned->signed conversion */
         *dataptr.offset(0 as i32 as isize) = ((z1 + tmp1 + tmp3
-            - (7 as i32 * 128 as i32) as libc::c_long)
+            - (7 as i32 * 128 as i32) as isize)
             << 2 as i32) as crate::jdct_h::DCTELEM; /* (c2+c6-c4)/2 */
         tmp3 += tmp3; /* (c2+c4-c6)/2 */
         z1 -= tmp3; /* c6 */
@@ -6140,7 +6140,7 @@ pub unsafe extern "C" fn jpeg_fdct_6x12(
             - *elemptr.offset(3 as i32 as isize) as i32) as crate::jmorecfg_h::INT32;
         /* Apply unsigned->signed conversion */
         *dataptr.offset(0 as i32 as isize) = ((tmp10 + tmp11
-            - (6 as i32 * 128 as i32) as libc::c_long)
+            - (6 as i32 * 128 as i32) as isize)
             << 2 as i32) as crate::jdct_h::DCTELEM;
         *dataptr.offset(2 as i32 as isize) = (tmp12
             * (1.224744871f64 * ((1 as i32 as crate::jmorecfg_h::INT32) << 13 as i32) as f64
@@ -6394,7 +6394,7 @@ pub unsafe extern "C" fn jpeg_fdct_5x10(
             - *elemptr.offset(3 as i32 as isize) as i32) as crate::jmorecfg_h::INT32;
         /* Apply unsigned->signed conversion */
         *dataptr.offset(0 as i32 as isize) = ((tmp10 + tmp2
-            - (5 as i32 * 128 as i32) as libc::c_long)
+            - (5 as i32 * 128 as i32) as isize)
             << 2 as i32) as crate::jdct_h::DCTELEM; /* (c2+c4)/2 */
         tmp11 = tmp11
             * (0.790569415f64 * ((1 as i32 as crate::jmorecfg_h::INT32) << 13 as i32) as f64
@@ -6632,7 +6632,7 @@ pub unsafe extern "C" fn jpeg_fdct_4x8(
             - *elemptr.offset(2 as i32 as isize) as i32)
             as crate::jmorecfg_h::INT32;
         *dataptr.offset(0 as i32 as isize) =
-            ((tmp0 + tmp1 - (4 as i32 * 128 as i32) as libc::c_long) << 2 as i32 + 1 as i32)
+            ((tmp0 + tmp1 - (4 as i32 * 128 as i32) as isize) << 2 as i32 + 1 as i32)
                 as crate::jdct_h::DCTELEM;
         *dataptr.offset(2 as i32 as isize) =
             (tmp0 - tmp1 << 2 as i32 + 1 as i32) as crate::jdct_h::DCTELEM;
@@ -6792,7 +6792,7 @@ pub unsafe extern "C" fn jpeg_fdct_3x6(
         tmp2 = (*elemptr.offset(0 as i32 as isize) as i32
             - *elemptr.offset(2 as i32 as isize) as i32) as crate::jmorecfg_h::INT32;
         *dataptr.offset(0 as i32 as isize) =
-            ((tmp0 + tmp1 - (3 as i32 * 128 as i32) as libc::c_long) << 2 as i32 + 1 as i32)
+            ((tmp0 + tmp1 - (3 as i32 * 128 as i32) as isize) << 2 as i32 + 1 as i32)
                 as crate::jdct_h::DCTELEM;
         *dataptr.offset(2 as i32 as isize) = ((tmp0 - tmp1 - tmp1)
             * (0.707106781f64 * ((1 as i32 as crate::jmorecfg_h::INT32) << 13 as i32) as f64
@@ -6930,7 +6930,7 @@ pub unsafe extern "C" fn jpeg_fdct_2x4(
         tmp0 = *elemptr.offset(0 as i32 as isize) as i32 as crate::jmorecfg_h::INT32;
         tmp1 = *elemptr.offset(1 as i32 as isize) as i32 as crate::jmorecfg_h::INT32;
         *dataptr.offset(0 as i32 as isize) = ((tmp0 + tmp1
-            - (2 as i32 * 128 as i32) as libc::c_long)
+            - (2 as i32 * 128 as i32) as isize)
             << 3 as i32) as crate::jdct_h::DCTELEM;
         *dataptr.offset(1 as i32 as isize) = (tmp0 - tmp1 << 3 as i32) as crate::jdct_h::DCTELEM;
         dataptr = dataptr.offset(8 as i32 as isize);
@@ -7009,7 +7009,7 @@ pub unsafe extern "C" fn jpeg_fdct_1x2(
     /* Even part */
     /* Apply unsigned->signed conversion */
     *data.offset((8 as i32 * 0 as i32) as isize) = ((tmp0 + tmp1
-        - (2 as i32 * 128 as i32) as libc::c_long)
+        - (2 as i32 * 128 as i32) as isize)
         << 5 as i32) as crate::jdct_h::DCTELEM;
     /* Odd part */
     *data.offset((8 as i32 * 1 as i32) as isize) =

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jidctfst.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jidctfst.rs
@@ -244,7 +244,7 @@ pub unsafe extern "C" fn jpeg_idct_ifast(
             tmp10 = tmp0 + tmp2;
             tmp11 = tmp0 - tmp2;
             tmp13 = tmp1 + tmp3;
-            tmp12 = ((tmp1 - tmp3) as libc::c_long * 362 as i32 as crate::jmorecfg_h::INT32
+            tmp12 = ((tmp1 - tmp3) as isize * 362 as i32 as crate::jmorecfg_h::INT32
                 >> 8 as i32) as crate::jdct_h::DCTELEM
                 - tmp13;
             tmp0 = tmp10 + tmp13;
@@ -265,14 +265,14 @@ pub unsafe extern "C" fn jpeg_idct_ifast(
             z11 = tmp4 + tmp7; /* phase 2 */
             z12 = tmp4 - tmp7; /* advance pointers to next column */
             tmp7 = z11 + z13;
-            tmp11 = ((z11 - z13) as libc::c_long * 362 as i32 as crate::jmorecfg_h::INT32
+            tmp11 = ((z11 - z13) as isize * 362 as i32 as crate::jmorecfg_h::INT32
                 >> 8 as i32) as crate::jdct_h::DCTELEM;
-            z5 = ((z10 + z12) as libc::c_long * 473 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
+            z5 = ((z10 + z12) as isize * 473 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
                 as crate::jdct_h::DCTELEM;
-            tmp10 = (z12 as libc::c_long * 277 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
+            tmp10 = (z12 as isize * 277 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
                 as crate::jdct_h::DCTELEM
                 - z5;
-            tmp12 = (z10 as libc::c_long * -(669 as i32 as crate::jmorecfg_h::INT32) >> 8 as i32)
+            tmp12 = (z10 as isize * -(669 as i32 as crate::jmorecfg_h::INT32) >> 8 as i32)
                 as crate::jdct_h::DCTELEM
                 + z5;
             tmp6 = tmp12 - tmp7;
@@ -335,7 +335,7 @@ pub unsafe extern "C" fn jpeg_idct_ifast(
             tmp11 = *wsptr.offset(0 as i32 as isize) - *wsptr.offset(4 as i32 as isize);
             tmp13 = *wsptr.offset(2 as i32 as isize) + *wsptr.offset(6 as i32 as isize);
             tmp12 = ((*wsptr.offset(2 as i32 as isize) - *wsptr.offset(6 as i32 as isize))
-                as libc::c_long
+                as isize
                 * 362 as i32 as crate::jmorecfg_h::INT32
                 >> 8 as i32) as crate::jdct_h::DCTELEM
                 - tmp13;
@@ -349,14 +349,14 @@ pub unsafe extern "C" fn jpeg_idct_ifast(
             z11 = *wsptr.offset(1 as i32 as isize) + *wsptr.offset(7 as i32 as isize); /* 2*c2 */
             z12 = *wsptr.offset(1 as i32 as isize) - *wsptr.offset(7 as i32 as isize); /* 2*(c2-c6) */
             tmp7 = z11 + z13; /* -2*(c2+c6) */
-            tmp11 = ((z11 - z13) as libc::c_long * 362 as i32 as crate::jmorecfg_h::INT32
+            tmp11 = ((z11 - z13) as isize * 362 as i32 as crate::jmorecfg_h::INT32
                 >> 8 as i32) as crate::jdct_h::DCTELEM; /* phase 2 */
-            z5 = ((z10 + z12) as libc::c_long * 473 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
+            z5 = ((z10 + z12) as isize * 473 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
                 as crate::jdct_h::DCTELEM;
-            tmp10 = (z12 as libc::c_long * 277 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
+            tmp10 = (z12 as isize * 277 as i32 as crate::jmorecfg_h::INT32 >> 8 as i32)
                 as crate::jdct_h::DCTELEM
                 - z5;
-            tmp12 = (z10 as libc::c_long * -(669 as i32 as crate::jmorecfg_h::INT32) >> 8 as i32)
+            tmp12 = (z10 as isize * -(669 as i32 as crate::jmorecfg_h::INT32) >> 8 as i32)
                 as crate::jdct_h::DCTELEM
                 + z5;
             tmp6 = tmp12 - tmp7;

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jidctint.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jidctint.rs
@@ -3665,7 +3665,7 @@ pub unsafe extern "C" fn jpeg_idct_16x16(
             as crate::jmorecfg_h::INT32;
         tmp0 <<= 13 as i32;
         /* Add fudge factor here for final descale. */
-        tmp0 += ((1 as i32) << 13 as i32 - 2 as i32 - 1 as i32) as libc::c_long; /* c4[16] = c2[8] */
+        tmp0 += ((1 as i32) << 13 as i32 - 2 as i32 - 1 as i32) as isize; /* c4[16] = c2[8] */
         z1 = (*inptr.offset((8 as i32 * 4 as i32) as isize) as crate::jdct_h::ISLOW_MULT_TYPE
             * *quantptr.offset((8 as i32 * 4 as i32) as isize))
             as crate::jmorecfg_h::INT32; /* c12[16] = c6[8] */

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jmemmgr.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jmemmgr.rs
@@ -223,7 +223,7 @@ pub struct my_memory_mgr {
     pub large_list: [large_pool_ptr; 2],
     pub virt_sarray_list: crate::jpeglib_h::jvirt_sarray_ptr,
     pub virt_barray_list: crate::jpeglib_h::jvirt_barray_ptr,
-    pub total_space_allocated: libc::c_long,
+    pub total_space_allocated: isize,
     pub last_rowsperchunk: crate::jmorecfg_h::JDIMENSION,
 }
 
@@ -396,7 +396,7 @@ unsafe extern "C" fn alloc_small(
     let mut slop: crate::stddef_h::size_t = 0;
     /* Check for unsatisfiable request (do now to ensure no overflow below) */
     if sizeofobject
-        > (1000000000 as libc::c_long as libc::c_ulong)
+        > (1000000000 as isize as libc::c_ulong)
             .wrapping_sub(::std::mem::size_of::<small_pool_hdr>() as libc::c_ulong)
     {
         out_of_memory(cinfo, 1 as i32); /* request exceeds malloc's ability */
@@ -440,8 +440,8 @@ unsafe extern "C" fn alloc_small(
             slop = extra_pool_slop[pool_id as usize]
         }
         /* Don't ask for more than MAX_ALLOC_CHUNK */
-        if slop > (1000000000 as libc::c_long as libc::c_ulong).wrapping_sub(min_request) {
-            slop = (1000000000 as libc::c_long as libc::c_ulong).wrapping_sub(min_request)
+        if slop > (1000000000 as isize as libc::c_ulong).wrapping_sub(min_request) {
+            slop = (1000000000 as isize as libc::c_ulong).wrapping_sub(min_request)
         }
         loop
         /* Try to get space, if fail reduce slop and try again */
@@ -462,7 +462,7 @@ unsafe extern "C" fn alloc_small(
         }
         (*mem).total_space_allocated = ((*mem).total_space_allocated as libc::c_ulong)
             .wrapping_add(min_request.wrapping_add(slop))
-            as libc::c_long as libc::c_long;
+            as isize as isize;
         /* Success, initialize the new pool header and add to end of list */
         (*hdr_ptr).hdr.next = 0 as small_pool_ptr;
         (*hdr_ptr).hdr.bytes_used = 0 as i32 as crate::stddef_h::size_t;
@@ -510,7 +510,7 @@ unsafe extern "C" fn alloc_large(
     let mut odd_bytes: crate::stddef_h::size_t = 0;
     /* Check for unsatisfiable request (do now to ensure no overflow below) */
     if sizeofobject
-        > (1000000000 as libc::c_long as libc::c_ulong)
+        > (1000000000 as isize as libc::c_ulong)
             .wrapping_sub(::std::mem::size_of::<large_pool_hdr>() as libc::c_ulong)
     {
         out_of_memory(cinfo, 3 as i32); /* request exceeds malloc's ability */
@@ -542,7 +542,7 @@ unsafe extern "C" fn alloc_large(
     }
     (*mem).total_space_allocated = ((*mem).total_space_allocated as libc::c_ulong).wrapping_add(
         sizeofobject.wrapping_add(::std::mem::size_of::<large_pool_hdr>() as libc::c_ulong),
-    ) as libc::c_long as libc::c_long;
+    ) as isize as isize;
     /* Success, initialize the new pool header and add to list */
     (*hdr_ptr).hdr.next = (*mem).large_list[pool_id as usize];
     /* We maintain space counts in each pool header for statistical purposes,
@@ -580,15 +580,15 @@ unsafe extern "C" fn alloc_sarray(
     let mut rowsperchunk: crate::jmorecfg_h::JDIMENSION = 0;
     let mut currow: crate::jmorecfg_h::JDIMENSION = 0;
     let mut i: crate::jmorecfg_h::JDIMENSION = 0;
-    let mut ltemp: libc::c_long = 0;
+    let mut ltemp: isize = 0;
     /* Calculate max # of rows allowed in one allocation chunk */
-    ltemp = (1000000000 as libc::c_long as libc::c_ulong)
+    ltemp = (1000000000 as isize as libc::c_ulong)
         .wrapping_sub(::std::mem::size_of::<large_pool_hdr>() as libc::c_ulong)
         .wrapping_div(
-            (samplesperrow as libc::c_long as libc::c_ulong)
+            (samplesperrow as isize as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::jmorecfg_h::JSAMPLE>() as libc::c_ulong),
-        ) as libc::c_long;
-    if ltemp <= 0 as i32 as libc::c_long {
+        ) as isize;
+    if ltemp <= 0 as i32 as isize {
         (*(*cinfo).err).msg_code = crate::src::jpeg_8c::jerror::JERR_WIDTH_OVERFLOW as i32;
         Some(
             (*(*cinfo).err)
@@ -597,7 +597,7 @@ unsafe extern "C" fn alloc_sarray(
         )
         .expect("non-null function pointer")(cinfo);
     }
-    if ltemp < numrows as libc::c_long {
+    if ltemp < numrows as isize {
         rowsperchunk = ltemp as crate::jmorecfg_h::JDIMENSION
     } else {
         rowsperchunk = numrows
@@ -655,15 +655,15 @@ unsafe extern "C" fn alloc_barray(
     let mut rowsperchunk: crate::jmorecfg_h::JDIMENSION = 0;
     let mut currow: crate::jmorecfg_h::JDIMENSION = 0;
     let mut i: crate::jmorecfg_h::JDIMENSION = 0;
-    let mut ltemp: libc::c_long = 0;
+    let mut ltemp: isize = 0;
     /* Calculate max # of rows allowed in one allocation chunk */
-    ltemp = (1000000000 as libc::c_long as libc::c_ulong)
+    ltemp = (1000000000 as isize as libc::c_ulong)
         .wrapping_sub(::std::mem::size_of::<large_pool_hdr>() as libc::c_ulong)
         .wrapping_div(
-            (blocksperrow as libc::c_long as libc::c_ulong)
+            (blocksperrow as isize as libc::c_ulong)
                 .wrapping_mul(::std::mem::size_of::<crate::jpeglib_h::JBLOCK>() as libc::c_ulong),
-        ) as libc::c_long;
-    if ltemp <= 0 as i32 as libc::c_long {
+        ) as isize;
+    if ltemp <= 0 as i32 as isize {
         (*(*cinfo).err).msg_code = crate::src::jpeg_8c::jerror::JERR_WIDTH_OVERFLOW as i32;
         Some(
             (*(*cinfo).err)
@@ -672,7 +672,7 @@ unsafe extern "C" fn alloc_barray(
         )
         .expect("non-null function pointer")(cinfo);
     }
-    if ltemp < numrows as libc::c_long {
+    if ltemp < numrows as isize {
         rowsperchunk = ltemp as crate::jmorecfg_h::JDIMENSION
     } else {
         rowsperchunk = numrows
@@ -830,37 +830,37 @@ unsafe extern "C" fn realize_virt_arrays(mut cinfo: crate::jpeglib_h::j_common_p
 /* Allocate the in-memory buffers for any unrealized virtual arrays */
 {
     let mut mem: my_mem_ptr = (*cinfo).mem as my_mem_ptr;
-    let mut space_per_minheight: libc::c_long = 0;
-    let mut maximum_space: libc::c_long = 0;
-    let mut avail_mem: libc::c_long = 0;
-    let mut minheights: libc::c_long = 0;
-    let mut max_minheights: libc::c_long = 0;
+    let mut space_per_minheight: isize = 0;
+    let mut maximum_space: isize = 0;
+    let mut avail_mem: isize = 0;
+    let mut minheights: isize = 0;
+    let mut max_minheights: isize = 0;
     let mut sptr: crate::jpeglib_h::jvirt_sarray_ptr = 0 as *mut jvirt_sarray_control;
     let mut bptr: crate::jpeglib_h::jvirt_barray_ptr = 0 as *mut jvirt_barray_control;
     /* Compute the minimum space needed (maxaccess rows in each buffer)
      * and the maximum space needed (full image height in each buffer).
      * These may be of use to the system-dependent jpeg_mem_available routine.
      */
-    space_per_minheight = 0 as i32 as libc::c_long;
-    maximum_space = 0 as i32 as libc::c_long;
+    space_per_minheight = 0 as i32 as isize;
+    maximum_space = 0 as i32 as isize;
     sptr = (*mem).virt_sarray_list;
     while !sptr.is_null() {
         if (*sptr).mem_buffer.is_null() {
             /* if not realized yet */
             space_per_minheight = (space_per_minheight as libc::c_ulong).wrapping_add(
-                (((*sptr).maxaccess as libc::c_long * (*sptr).samplesperrow as libc::c_long)
+                (((*sptr).maxaccess as isize * (*sptr).samplesperrow as isize)
                     as libc::c_ulong)
                     .wrapping_mul(
                         ::std::mem::size_of::<crate::jmorecfg_h::JSAMPLE>() as libc::c_ulong
                     ),
-            ) as libc::c_long as libc::c_long;
+            ) as isize as isize;
             maximum_space = (maximum_space as libc::c_ulong).wrapping_add(
-                (((*sptr).rows_in_array as libc::c_long * (*sptr).samplesperrow as libc::c_long)
+                (((*sptr).rows_in_array as isize * (*sptr).samplesperrow as isize)
                     as libc::c_ulong)
                     .wrapping_mul(
                         ::std::mem::size_of::<crate::jmorecfg_h::JSAMPLE>() as libc::c_ulong
                     ),
-            ) as libc::c_long as libc::c_long
+            ) as isize as isize
         }
         sptr = (*sptr).next
     }
@@ -869,23 +869,23 @@ unsafe extern "C" fn realize_virt_arrays(mut cinfo: crate::jpeglib_h::j_common_p
         if (*bptr).mem_buffer.is_null() {
             /* if not realized yet */
             space_per_minheight = (space_per_minheight as libc::c_ulong).wrapping_add(
-                (((*bptr).maxaccess as libc::c_long * (*bptr).blocksperrow as libc::c_long)
+                (((*bptr).maxaccess as isize * (*bptr).blocksperrow as isize)
                     as libc::c_ulong)
                     .wrapping_mul(
                         ::std::mem::size_of::<crate::jpeglib_h::JBLOCK>() as libc::c_ulong
                     ),
-            ) as libc::c_long as libc::c_long; /* no unrealized arrays, no work */
+            ) as isize as isize; /* no unrealized arrays, no work */
             maximum_space = (maximum_space as libc::c_ulong).wrapping_add(
-                (((*bptr).rows_in_array as libc::c_long * (*bptr).blocksperrow as libc::c_long)
+                (((*bptr).rows_in_array as isize * (*bptr).blocksperrow as isize)
                     as libc::c_ulong)
                     .wrapping_mul(
                         ::std::mem::size_of::<crate::jpeglib_h::JBLOCK>() as libc::c_ulong
                     ),
-            ) as libc::c_long as libc::c_long
+            ) as isize as isize
         }
         bptr = (*bptr).next
     }
-    if space_per_minheight <= 0 as i32 as libc::c_long {
+    if space_per_minheight <= 0 as i32 as isize {
         return;
     }
     /* Determine amount of memory to actually use; this is system-dependent. */
@@ -900,14 +900,14 @@ unsafe extern "C" fn realize_virt_arrays(mut cinfo: crate::jpeglib_h::j_common_p
      * in each buffer.
      */
     if avail_mem >= maximum_space {
-        max_minheights = 1000000000 as libc::c_long
+        max_minheights = 1000000000 as isize
     } else {
         max_minheights = avail_mem / space_per_minheight;
         /* If there doesn't seem to be enough space, try to get the minimum
          * anyway.  This allows a "stub" implementation of jpeg_mem_available().
          */
-        if max_minheights <= 0 as i32 as libc::c_long {
-            max_minheights = 1 as i32 as libc::c_long
+        if max_minheights <= 0 as i32 as isize {
+            max_minheights = 1 as i32 as isize
         }
     }
     /* Allocate the in-memory buffers and initialize backing store as needed. */
@@ -915,23 +915,23 @@ unsafe extern "C" fn realize_virt_arrays(mut cinfo: crate::jpeglib_h::j_common_p
     while !sptr.is_null() {
         if (*sptr).mem_buffer.is_null() {
             /* if not realized yet */
-            minheights = ((*sptr).rows_in_array as libc::c_long - 1 as libc::c_long)
-                / (*sptr).maxaccess as libc::c_long
-                + 1 as libc::c_long;
+            minheights = ((*sptr).rows_in_array as isize - 1 as isize)
+                / (*sptr).maxaccess as isize
+                + 1 as isize;
             if minheights <= max_minheights {
                 /* This buffer fits in memory */
                 (*sptr).rows_in_mem = (*sptr).rows_in_array
             } else {
                 /* It doesn't fit in memory, create backing store. */
-                (*sptr).rows_in_mem = (max_minheights * (*sptr).maxaccess as libc::c_long)
+                (*sptr).rows_in_mem = (max_minheights * (*sptr).maxaccess as isize)
                     as crate::jmorecfg_h::JDIMENSION;
                 crate::src::jpeg_8c::jmemnobs::jpeg_open_backing_store(
                     cinfo as *mut crate::jpeglib_h::jpeg_common_struct,
                     &mut (*sptr).b_s_info as *mut _ as *mut crate::jmemsys_h::backing_store_struct,
-                    (*sptr).rows_in_array as libc::c_long
-                        * (*sptr).samplesperrow as libc::c_long
+                    (*sptr).rows_in_array as isize
+                        * (*sptr).samplesperrow as isize
                         * ::std::mem::size_of::<crate::jmorecfg_h::JSAMPLE>() as libc::c_ulong
-                            as libc::c_long,
+                            as isize,
                 );
                 (*sptr).b_s_open = 1 as i32
             }
@@ -948,23 +948,23 @@ unsafe extern "C" fn realize_virt_arrays(mut cinfo: crate::jpeglib_h::j_common_p
     while !bptr.is_null() {
         if (*bptr).mem_buffer.is_null() {
             /* if not realized yet */
-            minheights = ((*bptr).rows_in_array as libc::c_long - 1 as libc::c_long)
-                / (*bptr).maxaccess as libc::c_long
-                + 1 as libc::c_long;
+            minheights = ((*bptr).rows_in_array as isize - 1 as isize)
+                / (*bptr).maxaccess as isize
+                + 1 as isize;
             if minheights <= max_minheights {
                 /* This buffer fits in memory */
                 (*bptr).rows_in_mem = (*bptr).rows_in_array
             } else {
                 /* It doesn't fit in memory, create backing store. */
-                (*bptr).rows_in_mem = (max_minheights * (*bptr).maxaccess as libc::c_long)
+                (*bptr).rows_in_mem = (max_minheights * (*bptr).maxaccess as isize)
                     as crate::jmorecfg_h::JDIMENSION;
                 crate::src::jpeg_8c::jmemnobs::jpeg_open_backing_store(
                     cinfo as *mut crate::jpeglib_h::jpeg_common_struct,
                     &mut (*bptr).b_s_info as *mut _ as *mut crate::jmemsys_h::backing_store_struct,
-                    (*bptr).rows_in_array as libc::c_long
-                        * (*bptr).blocksperrow as libc::c_long
+                    (*bptr).rows_in_array as isize
+                        * (*bptr).blocksperrow as isize
                         * ::std::mem::size_of::<crate::jpeglib_h::JBLOCK>() as libc::c_ulong
-                            as libc::c_long,
+                            as isize,
                 );
                 (*bptr).b_s_open = 1 as i32
             }
@@ -986,39 +986,39 @@ unsafe extern "C" fn do_sarray_io(
 )
 /* Do backing store read or write of a virtual sample array */
 {
-    let mut bytesperrow: libc::c_long = 0;
-    let mut file_offset: libc::c_long = 0;
-    let mut byte_count: libc::c_long = 0;
-    let mut rows: libc::c_long = 0;
-    let mut thisrow: libc::c_long = 0;
-    let mut i: libc::c_long = 0;
-    bytesperrow = ((*ptr).samplesperrow as libc::c_long as libc::c_ulong)
+    let mut bytesperrow: isize = 0;
+    let mut file_offset: isize = 0;
+    let mut byte_count: isize = 0;
+    let mut rows: isize = 0;
+    let mut thisrow: isize = 0;
+    let mut i: isize = 0;
+    bytesperrow = ((*ptr).samplesperrow as isize as libc::c_ulong)
         .wrapping_mul(::std::mem::size_of::<crate::jmorecfg_h::JSAMPLE>() as libc::c_ulong)
-        as libc::c_long;
-    file_offset = (*ptr).cur_start_row as libc::c_long * bytesperrow;
+        as isize;
+    file_offset = (*ptr).cur_start_row as isize * bytesperrow;
     /* Loop to read or write each allocation chunk in mem_buffer */
-    i = 0 as i32 as libc::c_long;
-    while i < (*ptr).rows_in_mem as libc::c_long {
+    i = 0 as i32 as isize;
+    while i < (*ptr).rows_in_mem as isize {
         /* One chunk, but check for short chunk at end of buffer */
-        rows = if ((*ptr).rowsperchunk as libc::c_long) < (*ptr).rows_in_mem as libc::c_long - i {
-            (*ptr).rowsperchunk as libc::c_long
+        rows = if ((*ptr).rowsperchunk as isize) < (*ptr).rows_in_mem as isize - i {
+            (*ptr).rowsperchunk as isize
         } else {
-            ((*ptr).rows_in_mem as libc::c_long) - i
+            ((*ptr).rows_in_mem as isize) - i
         };
         /* Transfer no more than is currently defined */
-        thisrow = (*ptr).cur_start_row as libc::c_long + i;
-        rows = if rows < (*ptr).first_undef_row as libc::c_long - thisrow {
+        thisrow = (*ptr).cur_start_row as isize + i;
+        rows = if rows < (*ptr).first_undef_row as isize - thisrow {
             rows
         } else {
-            ((*ptr).first_undef_row as libc::c_long) - thisrow
+            ((*ptr).first_undef_row as isize) - thisrow
         };
         /* Transfer no more than fits in file */
-        rows = if rows < (*ptr).rows_in_array as libc::c_long - thisrow {
+        rows = if rows < (*ptr).rows_in_array as isize - thisrow {
             rows
         } else {
-            ((*ptr).rows_in_array as libc::c_long) - thisrow
+            ((*ptr).rows_in_array as isize) - thisrow
         };
-        if rows <= 0 as i32 as libc::c_long {
+        if rows <= 0 as i32 as isize {
             break;
         }
         byte_count = rows * bytesperrow;
@@ -1052,7 +1052,7 @@ unsafe extern "C" fn do_sarray_io(
             );
         }
         file_offset += byte_count;
-        i += (*ptr).rowsperchunk as libc::c_long
+        i += (*ptr).rowsperchunk as isize
     }
 }
 
@@ -1063,39 +1063,39 @@ unsafe extern "C" fn do_barray_io(
 )
 /* Do backing store read or write of a virtual coefficient-block array */
 {
-    let mut bytesperrow: libc::c_long = 0;
-    let mut file_offset: libc::c_long = 0;
-    let mut byte_count: libc::c_long = 0;
-    let mut rows: libc::c_long = 0;
-    let mut thisrow: libc::c_long = 0;
-    let mut i: libc::c_long = 0;
-    bytesperrow = ((*ptr).blocksperrow as libc::c_long as libc::c_ulong)
+    let mut bytesperrow: isize = 0;
+    let mut file_offset: isize = 0;
+    let mut byte_count: isize = 0;
+    let mut rows: isize = 0;
+    let mut thisrow: isize = 0;
+    let mut i: isize = 0;
+    bytesperrow = ((*ptr).blocksperrow as isize as libc::c_ulong)
         .wrapping_mul(::std::mem::size_of::<crate::jpeglib_h::JBLOCK>() as libc::c_ulong)
-        as libc::c_long;
-    file_offset = (*ptr).cur_start_row as libc::c_long * bytesperrow;
+        as isize;
+    file_offset = (*ptr).cur_start_row as isize * bytesperrow;
     /* Loop to read or write each allocation chunk in mem_buffer */
-    i = 0 as i32 as libc::c_long;
-    while i < (*ptr).rows_in_mem as libc::c_long {
+    i = 0 as i32 as isize;
+    while i < (*ptr).rows_in_mem as isize {
         /* One chunk, but check for short chunk at end of buffer */
-        rows = if ((*ptr).rowsperchunk as libc::c_long) < (*ptr).rows_in_mem as libc::c_long - i {
-            (*ptr).rowsperchunk as libc::c_long
+        rows = if ((*ptr).rowsperchunk as isize) < (*ptr).rows_in_mem as isize - i {
+            (*ptr).rowsperchunk as isize
         } else {
-            ((*ptr).rows_in_mem as libc::c_long) - i
+            ((*ptr).rows_in_mem as isize) - i
         };
         /* Transfer no more than is currently defined */
-        thisrow = (*ptr).cur_start_row as libc::c_long + i;
-        rows = if rows < (*ptr).first_undef_row as libc::c_long - thisrow {
+        thisrow = (*ptr).cur_start_row as isize + i;
+        rows = if rows < (*ptr).first_undef_row as isize - thisrow {
             rows
         } else {
-            ((*ptr).first_undef_row as libc::c_long) - thisrow
+            ((*ptr).first_undef_row as isize) - thisrow
         };
         /* Transfer no more than fits in file */
-        rows = if rows < (*ptr).rows_in_array as libc::c_long - thisrow {
+        rows = if rows < (*ptr).rows_in_array as isize - thisrow {
             rows
         } else {
-            ((*ptr).rows_in_array as libc::c_long) - thisrow
+            ((*ptr).rows_in_array as isize) - thisrow
         };
-        if rows <= 0 as i32 as libc::c_long {
+        if rows <= 0 as i32 as isize {
             break;
         }
         byte_count = rows * bytesperrow;
@@ -1129,7 +1129,7 @@ unsafe extern "C" fn do_barray_io(
             );
         }
         file_offset += byte_count;
-        i += (*ptr).rowsperchunk as libc::c_long
+        i += (*ptr).rowsperchunk as isize
     }
 }
 
@@ -1185,10 +1185,10 @@ unsafe extern "C" fn access_virt_sarray(
             (*ptr).cur_start_row = start_row
         } else {
             /* use long arithmetic here to avoid overflow & unsigned problems */
-            let mut ltemp: libc::c_long = 0; /* don't fall off front end of file */
-            ltemp = end_row as libc::c_long - (*ptr).rows_in_mem as libc::c_long;
-            if ltemp < 0 as i32 as libc::c_long {
-                ltemp = 0 as i32 as libc::c_long
+            let mut ltemp: isize = 0; /* don't fall off front end of file */
+            ltemp = end_row as isize - (*ptr).rows_in_mem as isize;
+            if ltemp < 0 as i32 as isize {
+                ltemp = 0 as i32 as isize
             }
             (*ptr).cur_start_row = ltemp as crate::jmorecfg_h::JDIMENSION
         }
@@ -1313,10 +1313,10 @@ unsafe extern "C" fn access_virt_barray(
             (*ptr).cur_start_row = start_row
         } else {
             /* use long arithmetic here to avoid overflow & unsigned problems */
-            let mut ltemp: libc::c_long = 0; /* don't fall off front end of file */
-            ltemp = end_row as libc::c_long - (*ptr).rows_in_mem as libc::c_long;
-            if ltemp < 0 as i32 as libc::c_long {
-                ltemp = 0 as i32 as libc::c_long
+            let mut ltemp: isize = 0; /* don't fall off front end of file */
+            ltemp = end_row as isize - (*ptr).rows_in_mem as isize;
+            if ltemp < 0 as i32 as isize {
+                ltemp = 0 as i32 as isize
             }
             (*ptr).cur_start_row = ltemp as crate::jmorecfg_h::JDIMENSION
         }
@@ -1460,8 +1460,8 @@ unsafe extern "C" fn free_pool(mut cinfo: crate::jpeglib_h::j_common_ptr, mut po
             space_freed,
         );
         (*mem).total_space_allocated = ((*mem).total_space_allocated as libc::c_ulong)
-            .wrapping_sub(space_freed) as libc::c_long
-            as libc::c_long;
+            .wrapping_sub(space_freed) as isize
+            as isize;
         lhdr_ptr = next_lhdr_ptr
     }
     /* Release small objects */
@@ -1480,8 +1480,8 @@ unsafe extern "C" fn free_pool(mut cinfo: crate::jpeglib_h::j_common_ptr, mut po
             space_freed,
         );
         (*mem).total_space_allocated = ((*mem).total_space_allocated as libc::c_ulong)
-            .wrapping_sub(space_freed) as libc::c_long
-            as libc::c_long;
+            .wrapping_sub(space_freed) as isize
+            as isize;
         shdr_ptr = next_shdr_ptr
     }
 }
@@ -1521,7 +1521,7 @@ unsafe extern "C" fn self_destruct(mut cinfo: crate::jpeglib_h::j_common_ptr) {
 
 pub unsafe extern "C" fn jinit_memory_mgr(mut cinfo: crate::jpeglib_h::j_common_ptr) {
     let mut mem: my_mem_ptr = 0 as *mut my_memory_mgr; /* for safety if init fails */
-    let mut max_to_use: libc::c_long = 0;
+    let mut max_to_use: isize = 0;
     let mut pool: i32 = 0;
     let mut test_mac: crate::stddef_h::size_t = 0;
     (*cinfo).mem = 0 as *mut crate::jpeglib_h::jpeg_memory_mgr;
@@ -1549,9 +1549,9 @@ pub unsafe extern "C" fn jinit_memory_mgr(mut cinfo: crate::jpeglib_h::j_common_
      * Again, an "unreachable code" warning may be ignored here.
      * But a "constant too large" warning means you need to fix MAX_ALLOC_CHUNK.
      */
-    test_mac = 1000000000 as libc::c_long as crate::stddef_h::size_t; /* system-dependent initialization */
-    if test_mac as libc::c_long != 1000000000 as libc::c_long
-        || (1000000000 as libc::c_long as libc::c_ulong)
+    test_mac = 1000000000 as isize as crate::stddef_h::size_t; /* system-dependent initialization */
+    if test_mac as isize != 1000000000 as isize
+        || (1000000000 as isize as libc::c_ulong)
             .wrapping_rem(::std::mem::size_of::<f64>() as libc::c_ulong)
             != 0 as i32 as libc::c_ulong
     {
@@ -1668,7 +1668,7 @@ pub unsafe extern "C" fn jinit_memory_mgr(mut cinfo: crate::jpeglib_h::j_common_
     (*mem).pub_0.self_destruct =
         Some(self_destruct as unsafe extern "C" fn(_: crate::jpeglib_h::j_common_ptr) -> ());
     /* Make MAX_ALLOC_CHUNK accessible to other modules */
-    (*mem).pub_0.max_alloc_chunk = 1000000000 as libc::c_long;
+    (*mem).pub_0.max_alloc_chunk = 1000000000 as isize;
     /* Initialize working state */
     (*mem).pub_0.max_memory_to_use = max_to_use;
     pool = 2 as i32 - 1 as i32;
@@ -1680,7 +1680,7 @@ pub unsafe extern "C" fn jinit_memory_mgr(mut cinfo: crate::jpeglib_h::j_common_
     (*mem).virt_sarray_list = 0 as crate::jpeglib_h::jvirt_sarray_ptr;
     (*mem).virt_barray_list = 0 as crate::jpeglib_h::jvirt_barray_ptr;
     (*mem).total_space_allocated =
-        ::std::mem::size_of::<my_memory_mgr>() as libc::c_ulong as libc::c_long;
+        ::std::mem::size_of::<my_memory_mgr>() as libc::c_ulong as isize;
     /* Declare ourselves open for business */
     (*cinfo).mem = &mut (*mem).pub_0;
     /* Check for an environment variable JPEGMEM; if found, override the
@@ -1696,14 +1696,14 @@ pub unsafe extern "C" fn jinit_memory_mgr(mut cinfo: crate::jpeglib_h::j_common_
         if ::libc::sscanf(
             memenv,
             b"%ld%c\x00" as *const u8 as *const libc::c_char,
-            &mut max_to_use as *mut libc::c_long,
+            &mut max_to_use as *mut isize,
             &mut ch as *mut libc::c_char,
         ) > 0 as i32
         {
             if ch as i32 == 'm' as i32 || ch as i32 == 'M' as i32 {
-                max_to_use *= 1000 as libc::c_long
+                max_to_use *= 1000 as isize
             }
-            (*mem).pub_0.max_memory_to_use = max_to_use * 1000 as libc::c_long
+            (*mem).pub_0.max_memory_to_use = max_to_use * 1000 as isize
         }
     };
 }

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jmemnobs.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jmemnobs.rs
@@ -303,10 +303,10 @@ pub unsafe extern "C" fn jpeg_free_large(
 
 pub unsafe extern "C" fn jpeg_mem_available(
     mut _cinfo: crate::jpeglib_h::j_common_ptr,
-    mut _min_bytes_needed: libc::c_long,
-    mut max_bytes_needed: libc::c_long,
-    mut _already_allocated: libc::c_long,
-) -> libc::c_long {
+    mut _min_bytes_needed: isize,
+    mut max_bytes_needed: isize,
+    mut _already_allocated: isize,
+) -> isize {
     return max_bytes_needed;
 }
 /*
@@ -326,7 +326,7 @@ pub unsafe extern "C" fn jpeg_mem_available(
 pub unsafe extern "C" fn jpeg_open_backing_store(
     mut cinfo: crate::jpeglib_h::j_common_ptr,
     mut _info: crate::jmemsys_h::backing_store_ptr,
-    mut _total_bytes_needed: libc::c_long,
+    mut _total_bytes_needed: isize,
 ) {
     (*(*cinfo).err).msg_code = crate::src::jpeg_8c::jerror::JERR_NO_BACKING_STORE as i32;
     Some(
@@ -353,8 +353,8 @@ pub unsafe extern "C" fn jpeg_open_backing_store(
  */
 #[no_mangle]
 
-pub unsafe extern "C" fn jpeg_mem_init(mut _cinfo: crate::jpeglib_h::j_common_ptr) -> libc::c_long {
-    return 0 as i32 as libc::c_long;
+pub unsafe extern "C" fn jpeg_mem_init(mut _cinfo: crate::jpeglib_h::j_common_ptr) -> isize {
+    return 0 as i32 as isize;
     /* just set max_memory_to_use to 0 */
 }
 #[no_mangle]

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jquant1.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jquant1.rs
@@ -571,20 +571,20 @@ unsafe extern "C" fn select_ncolors(
     let mut i: i32 = 0;
     let mut j: i32 = 0;
     let mut changed: crate::jmorecfg_h::boolean = 0;
-    let mut temp: libc::c_long = 0;
+    let mut temp: isize = 0;
     static mut RGB_order: [i32; 3] = [1 as i32, 0 as i32, 2 as i32];
     /* We can allocate at least the nc'th root of max_colors per component. */
     /* Compute floor(nc'th root of max_colors). */
     iroot = 1 as i32; /* repeat till iroot exceeds root */
     loop {
         iroot += 1; /* set temp = iroot ** nc */
-        temp = iroot as libc::c_long; /* now iroot = floor(root) */
+        temp = iroot as isize; /* now iroot = floor(root) */
         i = 1 as i32;
         while i < nc {
-            temp *= iroot as libc::c_long;
+            temp *= iroot as isize;
             i += 1
         }
-        if !(temp <= max_colors as libc::c_long) {
+        if !(temp <= max_colors as isize) {
             break;
         }
     }
@@ -625,9 +625,9 @@ unsafe extern "C" fn select_ncolors(
                 i
             };
             /* calculate new total_colors if Ncolors[j] is incremented */
-            temp = (total_colors / *Ncolors.offset(j as isize)) as libc::c_long; /* done in long arith to avoid oflo */
-            temp *= (*Ncolors.offset(j as isize) + 1 as i32) as libc::c_long; /* won't fit, done with this pass */
-            if temp > max_colors as libc::c_long {
+            temp = (total_colors / *Ncolors.offset(j as isize)) as isize; /* done in long arith to avoid oflo */
+            temp *= (*Ncolors.offset(j as isize) + 1 as i32) as isize; /* won't fit, done with this pass */
+            if temp > max_colors as isize {
                 break; /* OK, apply the increment */
             }
             let ref mut fresh0 = *Ncolors.offset(j as isize);
@@ -656,9 +656,9 @@ unsafe extern "C" fn output_value(
      * (Forcing the upper and lower values to the limits ensures that
      * dithering can't produce a color outside the selected gamut.)
      */
-    return ((j as crate::jmorecfg_h::INT32 * 255 as i32 as libc::c_long
-        + (maxj / 2 as i32) as libc::c_long)
-        / maxj as libc::c_long) as i32;
+    return ((j as crate::jmorecfg_h::INT32 * 255 as i32 as isize
+        + (maxj / 2 as i32) as isize)
+        / maxj as isize) as i32;
 }
 
 unsafe extern "C" fn largest_input_value(
@@ -670,9 +670,9 @@ unsafe extern "C" fn largest_input_value(
 /* Return largest input value that should map to j'th output value */
 /* Must have largest(j=0) >= 0, and largest(j=maxj) >= MAXJSAMPLE */ {
     /* Breakpoints are halfway between values returned by output_value */
-    return (((2 as i32 * j + 1 as i32) as crate::jmorecfg_h::INT32 * 255 as i32 as libc::c_long
-        + maxj as libc::c_long)
-        / (2 as i32 * maxj) as libc::c_long) as i32;
+    return (((2 as i32 * j + 1 as i32) as crate::jmorecfg_h::INT32 * 255 as i32 as isize
+        + maxj as isize)
+        / (2 as i32 * maxj) as isize) as i32;
 }
 /*
  * Create the colormap.
@@ -877,7 +877,7 @@ unsafe extern "C" fn make_odither_array(
      * (f=0..N-1) should be (N-1-2*f)/(2*N) * MAXJSAMPLE/(ncolors-1).
      * On 16-bit-int machine, be careful to avoid overflow.
      */
-    den = (2 as i32 * (16 as i32 * 16 as i32)) as libc::c_long
+    den = (2 as i32 * (16 as i32 * 16 as i32)) as isize
         * (ncolors - 1 as i32) as crate::jmorecfg_h::INT32;
     j = 0 as i32;
     while j < 16 as i32 {
@@ -887,11 +887,11 @@ unsafe extern "C" fn make_odither_array(
                 - 1 as i32
                 - 2 as i32 * base_dither_matrix[j as usize][k as usize] as i32)
                 as crate::jmorecfg_h::INT32
-                * 255 as i32 as libc::c_long;
+                * 255 as i32 as isize;
             /* Ensure round towards zero despite C's lack of consistency
              * about rounding negative values in integer division...
              */
-            (*odither.offset(j as isize))[k as usize] = if num < 0 as i32 as libc::c_long {
+            (*odither.offset(j as isize))[k as usize] = if num < 0 as i32 as isize {
                 -(-num / den)
             } else {
                 (num) / den

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jquant2.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jquant2.rs
@@ -267,7 +267,7 @@ pub struct box_0 {
     pub c2min: i32,
     pub c2max: i32,
     pub volume: crate::jmorecfg_h::INT32,
-    pub colorcount: libc::c_long,
+    pub colorcount: isize,
 }
 /* histogram cell; prefer an unsigned type */
 
@@ -326,12 +326,12 @@ unsafe extern "C" fn find_biggest_color_pop(mut boxlist: boxptr, mut numboxes: i
 /* Returns NULL if no splittable boxes remain */ {
     let mut boxp: boxptr = 0 as *mut box_0;
     let mut i: i32 = 0;
-    let mut maxc: libc::c_long = 0 as i32 as libc::c_long;
+    let mut maxc: isize = 0 as i32 as isize;
     let mut which: boxptr = 0 as boxptr;
     i = 0 as i32;
     boxp = boxlist;
     while i < numboxes {
-        if (*boxp).colorcount > maxc && (*boxp).volume > 0 as i32 as libc::c_long {
+        if (*boxp).colorcount > maxc && (*boxp).volume > 0 as i32 as isize {
             which = boxp;
             maxc = (*boxp).colorcount
         }
@@ -380,7 +380,7 @@ unsafe extern "C" fn update_box(mut cinfo: crate::jpeglib_h::j_decompress_ptr, m
     let mut dist0: crate::jmorecfg_h::INT32 = 0;
     let mut dist1: crate::jmorecfg_h::INT32 = 0;
     let mut dist2: crate::jmorecfg_h::INT32 = 0;
-    let mut ccount: libc::c_long = 0;
+    let mut ccount: isize = 0;
     c0min = (*boxp).c0min;
     c0max = (*boxp).c0max;
     c1min = (*boxp).c1min;
@@ -548,7 +548,7 @@ unsafe extern "C" fn update_box(mut cinfo: crate::jpeglib_h::j_decompress_ptr, m
     dist2 = ((c2max - c2min << 8 as i32 - 5 as i32) * 1 as i32) as crate::jmorecfg_h::INT32;
     (*boxp).volume = dist0 * dist0 + dist1 * dist1 + dist2 * dist2;
     /* Now scan remaining volume of box and compute population */
-    ccount = 0 as i32 as libc::c_long;
+    ccount = 0 as i32 as isize;
     c0 = c0min;
     while c0 <= c0max {
         c1 = c1min;
@@ -678,11 +678,11 @@ unsafe extern "C" fn compute_color(
     let mut c1max: i32 = 0;
     let mut c2min: i32 = 0;
     let mut c2max: i32 = 0;
-    let mut count: libc::c_long = 0;
-    let mut total: libc::c_long = 0 as i32 as libc::c_long;
-    let mut c0total: libc::c_long = 0 as i32 as libc::c_long;
-    let mut c1total: libc::c_long = 0 as i32 as libc::c_long;
-    let mut c2total: libc::c_long = 0 as i32 as libc::c_long;
+    let mut count: isize = 0;
+    let mut total: isize = 0 as i32 as isize;
+    let mut c0total: isize = 0 as i32 as isize;
+    let mut c1total: isize = 0 as i32 as isize;
+    let mut c2total: isize = 0 as i32 as isize;
     c0min = (*boxp).c0min;
     c0max = (*boxp).c0max;
     c1min = (*boxp).c1min;
@@ -700,20 +700,20 @@ unsafe extern "C" fn compute_color(
             while c2 <= c2max {
                 let fresh4 = histp;
                 histp = histp.offset(1);
-                count = *fresh4 as libc::c_long;
-                if count != 0 as i32 as libc::c_long {
+                count = *fresh4 as isize;
+                if count != 0 as i32 as isize {
                     total += count;
                     c0total += ((c0 << 8 as i32 - 5 as i32)
                         + ((1 as i32) << 8 as i32 - 5 as i32 >> 1 as i32))
-                        as libc::c_long
+                        as isize
                         * count;
                     c1total += ((c1 << 8 as i32 - 6 as i32)
                         + ((1 as i32) << 8 as i32 - 6 as i32 >> 1 as i32))
-                        as libc::c_long
+                        as isize
                         * count;
                     c2total += ((c2 << 8 as i32 - 5 as i32)
                         + ((1 as i32) << 8 as i32 - 5 as i32 >> 1 as i32))
-                        as libc::c_long
+                        as isize
                         * count
                 }
                 c2 += 1
@@ -843,7 +843,7 @@ unsafe extern "C" fn find_nearby_colors(
      * We save the minimum distance for each color in mindist[];
      * only the smallest maximum distance is of interest.
      */
-    minmaxdist = 0x7fffffff as libc::c_long;
+    minmaxdist = 0x7fffffff as isize;
     i = 0 as i32;
     while i < numcolors {
         /* We compute the squared-c0-distance term, then add in the other two. */
@@ -973,7 +973,7 @@ unsafe extern "C" fn find_best_colors(
     while i >= 0 as i32 {
         let fresh6 = bptr;
         bptr = bptr.offset(1);
-        *fresh6 = 0x7fffffff as libc::c_long;
+        *fresh6 = 0x7fffffff as isize;
         i -= 1
     }
     /* For each color selected by find_nearby_colors,
@@ -998,18 +998,18 @@ unsafe extern "C" fn find_best_colors(
             * 1 as i32) as crate::jmorecfg_h::INT32;
         dist0 += inc2 * inc2;
         /* Form the initial difference increments */
-        inc0 = inc0 * (2 as i32 * (((1 as i32) << 8 as i32 - 5 as i32) * 2 as i32)) as libc::c_long
+        inc0 = inc0 * (2 as i32 * (((1 as i32) << 8 as i32 - 5 as i32) * 2 as i32)) as isize
             + (((1 as i32) << 8 as i32 - 5 as i32)
                 * 2 as i32
-                * (((1 as i32) << 8 as i32 - 5 as i32) * 2 as i32)) as libc::c_long;
-        inc1 = inc1 * (2 as i32 * (((1 as i32) << 8 as i32 - 6 as i32) * 3 as i32)) as libc::c_long
+                * (((1 as i32) << 8 as i32 - 5 as i32) * 2 as i32)) as isize;
+        inc1 = inc1 * (2 as i32 * (((1 as i32) << 8 as i32 - 6 as i32) * 3 as i32)) as isize
             + (((1 as i32) << 8 as i32 - 6 as i32)
                 * 3 as i32
-                * (((1 as i32) << 8 as i32 - 6 as i32) * 3 as i32)) as libc::c_long;
-        inc2 = inc2 * (2 as i32 * (((1 as i32) << 8 as i32 - 5 as i32) * 1 as i32)) as libc::c_long
+                * (((1 as i32) << 8 as i32 - 6 as i32) * 3 as i32)) as isize;
+        inc2 = inc2 * (2 as i32 * (((1 as i32) << 8 as i32 - 5 as i32) * 1 as i32)) as isize
             + (((1 as i32) << 8 as i32 - 5 as i32)
                 * 1 as i32
-                * (((1 as i32) << 8 as i32 - 5 as i32) * 1 as i32)) as libc::c_long;
+                * (((1 as i32) << 8 as i32 - 5 as i32) * 1 as i32)) as isize;
         /* Now loop over all cells in box, updating distance per Thomas method */
         bptr = bestdist.as_mut_ptr();
         cptr = bestcolor;
@@ -1032,7 +1032,7 @@ unsafe extern "C" fn find_best_colors(
                     xx2 += (2 as i32
                         * (((1 as i32) << 8 as i32 - 5 as i32) * 1 as i32)
                         * (((1 as i32) << 8 as i32 - 5 as i32) * 1 as i32))
-                        as libc::c_long;
+                        as isize;
                     bptr = bptr.offset(1);
                     cptr = cptr.offset(1);
                     ic2 -= 1
@@ -1041,14 +1041,14 @@ unsafe extern "C" fn find_best_colors(
                 xx1 += (2 as i32
                     * (((1 as i32) << 8 as i32 - 6 as i32) * 3 as i32)
                     * (((1 as i32) << 8 as i32 - 6 as i32) * 3 as i32))
-                    as libc::c_long;
+                    as isize;
                 ic1 -= 1
             }
             dist0 += xx0;
             xx0 += (2 as i32
                 * (((1 as i32) << 8 as i32 - 5 as i32) * 2 as i32)
                 * (((1 as i32) << 8 as i32 - 5 as i32) * 2 as i32))
-                as libc::c_long;
+                as isize;
             ic0 -= 1
         }
         i += 1

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jutils.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeg_8c/jutils.rs
@@ -115,17 +115,17 @@ pub static mut jpeg_natural_order2: [i32; 20] = [
  */
 #[no_mangle]
 
-pub unsafe extern "C" fn jdiv_round_up(mut a: libc::c_long, mut b: libc::c_long) -> libc::c_long
+pub unsafe extern "C" fn jdiv_round_up(mut a: isize, mut b: isize) -> isize
 /* Compute a/b rounded up to next integer, ie, ceil(a/b) */
 /* Assumes a >= 0, b > 0 */ {
-    return (a + b - 1 as libc::c_long) / b;
+    return (a + b - 1 as isize) / b;
 }
 #[no_mangle]
 
-pub unsafe extern "C" fn jround_up(mut a: libc::c_long, mut b: libc::c_long) -> libc::c_long
+pub unsafe extern "C" fn jround_up(mut a: isize, mut b: isize) -> isize
 /* Compute a rounded up to next multiple of b, ie, ceil(a/b)*b */
 /* Assumes a >= 0, b > 0 */ {
-    a += b - 1 as libc::c_long;
+    a += b - 1 as isize;
     return a - a % b;
 }
 /* On normal machines we can apply MEMCOPY() and MEMZERO() to sample arrays

--- a/quake3-rs/renderer_opengl1_x86_64/src/jpeglib_h.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/jpeglib_h.rs
@@ -401,7 +401,7 @@ pub struct jpeg_error_mgr {
     pub msg_code: i32,
     pub msg_parm: C2RustUnnamed_0,
     pub trace_level: i32,
-    pub num_warnings: libc::c_long,
+    pub num_warnings: isize,
     pub jpeg_message_table: *const *const libc::c_char,
     pub last_jpeg_message: i32,
     pub addon_message_table: *const *const libc::c_char,
@@ -418,8 +418,8 @@ pub union C2RustUnnamed_0 {
 #[derive(Copy, Clone)]
 pub struct jpeg_progress_mgr {
     pub progress_monitor: Option<unsafe extern "C" fn(_: j_common_ptr) -> ()>,
-    pub pass_counter: libc::c_long,
-    pub pass_limit: libc::c_long,
+    pub pass_counter: isize,
+    pub pass_limit: isize,
     pub completed_passes: i32,
     pub total_passes: i32,
 }
@@ -442,7 +442,7 @@ pub struct jpeg_source_mgr {
     pub init_source: Option<unsafe extern "C" fn(_: j_decompress_ptr) -> ()>,
     pub fill_input_buffer:
         Option<unsafe extern "C" fn(_: j_decompress_ptr) -> crate::jmorecfg_h::boolean>,
-    pub skip_input_data: Option<unsafe extern "C" fn(_: j_decompress_ptr, _: libc::c_long) -> ()>,
+    pub skip_input_data: Option<unsafe extern "C" fn(_: j_decompress_ptr, _: isize) -> ()>,
     pub resync_to_restart:
         Option<unsafe extern "C" fn(_: j_decompress_ptr, _: i32) -> crate::jmorecfg_h::boolean>,
     pub term_source: Option<unsafe extern "C" fn(_: j_decompress_ptr) -> ()>,
@@ -1068,8 +1068,8 @@ pub struct jpeg_memory_mgr {
     >,
     pub free_pool: Option<unsafe extern "C" fn(_: j_common_ptr, _: i32) -> ()>,
     pub self_destruct: Option<unsafe extern "C" fn(_: j_common_ptr) -> ()>,
-    pub max_memory_to_use: libc::c_long,
-    pub max_alloc_chunk: libc::c_long,
+    pub max_memory_to_use: isize,
+    pub max_alloc_chunk: isize,
 }
 pub type jpeg_marker_parser_method =
     Option<unsafe extern "C" fn(_: j_decompress_ptr) -> crate::jmorecfg_h::boolean>;

--- a/quake3-rs/renderer_opengl1_x86_64/src/qcommon/puff.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/qcommon/puff.rs
@@ -77,7 +77,7 @@ unsafe extern "C" fn bits(
     (*s).bitbuf = val >> need;
     (*s).bitcnt -= need;
     /* return need bits, zeroing the bits above that */
-    return (val as libc::c_long & ((1 as libc::c_long) << need) - 1 as i32 as libc::c_long)
+    return (val as isize & ((1 as isize) << need) - 1 as i32 as isize)
         as crate::stdlib::int32_t;
 }
 /*

--- a/quake3-rs/renderer_opengl1_x86_64/src/qcommon/q_shared.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/qcommon/q_shared.rs
@@ -341,12 +341,12 @@ pub unsafe extern "C" fn COM_StripExtension(
         slash = ::libc::strrchr(in_0, '/' as i32);
         (slash.is_null()) || slash < dot
     } {
-        destsize = if (destsize as libc::c_long)
-            < dot.offset_from(in_0) as libc::c_long + 1 as i32 as libc::c_long
+        destsize = if (destsize as isize)
+            < dot.offset_from(in_0) as isize + 1 as i32 as isize
         {
-            destsize as libc::c_long
+            destsize as isize
         } else {
-            (dot.offset_from(in_0) as libc::c_long) + 1 as i32 as libc::c_long
+            (dot.offset_from(in_0) as isize) + 1 as i32 as isize
         } as i32
     }
     if in_0 == out as *const libc::c_char && destsize > 1 as i32 {
@@ -808,7 +808,7 @@ pub unsafe extern "C" fn COM_Compress(mut data_p: *mut libc::c_char) -> i32 {
         }
         *out = 0 as i32 as libc::c_char
     }
-    return out.offset_from(data_p) as libc::c_long as i32;
+    return out.offset_from(data_p) as isize as i32;
 }
 #[no_mangle]
 

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderercommon/tr_image_pcx.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderercommon/tr_image_pcx.rs
@@ -254,8 +254,8 @@ pub unsafe extern "C" fn R_LoadPCX(
     }
     if raw
         .b
-        .offset_from(pcx as *mut crate::src::qcommon::q_shared::byte) as libc::c_long
-        >= end.offset_from(769 as i32 as *mut crate::src::qcommon::q_shared::byte) as libc::c_long
+        .offset_from(pcx as *mut crate::src::qcommon::q_shared::byte) as isize
+        >= end.offset_from(769 as i32 as *mut crate::src::qcommon::q_shared::byte) as isize
         || *end.offset(-(769 as i32) as isize) as i32 != 0xc as i32
     {
         crate::src::renderergl1::tr_main::ri

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderercommon/tr_image_png.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderercommon/tr_image_png.rs
@@ -220,7 +220,7 @@ unsafe extern "C" fn BufferedFileRewind(
     /*
      *  How many bytes do we have already read?
      */
-    BytesRead = (*BF).Ptr.offset_from((*BF).Buffer) as libc::c_long as u32;
+    BytesRead = (*BF).Ptr.offset_from((*BF).Buffer) as isize as u32;
     /*
      *  We can only rewind to the beginning of the BufferedFile.
      */

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_backend.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_backend.rs
@@ -1908,7 +1908,7 @@ pub unsafe extern "C" fn RB_SwapBuffers(mut data: *const libc::c_void) -> *const
     // counting up the number of increments that have happened
     if (*crate::src::renderergl1::tr_init::r_measureOverdraw).integer != 0 {
         let mut i: i32 = 0;
-        let mut sum: libc::c_long = 0 as i32 as libc::c_long;
+        let mut sum: isize = 0 as i32 as isize;
         let mut stencilReadback: *mut u8 = 0 as *mut u8;
         stencilReadback = crate::src::renderergl1::tr_main::ri
             .Hunk_AllocateTempMemory
@@ -1929,7 +1929,7 @@ pub unsafe extern "C" fn RB_SwapBuffers(mut data: *const libc::c_void) -> *const
         while i < crate::src::renderergl1::tr_init::glConfig.vidWidth
             * crate::src::renderergl1::tr_init::glConfig.vidHeight
         {
-            sum += *stencilReadback.offset(i as isize) as libc::c_long;
+            sum += *stencilReadback.offset(i as isize) as isize;
             i += 1
         }
         backEnd.pc.c_overDraw += sum as f32;

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_bsp.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_bsp.rs
@@ -4719,7 +4719,7 @@ pub unsafe extern "C" fn RE_LoadWorldMap(mut name: *const libc::c_char) {
         .expect("non-null function pointer")(
         0 as i32, crate::src::qcommon::q_shared::h_low
     ) as *mut crate::src::qcommon::q_shared::byte)
-        .offset_from(startMarker) as libc::c_long as i32;
+        .offset_from(startMarker) as isize as i32;
     // only set tr.world now that we know the entire level has loaded properly
     crate::src::renderergl1::tr_main::tr.world = &mut s_worldData;
     crate::src::renderergl1::tr_main::ri

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_image.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_image.rs
@@ -426,11 +426,11 @@ return a hash value for the filename
 ================
 */
 
-unsafe extern "C" fn generateHashValue(mut fname: *const libc::c_char) -> libc::c_long {
+unsafe extern "C" fn generateHashValue(mut fname: *const libc::c_char) -> isize {
     let mut i: i32 = 0; // don't include extension
-    let mut hash: libc::c_long = 0; // damn path names
+    let mut hash: isize = 0; // damn path names
     let mut letter: libc::c_char = 0;
-    hash = 0 as i32 as libc::c_long;
+    hash = 0 as i32 as isize;
     i = 0 as i32;
     while *fname.offset(i as isize) as i32 != '\u{0}' as i32 {
         letter = ({
@@ -458,10 +458,10 @@ unsafe extern "C" fn generateHashValue(mut fname: *const libc::c_char) -> libc::
         if letter as i32 == '\\' as i32 {
             letter = '/' as i32 as libc::c_char
         }
-        hash += letter as libc::c_long * (i + 119 as i32) as libc::c_long;
+        hash += letter as isize * (i + 119 as i32) as isize;
         i += 1
     }
-    hash &= (1024 as i32 - 1 as i32) as libc::c_long;
+    hash &= (1024 as i32 - 1 as i32) as isize;
     return hash;
 }
 /*
@@ -1680,7 +1680,7 @@ pub unsafe extern "C" fn R_CreateImage(
     let mut image: *mut crate::tr_common_h::image_t = 0 as *mut crate::tr_common_h::image_t;
     let mut isLightmap: crate::src::qcommon::q_shared::qboolean =
         crate::src::qcommon::q_shared::qfalse;
-    let mut hash: libc::c_long = 0;
+    let mut hash: isize = 0;
     let mut glWrapClampMode: i32 = 0;
     if crate::stdlib::strlen(name) >= 64 as i32 as libc::c_ulong {
         crate::src::renderergl1::tr_main::ri
@@ -2051,7 +2051,7 @@ pub unsafe extern "C" fn R_FindImageFile(
     let mut height: i32 = 0;
     let mut pic: *mut crate::src::qcommon::q_shared::byte =
         0 as *mut crate::src::qcommon::q_shared::byte;
-    let mut hash: libc::c_long = 0;
+    let mut hash: isize = 0;
     if name.is_null() {
         return 0 as *mut crate::tr_common_h::image_t;
     }

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_init.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_init.rs
@@ -1251,9 +1251,9 @@ pub unsafe extern "C" fn RB_ReadPixels(
     ) as *mut crate::src::qcommon::q_shared::byte;
     bufstart = ((buffer as crate::stdlib::intptr_t as libc::c_ulong).wrapping_add(*offset)
         as crate::stdlib::intptr_t
-        + packAlign as libc::c_long
-        - 1 as i32 as libc::c_long
-        & !(packAlign - 1 as i32) as libc::c_long) as *mut libc::c_void
+        + packAlign as isize
+        - 1 as i32 as isize
+        & !(packAlign - 1 as i32) as isize) as *mut libc::c_void
         as *mut crate::src::qcommon::q_shared::byte;
     crate::src::sdl::sdl_glimp::qglReadPixels.expect("non-null function pointer")(
         x,
@@ -1264,7 +1264,7 @@ pub unsafe extern "C" fn RB_ReadPixels(
         0x1401 as i32 as crate::stdlib::GLenum,
         bufstart as *mut libc::c_void,
     );
-    *offset = bufstart.offset_from(buffer) as libc::c_long as crate::stddef_h::size_t;
+    *offset = bufstart.offset_from(buffer) as isize as crate::stddef_h::size_t;
     *padlen = padwidth - linelen;
     return buffer;
 }
@@ -1911,9 +1911,9 @@ pub unsafe extern "C" fn RB_TakeVideoFrameCmd(
         .wrapping_sub(1 as i32 as libc::c_ulong)
         & !(4 as i32 - 1 as i32) as libc::c_ulong) as i32;
     avipadlen = (avipadwidth as libc::c_ulong).wrapping_sub(linelen) as i32;
-    cBuf = ((*cmd).captureBuffer as crate::stdlib::intptr_t + packAlign as libc::c_long
-        - 1 as i32 as libc::c_long
-        & !(packAlign - 1 as i32) as libc::c_long) as *mut libc::c_void
+    cBuf = ((*cmd).captureBuffer as crate::stdlib::intptr_t + packAlign as isize
+        - 1 as i32 as isize
+        & !(packAlign - 1 as i32) as isize) as *mut libc::c_void
         as *mut crate::src::qcommon::q_shared::byte;
     crate::src::sdl::sdl_glimp::qglReadPixels.expect("non-null function pointer")(
         0 as i32,
@@ -3245,7 +3245,7 @@ pub unsafe extern "C" fn R_Init() {
     }
     //	Swap_Init();
     if crate::src::renderergl1::tr_shade::tess.xyz.as_mut_ptr() as crate::stdlib::intptr_t
-        & 15 as i32 as libc::c_long
+        & 15 as i32 as isize
         != 0
     {
         crate::src::renderergl1::tr_main::ri

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_model.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_model.rs
@@ -1120,7 +1120,7 @@ unsafe extern "C" fn R_LoadMDR(
     frame = mdr.offset(1 as i32 as isize) as *mut crate::qfiles_h::mdrFrame_t;
     (*mdr).ofsFrames = (frame as *mut crate::src::qcommon::q_shared::byte)
         .offset_from(mdr as *mut crate::src::qcommon::q_shared::byte)
-        as libc::c_long as i32;
+        as isize as i32;
     if (*pinmodel).ofsFrames < 0 as i32 {
         let mut cframe: *mut crate::qfiles_h::mdrCompFrame_t =
             0 as *mut crate::qfiles_h::mdrCompFrame_t;
@@ -1233,7 +1233,7 @@ unsafe extern "C" fn R_LoadMDR(
     lod = frame as *mut crate::qfiles_h::mdrLOD_t;
     (*mdr).ofsLODs = (lod as *mut crate::src::qcommon::q_shared::byte)
         .offset_from(mdr as *mut crate::src::qcommon::q_shared::byte)
-        as libc::c_long as i32;
+        as isize as i32;
     curlod = (pinmodel as *mut crate::src::qcommon::q_shared::byte)
         .offset((*pinmodel).ofsLODs as isize) as *mut crate::qfiles_h::mdrLOD_t;
     // swap all the LOD's
@@ -1257,7 +1257,7 @@ unsafe extern "C" fn R_LoadMDR(
         surf = lod.offset(1 as i32 as isize) as *mut crate::qfiles_h::mdrSurface_t;
         (*lod).ofsSurfaces = (surf as *mut crate::src::qcommon::q_shared::byte)
             .offset_from(lod as *mut crate::src::qcommon::q_shared::byte)
-            as libc::c_long as i32;
+            as isize as i32;
         cursurf = (curlod as *mut crate::src::qcommon::q_shared::byte)
             .offset((*curlod).ofsSurfaces as isize)
             as *mut crate::qfiles_h::mdrSurface_t;
@@ -1291,7 +1291,7 @@ unsafe extern "C" fn R_LoadMDR(
             );
             (*surf).ofsHeader = (mdr as *mut crate::src::qcommon::q_shared::byte)
                 .offset_from(surf as *mut crate::src::qcommon::q_shared::byte)
-                as libc::c_long as i32;
+                as isize as i32;
             (*surf).numVerts = (*cursurf).numVerts;
             (*surf).numTriangles = (*cursurf).numTriangles;
             // numBoneReferences and BoneReferences generally seem to be unused
@@ -1349,7 +1349,7 @@ unsafe extern "C" fn R_LoadMDR(
             v = surf.offset(1 as i32 as isize) as *mut crate::qfiles_h::mdrVertex_t;
             (*surf).ofsVerts = (v as *mut crate::src::qcommon::q_shared::byte)
                 .offset_from(surf as *mut crate::src::qcommon::q_shared::byte)
-                as libc::c_long as i32;
+                as isize as i32;
             curv = (cursurf as *mut crate::src::qcommon::q_shared::byte)
                 .offset((*cursurf).ofsVerts as isize)
                 as *mut crate::qfiles_h::mdrVertex_t;
@@ -1406,7 +1406,7 @@ unsafe extern "C" fn R_LoadMDR(
             tri = v as *mut crate::qfiles_h::mdrTriangle_t;
             (*surf).ofsTriangles = (tri as *mut crate::src::qcommon::q_shared::byte)
                 .offset_from(surf as *mut crate::src::qcommon::q_shared::byte)
-                as libc::c_long as i32;
+                as isize as i32;
             curtri = (cursurf as *mut crate::src::qcommon::q_shared::byte)
                 .offset((*cursurf).ofsTriangles as isize)
                 as *mut crate::qfiles_h::mdrTriangle_t;
@@ -1438,7 +1438,7 @@ unsafe extern "C" fn R_LoadMDR(
             // tri now points to the end of the surface.
             (*surf).ofsEnd = (tri as *mut crate::src::qcommon::q_shared::byte)
                 .offset_from(surf as *mut crate::src::qcommon::q_shared::byte)
-                as libc::c_long as i32;
+                as isize as i32;
             surf = tri as *mut crate::qfiles_h::mdrSurface_t;
             // find the next surface.
             cursurf = (cursurf as *mut crate::src::qcommon::q_shared::byte)
@@ -1449,7 +1449,7 @@ unsafe extern "C" fn R_LoadMDR(
         // surf points to the next lod now.
         (*lod).ofsEnd = (surf as *mut crate::src::qcommon::q_shared::byte)
             .offset_from(lod as *mut crate::src::qcommon::q_shared::byte)
-            as libc::c_long as i32;
+            as isize as i32;
         lod = surf as *mut crate::qfiles_h::mdrLOD_t;
         // find the next LOD.
         curlod = (curlod as *mut crate::src::qcommon::q_shared::byte)
@@ -1460,7 +1460,7 @@ unsafe extern "C" fn R_LoadMDR(
     tag = lod as *mut crate::qfiles_h::mdrTag_t;
     (*mdr).ofsTags = (tag as *mut crate::src::qcommon::q_shared::byte)
         .offset_from(mdr as *mut crate::src::qcommon::q_shared::byte)
-        as libc::c_long as i32;
+        as isize as i32;
     curtag = (pinmodel as *mut crate::src::qcommon::q_shared::byte)
         .offset((*pinmodel).ofsTags as isize) as *mut crate::qfiles_h::mdrTag_t;
     // simple bounds check
@@ -1492,7 +1492,7 @@ unsafe extern "C" fn R_LoadMDR(
     // And finally we know the real offset to the end.
     (*mdr).ofsEnd = (tag as *mut crate::src::qcommon::q_shared::byte)
         .offset_from(mdr as *mut crate::src::qcommon::q_shared::byte)
-        as libc::c_long as i32;
+        as isize as i32;
     // phew! we're done.
     return crate::src::qcommon::q_shared::qtrue;
 }

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_shade.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_shade.rs
@@ -719,14 +719,14 @@ unsafe extern "C" fn R_BindAnimatedImage(mut bundle: *mut crate::tr_local_h::tex
     index = (tess.shaderTime * (*bundle).imageAnimationSpeed as f64 * 1024 as i32 as f64)
         as crate::stdlib::int64_t;
     index >>= 10 as i32;
-    if index < 0 as i32 as libc::c_long {
+    if index < 0 as i32 as isize {
         index = 0 as i32 as crate::stdlib::int64_t
         // may happen with shader time offsets
     }
     // Windows x86 doesn't load renderer DLL with 64 bit modulus
     //index %= bundle->numImageAnimations;
-    while index >= (*bundle).numImageAnimations as libc::c_long {
-        index -= (*bundle).numImageAnimations as libc::c_long
+    while index >= (*bundle).numImageAnimations as isize {
+        index -= (*bundle).numImageAnimations as isize
     }
     crate::src::renderergl1::tr_backend::GL_Bind(
         (*bundle).image[index as usize] as *mut crate::tr_common_h::image_s,

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_shade_calc.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_shade_calc.rs
@@ -571,7 +571,7 @@ unsafe extern "C" fn EvalWaveForm(mut wf: *const crate::tr_local_h::waveForm_t) 
             ((((*wf).phase as f64
                 + crate::src::renderergl1::tr_shade::tess.shaderTime * (*wf).frequency as f64)
                 * 1024 as i32 as f64) as crate::stdlib::int64_t
-                & (1024 as i32 - 1 as i32) as libc::c_long) as isize,
+                & (1024 as i32 - 1 as i32) as isize) as isize,
         ) * (*wf).amplitude;
 }
 
@@ -670,7 +670,7 @@ pub unsafe extern "C" fn RB_CalcDeformVertexes(mut ds: *mut crate::tr_local_h::d
                         + crate::src::renderergl1::tr_shade::tess.shaderTime
                             * (*ds).deformationWave.frequency as f64)
                         * 1024 as i32 as f64) as crate::stdlib::int64_t
-                        & (1024 as i32 - 1 as i32) as libc::c_long) as isize,
+                        & (1024 as i32 - 1 as i32) as isize) as isize,
                 ) * (*ds).deformationWave.amplitude;
             offset[0 as i32 as usize] = *normal.offset(0 as i32 as isize) * scale;
             offset[1 as i32 as usize] = *normal.offset(1 as i32 as isize) * scale;
@@ -761,7 +761,7 @@ pub unsafe extern "C" fn RB_CalcBulgeVertexes(mut ds: *mut crate::tr_local_h::de
             * ((*st.offset(0 as i32 as isize) * (*ds).bulgeWidth) as f64 + now))
             as crate::stdlib::int64_t;
         scale = crate::src::renderergl1::tr_main::tr.sinTable
-            [(off & (1024 as i32 - 1 as i32) as libc::c_long) as usize]
+            [(off & (1024 as i32 - 1 as i32) as isize) as usize]
             * (*ds).bulgeHeight;
         *xyz.offset(0 as i32 as isize) += *normal.offset(0 as i32 as isize) * scale;
         *xyz.offset(1 as i32 as isize) += *normal.offset(1 as i32 as isize) * scale;
@@ -794,7 +794,7 @@ pub unsafe extern "C" fn RB_CalcMoveVertexes(mut ds: *mut crate::tr_local_h::def
                 + crate::src::renderergl1::tr_shade::tess.shaderTime
                     * (*ds).deformationWave.frequency as f64)
                 * 1024 as i32 as f64) as crate::stdlib::int64_t
-                & (1024 as i32 - 1 as i32) as libc::c_long) as isize,
+                & (1024 as i32 - 1 as i32) as isize) as isize,
         ) * (*ds).deformationWave.amplitude;
     offset[0 as i32 as usize] = (*ds).moveVector[0 as i32 as usize] * scale;
     offset[1 as i32 as usize] = (*ds).moveVector[1 as i32 as usize] * scale;
@@ -2911,7 +2911,7 @@ pub unsafe extern "C" fn RB_CalcTurbulentTexCoords(
                 * 0.125f64
                 + now)
                 * 1024 as i32 as f64) as crate::stdlib::int64_t
-                & (1024 as i32 - 1 as i32) as libc::c_long) as usize]
+                & (1024 as i32 - 1 as i32) as isize) as usize]
             * (*wf).amplitude;
         *st.offset(1 as i32 as isize) = t + crate::src::renderergl1::tr_main::tr.sinTable
             [(((crate::src::renderergl1::tr_shade::tess.xyz[i as usize][1 as i32 as usize] as f64
@@ -2920,7 +2920,7 @@ pub unsafe extern "C" fn RB_CalcTurbulentTexCoords(
                 * 0.125f64
                 + now)
                 * 1024 as i32 as f64) as crate::stdlib::int64_t
-                & (1024 as i32 - 1 as i32) as libc::c_long) as usize]
+                & (1024 as i32 - 1 as i32) as isize) as usize]
             * (*wf).amplitude;
         i += 1;
         st = st.offset(2 as i32 as isize)
@@ -3020,10 +3020,10 @@ pub unsafe extern "C" fn RB_CalcRotateTexCoords(mut degsPerSecond: f32, mut st: 
     degs = -degsPerSecond as f64 * timeScale;
     index = (degs * (1024 as i32 as f32 / 360.0f32) as f64) as crate::stdlib::int64_t;
     sinValue = crate::src::renderergl1::tr_main::tr.sinTable
-        [(index & (1024 as i32 - 1 as i32) as libc::c_long) as usize];
+        [(index & (1024 as i32 - 1 as i32) as isize) as usize];
     cosValue = crate::src::renderergl1::tr_main::tr.sinTable[(index
-        + (1024 as i32 / 4 as i32) as libc::c_long
-        & (1024 as i32 - 1 as i32) as libc::c_long)
+        + (1024 as i32 / 4 as i32) as isize
+        & (1024 as i32 - 1 as i32) as isize)
         as usize];
     tmi.matrix[0 as i32 as usize][0 as i32 as usize] = cosValue;
     tmi.matrix[1 as i32 as usize][0 as i32 as usize] = -sinValue;

--- a/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_shader.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/renderergl1/tr_shader.rs
@@ -478,11 +478,11 @@ return a hash value for the filename
 ================
 */
 
-unsafe extern "C" fn generateHashValue(mut fname: *const libc::c_char, size: i32) -> libc::c_long {
+unsafe extern "C" fn generateHashValue(mut fname: *const libc::c_char, size: i32) -> isize {
     let mut i: i32 = 0; // don't include extension
-    let mut hash: libc::c_long = 0; // damn path names
+    let mut hash: isize = 0; // damn path names
     let mut letter: libc::c_char = 0; // damn path names
-    hash = 0 as i32 as libc::c_long;
+    hash = 0 as i32 as isize;
     i = 0 as i32;
     while *fname.offset(i as isize) as i32 != '\u{0}' as i32 {
         letter = ({
@@ -513,11 +513,11 @@ unsafe extern "C" fn generateHashValue(mut fname: *const libc::c_char, size: i32
         if letter as i32 == '/' as i32 {
             letter = '/' as i32 as libc::c_char
         }
-        hash += letter as libc::c_long * (i + 119 as i32) as libc::c_long;
+        hash += letter as isize * (i + 119 as i32) as isize;
         i += 1
     }
     hash = hash ^ hash >> 10 as i32 ^ hash >> 20 as i32;
-    hash &= (size - 1 as i32) as libc::c_long;
+    hash &= (size - 1 as i32) as isize;
     return hash;
 }
 #[no_mangle]
@@ -9175,8 +9175,8 @@ unsafe extern "C" fn ScanAndLoadShaderFiles() {
     let mut size: i32 = 0;
     let mut shaderName: [libc::c_char; 64] = [0; 64];
     let mut shaderLine: i32 = 0;
-    let mut sum: libc::c_long = 0 as i32 as libc::c_long;
-    let mut summand: libc::c_long = 0;
+    let mut sum: isize = 0 as i32 as isize;
+    let mut summand: isize = 0;
     // scan for shader files
     shaderFiles = crate::src::renderergl1::tr_main::ri
         .FS_ListFiles
@@ -9318,7 +9318,7 @@ unsafe extern "C" fn ScanAndLoadShaderFiles() {
     s_shaderText = crate::src::renderergl1::tr_main::ri
         .Hunk_Alloc
         .expect("non-null function pointer")(
-        (sum + (numShaderFiles * 2 as i32) as libc::c_long) as i32,
+        (sum + (numShaderFiles * 2 as i32) as isize) as i32,
         crate::src::qcommon::q_shared::h_low,
     ) as *mut libc::c_char;
     *s_shaderText.offset(0 as i32 as isize) = '\u{0}' as i32 as libc::c_char;

--- a/quake3-rs/renderer_opengl1_x86_64/src/stddef_h.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/stddef_h.rs
@@ -1,2 +1,2 @@
-pub type ptrdiff_t = libc::c_long;
+pub type ptrdiff_t = isize;
 pub type size_t = libc::c_ulong;

--- a/quake3-rs/renderer_opengl1_x86_64/src/stdlib.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/stdlib.rs
@@ -483,10 +483,10 @@ pub struct __jmp_buf_tag {
 pub type jmp_buf = [__jmp_buf_tag; 1];
 // ================ END include_setjmp_h ================
 // =============== BEGIN setjmp_h ================
-pub type __jmp_buf = [libc::c_long; 8];
+pub type __jmp_buf = [isize; 8];
 // ================ END setjmp_h ================
 // =============== BEGIN stdint_h ================
-pub type intptr_t = libc::c_long;
+pub type intptr_t = isize;
 // ================ END stdint_h ================
 // =============== BEGIN stdint_intn_h ================
 pub type int16_t = __int16_t;
@@ -544,6 +544,6 @@ pub type __int16_t = i16;
 pub type __uint16_t = u16;
 pub type __int32_t = i32;
 pub type __uint32_t = u32;
-pub type __int64_t = libc::c_long;
-pub type __off_t = libc::c_long;
-pub type __off64_t = libc::c_long;
+pub type __int64_t = isize;
+pub type __off_t = isize;
+pub type __off64_t = isize;

--- a/quake3-rs/renderer_opengl1_x86_64/src/tr_public_h.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/tr_public_h.rs
@@ -219,7 +219,7 @@ pub struct refimport_t {
     >,
     pub FS_FileIsInPAK: Option<unsafe extern "C" fn(_: *const libc::c_char, _: *mut i32) -> i32>,
     pub FS_ReadFile: Option<
-        unsafe extern "C" fn(_: *const libc::c_char, _: *mut *mut libc::c_void) -> libc::c_long,
+        unsafe extern "C" fn(_: *const libc::c_char, _: *mut *mut libc::c_void) -> isize,
     >,
     pub FS_FreeFile: Option<unsafe extern "C" fn(_: *mut libc::c_void) -> ()>,
     pub FS_ListFiles: Option<
@@ -246,7 +246,7 @@ pub struct refimport_t {
     pub IN_Init: Option<unsafe extern "C" fn(_: *mut libc::c_void) -> ()>,
     pub IN_Shutdown: Option<unsafe extern "C" fn() -> ()>,
     pub IN_Restart: Option<unsafe extern "C" fn() -> ()>,
-    pub ftol: Option<unsafe extern "C" fn(_: f32) -> libc::c_long>,
+    pub ftol: Option<unsafe extern "C" fn(_: f32) -> isize>,
     pub Sys_SetEnv:
         Option<unsafe extern "C" fn(_: *const libc::c_char, _: *const libc::c_char) -> ()>,
     pub Sys_GLimpSafeInit: Option<unsafe extern "C" fn() -> ()>,

--- a/quake3-rs/uix86_64/src/q3_ui/ui_demo2.rs
+++ b/quake3-rs/uix86_64/src/q3_ui/ui_demo2.rs
@@ -759,7 +759,7 @@ unsafe extern "C" fn Demos_MenuInit() {
                     (::std::mem::size_of::<[libc::c_char; 32768]>() as libc::c_ulong)
                         .wrapping_div(::std::mem::size_of::<libc::c_char>() as libc::c_ulong)
                         .wrapping_sub(demoname.offset_from(s_demos.names.as_mut_ptr())
-                            as libc::c_long as libc::c_ulong) as i32,
+                            as isize as libc::c_ulong) as i32,
                 )
         }
         j += 1

--- a/quake3-rs/uix86_64/src/q3_ui/ui_playermodel.rs
+++ b/quake3-rs/uix86_64/src/q3_ui/ui_playermodel.rs
@@ -1124,14 +1124,14 @@ unsafe extern "C" fn PlayerModel_PicEvent(mut ptr: *mut libc::c_void, mut event:
         crate::src::qcommon::q_shared::Q_strncpyz(
             s_playermodel.modelskin.as_mut_ptr(),
             buffptr,
-            (pdest.offset_from(buffptr) as libc::c_long + 1 as i32 as libc::c_long) as i32,
+            (pdest.offset_from(buffptr) as isize + 1 as i32 as isize) as i32,
         );
         ::libc::strcat(
             s_playermodel.modelskin.as_mut_ptr(),
             pdest.offset(5 as i32 as isize),
         );
         // separate the model name
-        maxlen = pdest.offset_from(buffptr) as libc::c_long as i32;
+        maxlen = pdest.offset_from(buffptr) as isize as i32;
         if maxlen > 16 as i32 {
             maxlen = 16 as i32
         }
@@ -1337,7 +1337,7 @@ unsafe extern "C" fn PlayerModel_SetMenuItems() {
             crate::src::qcommon::q_shared::Q_strncpyz(
                 modelskin.as_mut_ptr(),
                 buffptr,
-                (pdest.offset_from(buffptr) as libc::c_long + 1 as i32 as libc::c_long) as i32,
+                (pdest.offset_from(buffptr) as isize + 1 as i32 as isize) as i32,
             );
             ::libc::strcat(modelskin.as_mut_ptr(), pdest.offset(5 as i32 as isize));
             if crate::src::qcommon::q_shared::Q_stricmp(
@@ -1349,7 +1349,7 @@ unsafe extern "C" fn PlayerModel_SetMenuItems() {
                 s_playermodel.selectedmodel = i;
                 s_playermodel.modelpage = i / (4 as i32 * 4 as i32);
                 // separate the model name
-                maxlen = pdest.offset_from(buffptr) as libc::c_long as i32;
+                maxlen = pdest.offset_from(buffptr) as isize as i32;
                 if maxlen > 16 as i32 {
                     maxlen = 16 as i32
                 }

--- a/quake3-rs/uix86_64/src/q3_ui/ui_video.rs
+++ b/quake3-rs/uix86_64/src/q3_ui/ui_video.rs
@@ -1362,7 +1362,7 @@ unsafe extern "C" fn GraphicsOptions_GetAspectRatios() {
         crate::src::qcommon::q_shared::Q_strncpyz(
             str.as_mut_ptr(),
             *resolutions.offset(r as isize),
-            x.offset_from(*resolutions.offset(r as isize)) as libc::c_long as i32,
+            x.offset_from(*resolutions.offset(r as isize)) as isize as i32,
         );
         w = atoi(str.as_mut_ptr());
         h = atoi(x);

--- a/quake3-rs/uix86_64/src/qcommon/q_shared.rs
+++ b/quake3-rs/uix86_64/src/qcommon/q_shared.rs
@@ -442,12 +442,12 @@ pub unsafe extern "C" fn COM_StripExtension(
         slash = ::libc::strrchr(in_0, '/' as i32);
         (slash.is_null()) || slash < dot
     } {
-        destsize = if (destsize as libc::c_long)
-            < dot.offset_from(in_0) as libc::c_long + 1 as i32 as libc::c_long
+        destsize = if (destsize as isize)
+            < dot.offset_from(in_0) as isize + 1 as i32 as isize
         {
-            destsize as libc::c_long
+            destsize as isize
         } else {
-            (dot.offset_from(in_0) as libc::c_long) + 1 as i32 as libc::c_long
+            (dot.offset_from(in_0) as isize) + 1 as i32 as isize
         } as i32
     }
     if in_0 == out as *const libc::c_char && destsize > 1 as i32 {
@@ -902,7 +902,7 @@ pub unsafe extern "C" fn COM_Compress(mut data_p: *mut libc::c_char) -> i32 {
         }
         *out = 0 as i32 as libc::c_char
     }
-    return out.offset_from(data_p) as libc::c_long as i32;
+    return out.offset_from(data_p) as isize as i32;
 }
 #[no_mangle]
 pub unsafe extern "C" fn COM_ParseExt(

--- a/quake3-rs/uix86_64/src/stdlib.rs
+++ b/quake3-rs/uix86_64/src/stdlib.rs
@@ -83,7 +83,7 @@ pub const _ISpunct: crate::src::qcommon::q_shared::C2RustUnnamed_0 = 4;
 pub const _ISalnum: crate::src::qcommon::q_shared::C2RustUnnamed_0 = 8;
 // ================ END ctype_h ================
 // =============== BEGIN stdint_h ================
-pub type intptr_t = libc::c_long;
+pub type intptr_t = isize;
 // ================ END stdint_h ================
 // =============== BEGIN stdlib_h ================
 pub type __compar_fn_t =

--- a/quake3-rs/uix86_64/src/ui/ui_syscalls.rs
+++ b/quake3-rs/uix86_64/src/ui/ui_syscalls.rs
@@ -468,7 +468,7 @@ pub unsafe extern "C" fn trap_FS_GetFileList(
 
 pub unsafe extern "C" fn trap_FS_Seek(
     mut f: crate::src::qcommon::q_shared::fileHandle_t,
-    mut offset: libc::c_long,
+    mut offset: isize,
     mut origin: i32,
 ) -> i32 {
     return syscall.expect("non-null function pointer")(


### PR DESCRIPTION
## Summary
- handle libc functions expecting `c_long` by casting pointers and values
- correct labs call on codebook quantlist
- ensure timeval assignments cast to libc time types
- adjust tick count computation using `isize`

## Testing
- `cargo +nightly-2019-12-05 build --release`

------
https://chatgpt.com/codex/tasks/task_e_68539a3a7c608329ae2234874102b1dd