### PR TITLE
Fix build by avoiding null_mut

### DIFF
--- a/quake3-rs/ioquake3/src/client/snd_openal.rs
+++ b/quake3-rs/ioquake3/src/client/snd_openal.rs
@@ -2702,11 +2702,11 @@ unsafe extern "C" fn S_AL_MusicUpdate() {
 //===========================================================================
 // Local state variables
 
-static mut alDevice: *mut ALCdevice = std::ptr::null_mut();
+static mut alDevice: *mut ALCdevice = 0 as *mut ALCdevice;
 
-static mut alContext: *mut ALCcontext = std::ptr::null_mut();
+static mut alContext: *mut ALCcontext = 0 as *mut ALCcontext;
 
-static mut alCaptureDevice: *mut ALCdevice = std::ptr::null_mut();
+static mut alCaptureDevice: *mut ALCdevice = 0 as *mut ALCdevice;
 
 static mut s_alCapture: *mut cvar_t = std::ptr::null_mut();
 /*

--- a/quake3-rs/ioquake3/src/sdl/sdl_input.rs
+++ b/quake3-rs/ioquake3/src/sdl/sdl_input.rs
@@ -1115,9 +1115,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 static mut in_keyboardDebug: *mut cvar_t = std::ptr::null_mut();
 
-static mut gamepad: *mut SDL_GameController = std::ptr::null_mut();
+static mut gamepad: *mut SDL_GameController = 0 as *mut SDL_GameController;
 
-static mut stick: *mut SDL_Joystick = std::ptr::null_mut();
+static mut stick: *mut SDL_Joystick = 0 as *mut SDL_Joystick;
 
 static mut mouseAvailable: qboolean = qfalse;
 
@@ -1139,7 +1139,7 @@ static mut vidRestartTime: i32 = 0 as i32;
 
 static mut in_eventTime: i32 = 0 as i32;
 
-static mut SDL_window: *mut SDL_Window = std::ptr::null_mut();
+static mut SDL_window: *mut SDL_Window = 0 as *mut SDL_Window;
 /*
 ===============
 IN_PrintKey

--- a/quake3-rs/renderer_opengl1_x86_64/src/sdl/sdl_glimp.rs
+++ b/quake3-rs/renderer_opengl1_x86_64/src/sdl/sdl_glimp.rs
@@ -551,7 +551,7 @@ pub const RSERR_UNKNOWN: rserr_t = 3;
 pub const RSERR_OK: rserr_t = 0;
 #[no_mangle]
 
-pub static mut SDL_window: *mut SDL_Window = std::ptr::null_mut();
+pub static mut SDL_window: *mut SDL_Window = 0 as *mut SDL_Window;
 
 static mut SDL_glContext: SDL_GLContext = std::ptr::null_mut();
 #[no_mangle]


### PR DESCRIPTION
## Summary
- fix FFI static initializers that used `null_mut()` with extern types
- confirm build passes with `cargo +nightly-2019-12-05 build --release`

## Testing
- `cargo +nightly-2019-12-05 build --release`

------
https://chatgpt.com/codex/tasks/task_e_6854a86894388329bc215c5acefec361