### PR TITLE
Fix some Rust build errors

### DIFF
--- a/quake3-rs/ioquake3/src/botlib/be_ai_goal.rs
+++ b/quake3-rs/ioquake3/src/botlib/be_ai_goal.rs
@@ -3045,7 +3045,7 @@ unsafe extern "C" fn run_static_initializers() {
         {
             let mut init = fielddef_s {
                 name: b"name\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-                offset: &mut (*(std::ptr::null_mut())).name as *mut [libc::c_char; 80] as size_t
+                offset: &mut (*(std::ptr::null_mut::<iteminfo_s>())).name as *mut [libc::c_char; 80] as size_t
                     as i32,
                 type_0: 4 as i32,
                 maxarray: 0,

--- a/quake3-rs/ioquake3/src/botlib/be_ai_weap.rs
+++ b/quake3-rs/ioquake3/src/botlib/be_ai_weap.rs
@@ -960,7 +960,7 @@ unsafe extern "C" fn run_static_initializers() {
         {
             let mut init = fielddef_s {
                 name: b"level\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-                offset: &mut (*(std::ptr::null_mut())).level as *mut i32 as size_t as i32,
+                offset: &mut (*(std::ptr::null_mut::<weaponinfo_s>())).level as *mut i32 as size_t as i32,
                 type_0: 2 as i32,
                 maxarray: 0,
                 floatmin: 0.,
@@ -972,7 +972,7 @@ unsafe extern "C" fn run_static_initializers() {
         {
             let mut init = fielddef_s {
                 name: b"model\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-                offset: &mut (*(std::ptr::null_mut())).model as *mut [libc::c_char; 80] as size_t
+                offset: &mut (*(std::ptr::null_mut::<weaponinfo_s>())).model as *mut [libc::c_char; 80] as size_t
                     as i32,
                 type_0: 4 as i32,
                 maxarray: 0,
@@ -985,7 +985,7 @@ unsafe extern "C" fn run_static_initializers() {
         {
             let mut init = fielddef_s {
                 name: b"weaponindex\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-                offset: &mut (*(std::ptr::null_mut())).weaponindex as *mut i32 as size_t as i32,
+                offset: &mut (*(std::ptr::null_mut::<weaponinfo_s>())).weaponindex as *mut i32 as size_t as i32,
                 type_0: 2 as i32,
                 maxarray: 0,
                 floatmin: 0.,
@@ -997,7 +997,7 @@ unsafe extern "C" fn run_static_initializers() {
         {
             let mut init = fielddef_s {
                 name: b"flags\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-                offset: &mut (*(std::ptr::null_mut())).flags as *mut i32 as size_t as i32,
+                offset: &mut (*(std::ptr::null_mut::<weaponinfo_s>())).flags as *mut i32 as size_t as i32,
                 type_0: 2 as i32,
                 maxarray: 0,
                 floatmin: 0.,

--- a/quake3-rs/qagamex86_64/src/game/ai_chat.rs
+++ b/quake3-rs/qagamex86_64/src/game/ai_chat.rs
@@ -1252,7 +1252,7 @@ pub unsafe extern "C" fn BotChat_Death(mut bs: *mut bot_state_t) -> i32 {
                 bs as *mut bot_state_s,
                 b"death_cratered\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 BotRandomOpponentName(bs),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         } else if (*bs).botsuicide != 0
             || (*bs).botdeathtype == MOD_CRUSH as i32
@@ -1265,14 +1265,14 @@ pub unsafe extern "C" fn BotChat_Death(mut bs: *mut bot_state_t) -> i32 {
                 bs as *mut bot_state_s,
                 b"death_suicide\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 BotRandomOpponentName(bs),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         } else if (*bs).botdeathtype == MOD_TELEFRAG as i32 {
             BotAI_BotInitialChat(
                 bs as *mut bot_state_s,
                 b"death_telefrag\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 name.as_mut_ptr(),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         } else if ((*bs).botdeathtype == MOD_GAUNTLET as i32
             || (*bs).botdeathtype == MOD_RAILGUN as i32
@@ -1286,7 +1286,7 @@ pub unsafe extern "C" fn BotChat_Death(mut bs: *mut bot_state_t) -> i32 {
                     b"death_gauntlet\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                     name.as_mut_ptr(),
                     BotWeaponNameForMeansOfDeath((*bs).botdeathtype),
-                    std::ptr::null_mut(),
+                    std::ptr::null_mut::<libc::c_char>(),
                 );
             } else if (*bs).botdeathtype == MOD_RAILGUN as i32 {
                 BotAI_BotInitialChat(
@@ -1294,7 +1294,7 @@ pub unsafe extern "C" fn BotChat_Death(mut bs: *mut bot_state_t) -> i32 {
                     b"death_rail\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                     name.as_mut_ptr(),
                     BotWeaponNameForMeansOfDeath((*bs).botdeathtype),
-                    std::ptr::null_mut(),
+                    std::ptr::null_mut::<libc::c_char>(),
                 );
             } else {
                 BotAI_BotInitialChat(
@@ -1302,7 +1302,7 @@ pub unsafe extern "C" fn BotChat_Death(mut bs: *mut bot_state_t) -> i32 {
                     b"death_bfg\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                     name.as_mut_ptr(),
                     BotWeaponNameForMeansOfDeath((*bs).botdeathtype),
-                    std::ptr::null_mut(),
+                    std::ptr::null_mut::<libc::c_char>(),
                 );
             }
         } else if ((rand() & 0x7fff as i32) as f32 / 0x7fff as i32 as f32)
@@ -1318,7 +1318,7 @@ pub unsafe extern "C" fn BotChat_Death(mut bs: *mut bot_state_t) -> i32 {
                 b"death_insult\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 name.as_mut_ptr(),
                 BotWeaponNameForMeansOfDeath((*bs).botdeathtype),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         } else {
             BotAI_BotInitialChat(
@@ -1326,7 +1326,7 @@ pub unsafe extern "C" fn BotChat_Death(mut bs: *mut bot_state_t) -> i32 {
                 b"death_praise\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 name.as_mut_ptr(),
                 BotWeaponNameForMeansOfDeath((*bs).botdeathtype),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         }
         (*bs).chatto = 0 as i32
@@ -1403,21 +1403,21 @@ pub unsafe extern "C" fn BotChat_Kill(mut bs: *mut bot_state_t) -> i32 {
                 bs as *mut bot_state_s,
                 b"kill_gauntlet\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 name.as_mut_ptr(),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         } else if (*bs).enemydeathtype == MOD_RAILGUN as i32 {
             BotAI_BotInitialChat(
                 bs as *mut bot_state_s,
                 b"kill_rail\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 name.as_mut_ptr(),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         } else if (*bs).enemydeathtype == MOD_TELEFRAG as i32 {
             BotAI_BotInitialChat(
                 bs as *mut bot_state_s,
                 b"kill_telefrag\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 name.as_mut_ptr(),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         } else if ((rand() & 0x7fff as i32) as f32 / 0x7fff as i32 as f32)
             < trap_Characteristic_BFloat(
@@ -1431,14 +1431,14 @@ pub unsafe extern "C" fn BotChat_Kill(mut bs: *mut bot_state_t) -> i32 {
                 bs as *mut bot_state_s,
                 b"kill_insult\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 name.as_mut_ptr(),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         } else {
             BotAI_BotInitialChat(
                 bs as *mut bot_state_s,
                 b"kill_praise\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 name.as_mut_ptr(),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         }
     }
@@ -1863,7 +1863,7 @@ pub unsafe extern "C" fn BotChat_Random(mut bs: *mut bot_state_t) -> i32 {
             b"[invalid var]\x00" as *const u8 as *const libc::c_char,
             BotMapTitle(),
             BotRandomWeaponName(),
-            std::ptr::null_mut(),
+            std::ptr::null_mut::<libc::c_char>(),
         );
     } else {
         BotAI_BotInitialChat(
@@ -1875,7 +1875,7 @@ pub unsafe extern "C" fn BotChat_Random(mut bs: *mut bot_state_t) -> i32 {
             b"[invalid var]\x00" as *const u8 as *const libc::c_char,
             BotMapTitle(),
             BotRandomWeaponName(),
-            std::ptr::null_mut(),
+            std::ptr::null_mut::<libc::c_char>(),
         );
     }
     (*bs).lastchat_time = floattime;
@@ -1923,7 +1923,7 @@ pub unsafe extern "C" fn BotChatTest(mut bs: *mut bot_state_t) {
             b"[invalid var]\x00" as *const u8 as *const libc::c_char,
             b"[invalid var]\x00" as *const u8 as *const libc::c_char,
             BotMapTitle(),
-            std::ptr::null_mut(),
+            std::ptr::null_mut::<libc::c_char>(),
         );
         trap_BotEnterChat((*bs).cs, 0 as i32, 0 as i32);
         i += 1
@@ -1942,7 +1942,7 @@ pub unsafe extern "C" fn BotChatTest(mut bs: *mut bot_state_t) {
             b"[invalid var]\x00" as *const u8 as *const libc::c_char,
             b"[invalid var]\x00" as *const u8 as *const libc::c_char,
             BotMapTitle(),
-            std::ptr::null_mut(),
+            std::ptr::null_mut::<libc::c_char>(),
         );
         trap_BotEnterChat((*bs).cs, 0 as i32, 0 as i32);
         i += 1
@@ -1957,7 +1957,7 @@ pub unsafe extern "C" fn BotChatTest(mut bs: *mut bot_state_t) {
             bs as *mut bot_state_s,
             b"level_start\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             crate::src::game::ai_dmq3::EasyClientName((*bs).client, name.as_mut_ptr(), 32 as i32),
-            std::ptr::null_mut(),
+            std::ptr::null_mut::<libc::c_char>(),
         );
         trap_BotEnterChat((*bs).cs, 0 as i32, 0 as i32);
         i += 1
@@ -1976,7 +1976,7 @@ pub unsafe extern "C" fn BotChatTest(mut bs: *mut bot_state_t) {
             BotFirstClientInRankings(),
             BotLastClientInRankings(),
             BotMapTitle(),
-            std::ptr::null_mut(),
+            std::ptr::null_mut::<libc::c_char>(),
         );
         trap_BotEnterChat((*bs).cs, 0 as i32, 0 as i32);
         i += 1
@@ -1995,7 +1995,7 @@ pub unsafe extern "C" fn BotChatTest(mut bs: *mut bot_state_t) {
             BotFirstClientInRankings(),
             BotLastClientInRankings(),
             BotMapTitle(),
-            std::ptr::null_mut(),
+            std::ptr::null_mut::<libc::c_char>(),
         );
         trap_BotEnterChat((*bs).cs, 0 as i32, 0 as i32);
         i += 1
@@ -2014,7 +2014,7 @@ pub unsafe extern "C" fn BotChatTest(mut bs: *mut bot_state_t) {
             BotFirstClientInRankings(),
             BotLastClientInRankings(),
             BotMapTitle(),
-            std::ptr::null_mut(),
+            std::ptr::null_mut::<libc::c_char>(),
         );
         trap_BotEnterChat((*bs).cs, 0 as i32, 0 as i32);
         i += 1
@@ -2035,7 +2035,7 @@ pub unsafe extern "C" fn BotChatTest(mut bs: *mut bot_state_t) {
             bs as *mut bot_state_s,
             b"death_drown\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             name.as_mut_ptr(),
-            std::ptr::null_mut(),
+            std::ptr::null_mut::<libc::c_char>(),
         );
         trap_BotEnterChat((*bs).cs, 0 as i32, 0 as i32);
         i += 1
@@ -2050,7 +2050,7 @@ pub unsafe extern "C" fn BotChatTest(mut bs: *mut bot_state_t) {
             bs as *mut bot_state_s,
             b"death_slime\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             name.as_mut_ptr(),
-            std::ptr::null_mut(),
+            std::ptr::null_mut::<libc::c_char>(),
         );
         trap_BotEnterChat((*bs).cs, 0 as i32, 0 as i32);
         i += 1

--- a/quake3-rs/qagamex86_64/src/game/ai_cmd.rs
+++ b/quake3-rs/qagamex86_64/src/game/ai_cmd.rs
@@ -1750,7 +1750,7 @@ pub unsafe extern "C" fn BotMatch_CheckPoint(
             BotAI_BotInitialChat(
                 bs as *mut bot_state_s,
                 b"checkpoint_invalid\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
             trap_BotEnterChat((*bs).cs, client, 2 as i32);
         }
@@ -2088,7 +2088,7 @@ pub unsafe extern "C" fn BotMatch_WhatAreYouDoing(
                 bs as *mut bot_state_s,
                 b"helping\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 netname.as_mut_ptr(),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         }
         2 => {
@@ -2101,7 +2101,7 @@ pub unsafe extern "C" fn BotMatch_WhatAreYouDoing(
                 bs as *mut bot_state_s,
                 b"accompanying\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 netname.as_mut_ptr(),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         }
         3 => {
@@ -2114,7 +2114,7 @@ pub unsafe extern "C" fn BotMatch_WhatAreYouDoing(
                 bs as *mut bot_state_s,
                 b"defending\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 goalname.as_mut_ptr(),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         }
         10 => {
@@ -2127,7 +2127,7 @@ pub unsafe extern "C" fn BotMatch_WhatAreYouDoing(
                 bs as *mut bot_state_s,
                 b"gettingitem\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 goalname.as_mut_ptr(),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         }
         11 => {
@@ -2140,35 +2140,35 @@ pub unsafe extern "C" fn BotMatch_WhatAreYouDoing(
                 bs as *mut bot_state_s,
                 b"killing\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 netname.as_mut_ptr(),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         }
         7 | 8 => {
             BotAI_BotInitialChat(
                 bs as *mut bot_state_s,
                 b"camping\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         }
         9 => {
             BotAI_BotInitialChat(
                 bs as *mut bot_state_s,
                 b"patrolling\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         }
         4 => {
             BotAI_BotInitialChat(
                 bs as *mut bot_state_s,
                 b"capturingflag\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         }
         5 => {
             BotAI_BotInitialChat(
                 bs as *mut bot_state_s,
                 b"rushingbase\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         }
         6 => {
@@ -2429,7 +2429,7 @@ pub unsafe extern "C" fn BotMatch_WhereAreYou(
                     b"teamlocation\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                     nearbyitems[bestitem as usize],
                     b"red\x00" as *const u8 as *const libc::c_char,
-                    std::ptr::null_mut(),
+                    std::ptr::null_mut::<libc::c_char>(),
                 );
             } else if (bluett as f64) < (redtt + bluett) as f64 * 0.4f64 {
                 BotAI_BotInitialChat(
@@ -2437,14 +2437,14 @@ pub unsafe extern "C" fn BotMatch_WhereAreYou(
                     b"teamlocation\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                     nearbyitems[bestitem as usize],
                     b"blue\x00" as *const u8 as *const libc::c_char,
-                    std::ptr::null_mut(),
+                    std::ptr::null_mut::<libc::c_char>(),
                 );
             } else {
                 BotAI_BotInitialChat(
                     bs as *mut bot_state_s,
                     b"location\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                     nearbyitems[bestitem as usize],
-                    std::ptr::null_mut(),
+                    std::ptr::null_mut::<libc::c_char>(),
                 );
             }
         } else {
@@ -2452,7 +2452,7 @@ pub unsafe extern "C" fn BotMatch_WhereAreYou(
                 bs as *mut bot_state_s,
                 b"location\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 nearbyitems[bestitem as usize],
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         }
         trap_BotMatchVariable(
@@ -2549,7 +2549,7 @@ pub unsafe extern "C" fn BotMatch_LeadTheWay(
             bs as *mut bot_state_s,
             b"whois\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             netname.as_mut_ptr(),
-            std::ptr::null_mut(),
+            std::ptr::null_mut::<libc::c_char>(),
         );
         trap_BotEnterChat((*bs).cs, (*bs).client, 1 as i32);
         return;
@@ -2581,14 +2581,14 @@ pub unsafe extern "C" fn BotMatch_LeadTheWay(
                 bs as *mut bot_state_s,
                 b"whereis\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 teammate.as_mut_ptr(),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         } else {
             BotAI_BotInitialChat(
                 bs as *mut bot_state_s,
                 b"whereareyou\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 netname.as_mut_ptr(),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         }
         trap_BotEnterChat((*bs).cs, (*bs).client, 1 as i32);
@@ -2631,7 +2631,7 @@ pub unsafe extern "C" fn BotMatch_Kill(mut bs: *mut bot_state_t, mut match_0: *m
             bs as *mut bot_state_s,
             b"whois\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
             enemy.as_mut_ptr(),
-            std::ptr::null_mut(),
+            std::ptr::null_mut::<libc::c_char>(),
         );
         trap_BotMatchVariable(
             match_0 as *mut libc::c_void,

--- a/quake3-rs/qagamex86_64/src/game/ai_dmnet.rs
+++ b/quake3-rs/qagamex86_64/src/game/ai_dmnet.rs
@@ -1025,7 +1025,7 @@ pub unsafe extern "C" fn BotGetLongTermGoal(
                     netname.as_mut_ptr(),
                     ::std::mem::size_of::<[libc::c_char; 36]>() as usize as i32,
                 ),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
             trap_BotEnterChat((*bs).cs, (*bs).teammate, 2 as i32);
             (*bs).ltgtype = 0 as i32;
@@ -1073,7 +1073,7 @@ pub unsafe extern "C" fn BotGetLongTermGoal(
                 bs as *mut bot_state_s,
                 b"defend_start\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 buf.as_mut_ptr(),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
             trap_BotEnterChat((*bs).cs, 0 as i32, 1 as i32);
             crate::src::game::ai_team::BotVoiceChatOnly(
@@ -1100,7 +1100,7 @@ pub unsafe extern "C" fn BotGetLongTermGoal(
                 bs as *mut bot_state_s,
                 b"defend_stop\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 buf.as_mut_ptr(),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
             trap_BotEnterChat((*bs).cs, 0 as i32, 1 as i32);
             (*bs).ltgtype = 0 as i32
@@ -1140,7 +1140,7 @@ pub unsafe extern "C" fn BotGetLongTermGoal(
                 bs as *mut bot_state_s,
                 b"kill_start\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 buf.as_mut_ptr(),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
             trap_BotEnterChat((*bs).cs, (*bs).decisionmaker, 2 as i32);
             (*bs).teammessage_time = 0 as i32 as f32
@@ -1158,7 +1158,7 @@ pub unsafe extern "C" fn BotGetLongTermGoal(
                 bs as *mut bot_state_s,
                 b"kill_done\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 buf.as_mut_ptr(),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
             trap_BotEnterChat((*bs).cs, (*bs).decisionmaker, 2 as i32);
             (*bs).ltgtype = 0 as i32
@@ -1183,7 +1183,7 @@ pub unsafe extern "C" fn BotGetLongTermGoal(
                 bs as *mut bot_state_s,
                 b"getitem_start\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 buf.as_mut_ptr(),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
             trap_BotEnterChat((*bs).cs, (*bs).decisionmaker, 2 as i32);
             crate::src::game::ai_team::BotVoiceChatOnly(
@@ -1221,7 +1221,7 @@ pub unsafe extern "C" fn BotGetLongTermGoal(
                 bs as *mut bot_state_s,
                 b"getitem_notthere\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 buf.as_mut_ptr(),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
             trap_BotEnterChat((*bs).cs, (*bs).decisionmaker, 2 as i32);
             (*bs).ltgtype = 0 as i32
@@ -1235,7 +1235,7 @@ pub unsafe extern "C" fn BotGetLongTermGoal(
                 bs as *mut bot_state_s,
                 b"getitem_gotit\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 buf.as_mut_ptr(),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
             trap_BotEnterChat((*bs).cs, (*bs).decisionmaker, 2 as i32);
             (*bs).ltgtype = 0 as i32
@@ -1255,7 +1255,7 @@ pub unsafe extern "C" fn BotGetLongTermGoal(
                         netname.as_mut_ptr(),
                         ::std::mem::size_of::<[libc::c_char; 36]>() as usize as i32,
                     ),
-                    std::ptr::null_mut(),
+                    std::ptr::null_mut::<libc::c_char>(),
                 );
                 trap_BotEnterChat((*bs).cs, (*bs).decisionmaker, 2 as i32);
                 crate::src::game::ai_team::BotVoiceChatOnly(
@@ -1279,7 +1279,7 @@ pub unsafe extern "C" fn BotGetLongTermGoal(
                 BotAI_BotInitialChat(
                     bs as *mut bot_state_s,
                     b"camp_stop\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-                    std::ptr::null_mut(),
+                    std::ptr::null_mut::<libc::c_char>(),
                 );
                 trap_BotEnterChat((*bs).cs, (*bs).decisionmaker, 2 as i32);
             }
@@ -1697,7 +1697,7 @@ pub unsafe extern "C" fn BotLongTermGoal(
                     teammate.as_mut_ptr(),
                     ::std::mem::size_of::<[libc::c_char; 256]>() as usize as i32,
                 ),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
             trap_BotEnterChat((*bs).cs, (*bs).teammate, 2 as i32);
             (*bs).lead_time = 0 as i32 as f32;
@@ -1713,7 +1713,7 @@ pub unsafe extern "C" fn BotLongTermGoal(
                     teammate.as_mut_ptr(),
                     ::std::mem::size_of::<[libc::c_char; 256]>() as usize as i32,
                 ),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
             trap_BotEnterChat((*bs).cs, (*bs).teammate, 2 as i32);
             (*bs).leadmessage_time = floattime
@@ -1775,7 +1775,7 @@ pub unsafe extern "C" fn BotLongTermGoal(
                         teammate.as_mut_ptr(),
                         ::std::mem::size_of::<[libc::c_char; 256]>() as usize as i32,
                     ),
-                    std::ptr::null_mut(),
+                    std::ptr::null_mut::<libc::c_char>(),
                 );
                 trap_BotEnterChat((*bs).cs, (*bs).teammate, 2 as i32);
                 (*bs).leadmessage_time = floattime
@@ -1803,7 +1803,7 @@ pub unsafe extern "C" fn BotLongTermGoal(
                             teammate.as_mut_ptr(),
                             ::std::mem::size_of::<[libc::c_char; 256]>() as usize as i32,
                         ),
-                        std::ptr::null_mut(),
+                        std::ptr::null_mut::<libc::c_char>(),
                     );
                     trap_BotEnterChat((*bs).cs, (*bs).teammate, 2 as i32);
                     (*bs).leadmessage_time = floattime

--- a/quake3-rs/qagamex86_64/src/game/ai_team.rs
+++ b/quake3-rs/qagamex86_64/src/game/ai_team.rs
@@ -770,7 +770,7 @@ pub unsafe extern "C" fn BotCTFOrders_BothFlagsNotAtBase(mut bs: *mut bot_state_
                                 b"cmd_accompanyme\x00" as *const u8 as *const libc::c_char
                                     as *mut libc::c_char,
                                 name.as_mut_ptr(),
-                                std::ptr::null_mut(),
+                                std::ptr::null_mut::<libc::c_char>(),
                             );
                             BotSayVoiceTeamOrder(
                                 bs,
@@ -785,7 +785,7 @@ pub unsafe extern "C" fn BotCTFOrders_BothFlagsNotAtBase(mut bs: *mut bot_state_
                                     as *mut libc::c_char,
                                 name.as_mut_ptr(),
                                 carriername.as_mut_ptr(),
-                                std::ptr::null_mut(),
+                                std::ptr::null_mut::<libc::c_char>(),
                             );
                             BotSayVoiceTeamOrder(
                                 bs,
@@ -814,7 +814,7 @@ pub unsafe extern "C" fn BotCTFOrders_BothFlagsNotAtBase(mut bs: *mut bot_state_
                             b"cmd_getflag\x00" as *const u8 as *const libc::c_char
                                 as *mut libc::c_char,
                             name.as_mut_ptr(),
-                            std::ptr::null_mut(),
+                            std::ptr::null_mut::<libc::c_char>(),
                         );
                         BotSayVoiceTeamOrder(
                             bs,
@@ -840,7 +840,7 @@ pub unsafe extern "C" fn BotCTFOrders_BothFlagsNotAtBase(mut bs: *mut bot_state_
                         bs as *mut bot_state_s,
                         b"cmd_getflag\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                         name.as_mut_ptr(),
-                        std::ptr::null_mut(),
+                        std::ptr::null_mut::<libc::c_char>(),
                     );
                     BotSayTeamOrder(bs, teammates[(numteammates - i - 1 as i32) as usize]);
                     BotSayVoiceTeamOrder(
@@ -996,7 +996,7 @@ pub unsafe extern "C" fn BotCTFOrders_FlagNotAtBase(mut bs: *mut bot_state_t) {
                         b"cmd_defendbase\x00" as *const u8 as *const libc::c_char
                             as *mut libc::c_char,
                         name.as_mut_ptr(),
-                        std::ptr::null_mut(),
+                        std::ptr::null_mut::<libc::c_char>(),
                     );
                     BotSayTeamOrder(bs, teammates[i as usize]);
                     BotSayVoiceTeamOrder(
@@ -1018,7 +1018,7 @@ pub unsafe extern "C" fn BotCTFOrders_FlagNotAtBase(mut bs: *mut bot_state_t) {
                         bs as *mut bot_state_s,
                         b"cmd_getflag\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                         name.as_mut_ptr(),
-                        std::ptr::null_mut(),
+                        std::ptr::null_mut::<libc::c_char>(),
                     );
                     BotSayTeamOrder(bs, teammates[(numteammates - i - 1 as i32) as usize]);
                     BotSayVoiceTeamOrder(
@@ -1045,7 +1045,7 @@ pub unsafe extern "C" fn BotCTFOrders_FlagNotAtBase(mut bs: *mut bot_state_t) {
                     bs as *mut bot_state_s,
                     b"cmd_getflag\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                     name.as_mut_ptr(),
-                    std::ptr::null_mut(),
+                    std::ptr::null_mut::<libc::c_char>(),
                 );
                 BotSayTeamOrder(bs, teammates[0 as i32 as usize]);
                 BotSayVoiceTeamOrder(
@@ -1063,7 +1063,7 @@ pub unsafe extern "C" fn BotCTFOrders_FlagNotAtBase(mut bs: *mut bot_state_t) {
                     bs as *mut bot_state_s,
                     b"cmd_getflag\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                     name.as_mut_ptr(),
-                    std::ptr::null_mut(),
+                    std::ptr::null_mut::<libc::c_char>(),
                 );
                 BotSayTeamOrder(bs, teammates[1 as i32 as usize]);
                 BotSayVoiceTeamOrder(
@@ -1083,7 +1083,7 @@ pub unsafe extern "C" fn BotCTFOrders_FlagNotAtBase(mut bs: *mut bot_state_t) {
                     bs as *mut bot_state_s,
                     b"cmd_getflag\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                     name.as_mut_ptr(),
-                    std::ptr::null_mut(),
+                    std::ptr::null_mut::<libc::c_char>(),
                 );
                 BotSayTeamOrder(bs, teammates[0 as i32 as usize]);
                 BotSayVoiceTeamOrder(
@@ -1101,7 +1101,7 @@ pub unsafe extern "C" fn BotCTFOrders_FlagNotAtBase(mut bs: *mut bot_state_t) {
                     bs as *mut bot_state_s,
                     b"cmd_getflag\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                     name.as_mut_ptr(),
-                    std::ptr::null_mut(),
+                    std::ptr::null_mut::<libc::c_char>(),
                 );
                 BotSayTeamOrder(bs, teammates[1 as i32 as usize]);
                 BotSayVoiceTeamOrder(
@@ -1310,7 +1310,7 @@ pub unsafe extern "C" fn BotCTFOrders_EnemyFlagNotAtBase(mut bs: *mut bot_state_
                         b"cmd_defendbase\x00" as *const u8 as *const libc::c_char
                             as *mut libc::c_char,
                         name.as_mut_ptr(),
-                        std::ptr::null_mut(),
+                        std::ptr::null_mut::<libc::c_char>(),
                     );
                     BotSayTeamOrder(bs, teammates[i as usize]);
                     BotSayVoiceTeamOrder(
@@ -1344,7 +1344,7 @@ pub unsafe extern "C" fn BotCTFOrders_EnemyFlagNotAtBase(mut bs: *mut bot_state_
                                 b"cmd_accompanyme\x00" as *const u8 as *const libc::c_char
                                     as *mut libc::c_char,
                                 name.as_mut_ptr(),
-                                std::ptr::null_mut(),
+                                std::ptr::null_mut::<libc::c_char>(),
                             );
                             BotSayVoiceTeamOrder(
                                 bs,
@@ -1359,7 +1359,7 @@ pub unsafe extern "C" fn BotCTFOrders_EnemyFlagNotAtBase(mut bs: *mut bot_state_
                                     as *mut libc::c_char,
                                 name.as_mut_ptr(),
                                 carriername.as_mut_ptr(),
-                                std::ptr::null_mut(),
+                                std::ptr::null_mut::<libc::c_char>(),
                             );
                             BotSayVoiceTeamOrder(
                                 bs,
@@ -1388,7 +1388,7 @@ pub unsafe extern "C" fn BotCTFOrders_EnemyFlagNotAtBase(mut bs: *mut bot_state_
                             b"cmd_getflag\x00" as *const u8 as *const libc::c_char
                                 as *mut libc::c_char,
                             name.as_mut_ptr(),
-                            std::ptr::null_mut(),
+                            std::ptr::null_mut::<libc::c_char>(),
                         );
                         BotSayVoiceTeamOrder(
                             bs,
@@ -1445,7 +1445,7 @@ pub unsafe extern "C" fn BotCTFOrders_BothFlagsAtBase(mut bs: *mut bot_state_t) 
                     bs as *mut bot_state_s,
                     b"cmd_defendbase\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                     name.as_mut_ptr(),
-                    std::ptr::null_mut(),
+                    std::ptr::null_mut::<libc::c_char>(),
                 );
                 BotSayTeamOrder(bs, teammates[0 as i32 as usize]);
                 BotSayVoiceTeamOrder(
@@ -1463,7 +1463,7 @@ pub unsafe extern "C" fn BotCTFOrders_BothFlagsAtBase(mut bs: *mut bot_state_t) 
                     bs as *mut bot_state_s,
                     b"cmd_getflag\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                     name.as_mut_ptr(),
-                    std::ptr::null_mut(),
+                    std::ptr::null_mut::<libc::c_char>(),
                 );
                 BotSayTeamOrder(bs, teammates[1 as i32 as usize]);
                 BotSayVoiceTeamOrder(
@@ -1483,7 +1483,7 @@ pub unsafe extern "C" fn BotCTFOrders_BothFlagsAtBase(mut bs: *mut bot_state_t) 
                     bs as *mut bot_state_s,
                     b"cmd_defendbase\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                     name.as_mut_ptr(),
-                    std::ptr::null_mut(),
+                    std::ptr::null_mut::<libc::c_char>(),
                 );
                 BotSayTeamOrder(bs, teammates[0 as i32 as usize]);
                 BotSayVoiceTeamOrder(
@@ -1501,7 +1501,7 @@ pub unsafe extern "C" fn BotCTFOrders_BothFlagsAtBase(mut bs: *mut bot_state_t) 
                     bs as *mut bot_state_s,
                     b"cmd_defendbase\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                     name.as_mut_ptr(),
-                    std::ptr::null_mut(),
+                    std::ptr::null_mut::<libc::c_char>(),
                 );
                 BotSayTeamOrder(bs, teammates[1 as i32 as usize]);
                 BotSayVoiceTeamOrder(
@@ -1519,7 +1519,7 @@ pub unsafe extern "C" fn BotCTFOrders_BothFlagsAtBase(mut bs: *mut bot_state_t) 
                     bs as *mut bot_state_s,
                     b"cmd_getflag\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                     name.as_mut_ptr(),
-                    std::ptr::null_mut(),
+                    std::ptr::null_mut::<libc::c_char>(),
                 );
                 BotSayTeamOrder(bs, teammates[2 as i32 as usize]);
                 BotSayVoiceTeamOrder(
@@ -1550,7 +1550,7 @@ pub unsafe extern "C" fn BotCTFOrders_BothFlagsAtBase(mut bs: *mut bot_state_t) 
                         b"cmd_defendbase\x00" as *const u8 as *const libc::c_char
                             as *mut libc::c_char,
                         name.as_mut_ptr(),
-                        std::ptr::null_mut(),
+                        std::ptr::null_mut::<libc::c_char>(),
                     );
                     BotSayTeamOrder(bs, teammates[i as usize]);
                     BotSayVoiceTeamOrder(
@@ -1572,7 +1572,7 @@ pub unsafe extern "C" fn BotCTFOrders_BothFlagsAtBase(mut bs: *mut bot_state_t) 
                         bs as *mut bot_state_s,
                         b"cmd_getflag\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                         name.as_mut_ptr(),
-                        std::ptr::null_mut(),
+                        std::ptr::null_mut::<libc::c_char>(),
                     );
                     BotSayTeamOrder(bs, teammates[(numteammates - i - 1 as i32) as usize]);
                     BotSayVoiceTeamOrder(
@@ -1805,7 +1805,7 @@ pub unsafe extern "C" fn BotCreateGroup(
                 bs as *mut bot_state_s,
                 b"cmd_accompanyme\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 name.as_mut_ptr(),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         } else {
             BotAI_BotInitialChat(
@@ -1813,7 +1813,7 @@ pub unsafe extern "C" fn BotCreateGroup(
                 b"cmd_accompany\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
                 name.as_mut_ptr(),
                 leadername.as_mut_ptr(),
-                std::ptr::null_mut(),
+                std::ptr::null_mut::<libc::c_char>(),
             );
         }
         BotSayTeamOrderAlways(bs, *teammates.offset(i as isize));
@@ -2011,7 +2011,7 @@ pub unsafe extern "C" fn BotTeamAI(mut bs: *mut bot_state_t) {
                 BotAI_BotInitialChat(
                     bs as *mut bot_state_s,
                     b"whoisteamleader\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-                    std::ptr::null_mut(),
+                    std::ptr::null_mut::<libc::c_char>(),
                 );
                 trap_BotEnterChat((*bs).cs, 0 as i32, 1 as i32);
                 (*bs).askteamleader_time = 0 as i32 as f32;
@@ -2023,7 +2023,7 @@ pub unsafe extern "C" fn BotTeamAI(mut bs: *mut bot_state_t) {
                 BotAI_BotInitialChat(
                     bs as *mut bot_state_s,
                     b"iamteamleader\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-                    std::ptr::null_mut(),
+                    std::ptr::null_mut::<libc::c_char>(),
                 );
                 trap_BotEnterChat((*bs).cs, 0 as i32, 1 as i32);
                 BotSayVoiceTeamOrder(

--- a/quake3-rs/qagamex86_64/src/game/g_spawn.rs
+++ b/quake3-rs/qagamex86_64/src/game/g_spawn.rs
@@ -1447,7 +1447,7 @@ unsafe extern "C" fn run_static_initializers() {
         {
             let mut init = field_t {
                 name: b"model2\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-                ofs: &mut (*(std::ptr::null_mut())).model2 as *mut *mut libc::c_char as size_t,
+                ofs: &mut (*(std::ptr::null_mut::<gentity_s>())).model2 as *mut *mut libc::c_char as size_t,
                 type_0: F_STRING,
             };
             init
@@ -1455,7 +1455,7 @@ unsafe extern "C" fn run_static_initializers() {
         {
             let mut init = field_t {
                 name: b"spawnflags\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-                ofs: &mut (*(std::ptr::null_mut())).spawnflags as *mut i32 as size_t,
+                ofs: &mut (*(std::ptr::null_mut::<gentity_s>())).spawnflags as *mut i32 as size_t,
                 type_0: F_INT,
             };
             init
@@ -1463,7 +1463,7 @@ unsafe extern "C" fn run_static_initializers() {
         {
             let mut init = field_t {
                 name: b"speed\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-                ofs: &mut (*(std::ptr::null_mut())).speed as *mut f32 as size_t,
+                ofs: &mut (*(std::ptr::null_mut::<gentity_s>())).speed as *mut f32 as size_t,
                 type_0: F_FLOAT,
             };
             init
@@ -1471,7 +1471,7 @@ unsafe extern "C" fn run_static_initializers() {
         {
             let mut init = field_t {
                 name: b"target\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-                ofs: &mut (*(std::ptr::null_mut())).target as *mut *mut libc::c_char as size_t,
+                ofs: &mut (*(std::ptr::null_mut::<gentity_s>())).target as *mut *mut libc::c_char as size_t,
                 type_0: F_STRING,
             };
             init
@@ -1479,7 +1479,7 @@ unsafe extern "C" fn run_static_initializers() {
         {
             let mut init = field_t {
                 name: b"targetname\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-                ofs: &mut (*(std::ptr::null_mut())).targetname as *mut *mut libc::c_char as size_t,
+                ofs: &mut (*(std::ptr::null_mut::<gentity_s>())).targetname as *mut *mut libc::c_char as size_t,
                 type_0: F_STRING,
             };
             init
@@ -1487,7 +1487,7 @@ unsafe extern "C" fn run_static_initializers() {
         {
             let mut init = field_t {
                 name: b"message\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-                ofs: &mut (*(std::ptr::null_mut())).message as *mut *mut libc::c_char as size_t,
+                ofs: &mut (*(std::ptr::null_mut::<gentity_s>())).message as *mut *mut libc::c_char as size_t,
                 type_0: F_STRING,
             };
             init
@@ -1495,7 +1495,7 @@ unsafe extern "C" fn run_static_initializers() {
         {
             let mut init = field_t {
                 name: b"team\x00" as *const u8 as *const libc::c_char as *mut libc::c_char,
-                ofs: &mut (*(std::ptr::null_mut())).team as *mut *mut libc::c_char as size_t,
+                ofs: &mut (*(std::ptr::null_mut::<gentity_s>())).team as *mut *mut libc::c_char as size_t,
                 type_0: F_STRING,
             };
             init


### PR DESCRIPTION
## Summary
- update various null pointer generics to fix Rust build errors

## Testing
- `cargo +nightly-2019-12-05 build --release` *(fails: type annotations needed)*

------
https://chatgpt.com/codex/tasks/task_e_6854b29ce120832984ee7ca70f6a3642